### PR TITLE
fission lib: prefix anonymous functions IDs when patching modules

### DIFF
--- a/fission_lib/lib/fission_lib/core_erlang_utils.ex
+++ b/fission_lib/lib/fission_lib/core_erlang_utils.ex
@@ -113,6 +113,11 @@ defmodule FissionLib.CoreErlangUtils do
     end
   end
 
+  defp rename_funs({:id, {line, col, id}}, ctx) do
+    "-" <> id = Atom.to_string(id)
+    {:id, {line, col, :"-#{ctx.prefix}_#{id}"}}
+  end
+
   defp rename_funs(ast, ctx) do
     traverse(ast, &rename_funs(&1, ctx))
   end


### PR DESCRIPTION
Otherwise we may have duplicated fun IDs and thus funs probably somehow override each other, causing all kinds of bugs