### PR TITLE
Add a dev server which supports live reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ Cross-Origin-Embedder-Policy: require-corp
 
 Otherwise, browsers refuse to run WASM.
 
+### Live reloading
+
+Popcorn also ships with a server that supports like reloading. It can be generated with `mix popcorn.dev_server` which will replace the simple server above.
+
+The index.html requires an extra line to load the required JavaScript.
+
+```html
+<!-- index.html -->
+<html>
+  <script type="text/javascript" src="/dev_server.js"></script>
+  <script type="module">
+      import { Popcorn } from "./wasm/popcorn.js";
+      await Popcorn.init({ onStdout: console.log });
+  </script>
+  <body></body>
+</html>
+ ```
+
 ## Configuration of the runtime
 
 Popcorn runs AtomVM under the hood, and therefore it needs to either download precompied artifacts or compile it from source.

--- a/lib/mix/tasks/popcorn.dev_server.ex
+++ b/lib/mix/tasks/popcorn.dev_server.ex
@@ -1,0 +1,38 @@
+defmodule Mix.Tasks.Popcorn.DevServer do
+  @shortdoc """
+  Generates a static file server script with code reloading.
+  """
+  @moduledoc """
+  #{@shortdoc}
+
+  The dev server is more complicated than the simple server as
+  sets up a filesystem watcher and reloads the browser window
+  when the popcorn bundle changes.
+
+  It requires the following line in the index.html:
+
+  ```javascript
+  <script type="text/javascript" src="/app.js"></script>
+  ```
+
+  These assets can also be hosted with any other server,
+  but it has to add the following HTTP headers:
+
+  ```txt
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp
+  ```
+
+  Otherwise the browser refuses to run WASM.
+  """
+  @shortdoc @moduledoc
+
+  use Mix.Task
+
+  @priv_dir :code.priv_dir(:popcorn)
+
+  @impl true
+  def run(_args) do
+    File.cp!(Path.join(@priv_dir, "dev_server.exs"), "dev_server.exs")
+  end
+end

--- a/priv/dev_server.exs
+++ b/priv/dev_server.exs
@@ -1,0 +1,154 @@
+Mix.install([
+  {:bandit, "~> 1.1"},
+  {:websock_adapter, "~> 0.5"},
+  {:file_system, "~> 1.0"}
+])
+
+defmodule Reloader do
+  require Logger
+
+  def init(_args) do
+    Registry.register(Dispatcher, :reload, [])
+    {:ok, []}
+  end
+
+  def handle_in({"ping", [opcode: :text]}, state) do
+    {:reply, :ok, {:text, "pong"}, state}
+  end
+
+  def handle_info(:reload, state) do
+    Logger.debug("mix popcorn.cook finished. Reloading page.")
+    {:push, {:text, "reload"}, state}
+  end
+
+  def handle_info(_, state) do
+    {:ok, state}
+  end
+end
+
+defmodule Router do
+  use Plug.Router
+
+  @static_dir "#{__DIR__}/static"
+
+  plug(Plug.Logger)
+  plug(:add_headers)
+  plug(Plug.Static, from: @static_dir, at: "/")
+  plug(:match)
+  plug(:dispatch)
+
+  get "/" do
+    send_file(conn, 200, "#{@static_dir}/index.html")
+  end
+
+  get "dev_server.js" do
+    resp = """
+    sock = new WebSocket("ws://localhost:#{conn.port}/websocket");
+    sock.addEventListener("message", (message) => {
+      if (message.data === "reload") {
+        window.location.reload();
+      }
+    });
+    sock.addEventListener("open", () => {
+      setInterval(() => sock.send("ping"), 10000);
+    });
+    """
+
+    conn
+    |> put_resp_header("content-type", "application/javascript")
+    |> send_resp(200, resp)
+  end
+
+  get "/websocket" do
+    conn
+    |> WebSockAdapter.upgrade(Reloader, [], timeout: 60_000)
+    |> halt()
+  end
+
+  match _ do
+    send_resp(conn, 404, "not found")
+  end
+
+  def add_headers(conn, _opts) do
+    Plug.Conn.merge_resp_headers(
+      conn,
+      [
+        {"Access-Control-Allow-Origin", "*"},
+        {"Cross-Origin-Opener-Policy", "same-origin"},
+        {"Cross-Origin-Embedder-Policy", "require-corp"}
+      ]
+    )
+  end
+end
+
+defmodule Recompiler do
+  require Logger
+  use GenServer
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  def init(_opts) do
+    FileSystem.subscribe(:live_reload_file_monitor)
+    {:ok, %{cooking: false, cook_queued: false, cook_ref: nil}, {:continue, :cook}}
+  end
+
+  def handle_continue(:cook, state) do
+    {:noreply, cook(state)}
+  end
+
+  @valid_events [:created, :modified, [:modified, :closed], [:inodemetamod, :modified]]
+  def handle_info({:file_event, _pid, {path, event}}, state) do
+    valid = String.ends_with?(path, ".ex") && event in @valid_events
+
+    state =
+      case {valid, state.cooking} do
+        {false, _} -> state
+        {true, true} -> %{state | cook_queued: true}
+        {true, false} -> cook(state)
+      end
+
+    {:noreply, state}
+  end
+
+  def handle_info({cook_ref, _value}, %{cook_ref: cook_ref} = state) do
+    Registry.dispatch(Dispatcher, :reload, fn entries ->
+      for {pid, _value} <- entries, do: send(pid, :reload)
+    end)
+
+    state =
+      if state.cook_queued do
+        cook(state)
+      else
+        %{state | cooking: false, cook_ref: nil}
+      end
+
+    {:noreply, state}
+  end
+
+  def handle_info(_message, state) do
+    {:noreply, state}
+  end
+
+  defp cook(state) do
+    Logger.debug("running mix popcorn.cook")
+    %{ref: cook_ref} = Task.async(fn -> System.cmd("mix", ["popcorn.cook"]) end)
+    %{state | cook_queued: false, cooking: true, cook_ref: cook_ref}
+  end
+end
+
+{opts, _argv} = OptionParser.parse!(System.argv(), strict: [port: :integer])
+
+bandit = {Bandit, plug: Router, scheme: :http, port: Keyword.get(opts, :port, 4000)}
+
+file_system =
+  {FileSystem.Worker, name: :live_reload_file_monitor, dirs: Enum.map(["."], &Path.absname/1)}
+
+children = [{Registry, keys: :duplicate, name: Dispatcher}, file_system, bandit, Recompiler]
+{:ok, _} = Supervisor.start_link(children, strategy: :one_for_one)
+
+# unless running from IEx, sleep idenfinitely so we can serve requests
+unless IEx.started?() do
+  IO.getn("Press enter to exit\n")
+end


### PR DESCRIPTION
A new server has been added, which can be copied into the users directory using `mix popcorn.dev_server`. The dev server differs from the simple server as it sets up a file system watcher using the FileSystem library. This serves two purposes:

1. Whenever a module in the Elixir application changes, `mix popcorn.cook` is called. This uses `System.cmd` as the server runs separately from popcorn, so we can't invoke the mix task directly.
2. Whenver the static directory changes, the websocket sends a reload event, which reloads the web browser.