### PR TITLE
Ensure proper implementation of filename:split/1

### DIFF
--- a/fission_lib/patches/estdlib/filename.erl
+++ b/fission_lib/patches/estdlib/filename.erl
@@ -1,18 +1,5 @@
 -module(filename).
--compile({flb_patch_private, unix_splitb/1}).
 -compile({flb_patch_private, filename_string_to_binary/1}).
-
-unix_splitb(Name) ->
-    %Patch reason: binary:split using list of separators.
-    L = binary:split(Name, <<"/">>, [global]),
-    LL =
-        case L of
-            [<<>> | Rest] when Rest =/= [] ->
-                [<<"/">> | Rest];
-            _ ->
-                L
-        end,
-    [X || X <- LL, X =/= <<>>].
 
 filename_string_to_binary(List) ->
     %Patch reason: changed unicode to utf8 due to lack of support.

--- a/fission_lib/test/fission_lib/eval_test.exs
+++ b/fission_lib/test/fission_lib/eval_test.exs
@@ -545,4 +545,12 @@ defmodule FissionLib.EvalTest do
     |> AtomVM.assert_result(^os_type)
   end
   
+
+  async_test ":filename.split/1", %{tmp_dir: dir} do
+    """
+    :filename.split("path/to/a/file")
+    """
+    |> AtomVM.eval(:elixir, run_dir: dir)
+    |> AtomVM.assert_result(["path", "to", "a", "file"])
+  end
 end


### PR DESCRIPTION
Deleted patch. Added test to cover filename:split/1 function call.