### PR TITLE
Add patch for erl_eval

### DIFF
--- a/fission_lib/patches/estdlib/erl_eval.erl
+++ b/fission_lib/patches/estdlib/erl_eval.erl
@@ -1,0 +1,5 @@
+-module(erl_eval).
+-export([fun_data/1]).
+
+% Patch reason: in AVM erlang:fun_info(F, env) isn't implemented
+fun_data(_F) -> false.


### PR DESCRIPTION
Supports execution of following code:
```elixir
"""
A = fun() -> 5 end,
B = 10,
A() + B.
"""
|> :erlang.binary_to_list()
|> eval(:eval)
|> :erlang.display()
```

See: https://github.com/software-mansion-labs/FissionVM/pull/70

Reviewers: @TheSobkiewicz, @mat-hek 