### PR TITLE
Move code evaluation to a separate iframe for better fault tolerance

### DIFF
--- a/iex_wasm/static/erlang.html
+++ b/iex_wasm/static/erlang.html
@@ -50,10 +50,7 @@
       </div>
     </details>
 
-    <iframe id="evalFrame"
-      srcdoc='<html><script async src="iframe_script.js" defer></script><script async src="AtomVM.js" defer></script></html>'
-      style="width: 0; height: 0; visibility: hidden">
-    </iframe>
+    <iframe id="evalFrame" src="eval_frame.html" style="width: 0; height: 0; visibility: hidden"></iframe>
     <script async src="script.js" defer></script>
   </body>
 </html>

--- a/iex_wasm/static/eval_frame.html
+++ b/iex_wasm/static/eval_frame.html
@@ -1,0 +1,5 @@
+<html>
+<script src="iframe_script.js"></script>
+<script src="AtomVM.js"></script>
+
+</html>

--- a/iex_wasm/static/index.html
+++ b/iex_wasm/static/index.html
@@ -41,10 +41,7 @@
       </div>
     </details>
 
-    <iframe id="evalFrame"
-      srcdoc='<html><script async src="iframe_script.js" defer></script><script async src="AtomVM.js" defer></script></html>'
-      style="width: 0; height: 0; visibility: hidden">
-    </iframe>
+    <iframe id="evalFrame" src="eval_frame.html" style="width: 0; height: 0; visibility: hidden"></iframe>
     <script async src="script.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
So, it turns out that due to mutable, global state and various resources potentially kept by emscripten, it doesn't provide a way to 'restart' the WASM VM, as it could imply memory/resource leaks (see [Emscripten FAQ](https://emscripten.org/docs/getting_started/FAQ.html#can-i-use-multiple-emscripten-compiled-programs-on-one-web-page)). So, I just moved the execution to a separate iframe and reload it upon crash 😄 