### PR TITLE
Fix dockerfile

### DIFF
--- a/examples/game_of_life/mix.exs
+++ b/examples/game_of_life/mix.exs
@@ -26,7 +26,7 @@ defmodule GameOfLife.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:popcorn, github: "software-mansion/popcorn"}
+      {:popcorn, path: "../.."}
     ]
   end
 end

--- a/utils/landing-page/Dockerfile
+++ b/utils/landing-page/Dockerfile
@@ -64,13 +64,13 @@ RUN cd /root/elixir-wasm && \
  RUN echo 'export ERL_AFLAGS="+JMsingle true"' >> /root/.env
  RUN source /root/.env && \
      cd /root/elixir-wasm/examples/eval_in_wasm && \
-     cp -r /root/wasm static && \
-     mix deps.get && mix deps.compile && mix popcorn.cook && mix compile
+     mix deps.get && mix popcorn.cook && \
+     cp -r /root/wasm static
 
  RUN source /root/.env && \
      cd /root/elixir-wasm/examples/game_of_life && \
-     cp -r /root/wasm static && \
-     mix deps.get && mix deps.compile && mix popcorn.cook && mix compile
+     mix deps.get && mix popcorn.cook && \
+     cp -r /root/wasm static
 
  RUN source /root/.env && \
      cd /root/elixir-wasm/ && \


### PR DESCRIPTION
This PR overrides the AtomVM downloaded by Popcorn with the locally built one. Seems it [still works](https://popcorn.swmtest.xyz/) 