### PR TITLE
Fix hexdocs module tests

### DIFF
--- a/fission_lib/test/fission_lib/hexdocs_test.exs
+++ b/fission_lib/test/fission_lib/hexdocs_test.exs
@@ -962,7 +962,6 @@ defmodule FissionLib.HexdocsTest do
   """
   |> assert_eval(1)
   
-  @tag :skip
   """
   [a: a] = [a: 1, b: 2]
   """


### PR DESCRIPTION
Fixed module tests problems caused by the misused @additional_prep attribute.