### PR TITLE
Fix GH actions triggers

### DIFF
--- a/.github/workflows/eval_in_wasm_build_test.yml
+++ b/.github/workflows/eval_in_wasm_build_test.yml
@@ -7,13 +7,13 @@ name: Eval in WASM Build & test
 
 on:
   push:
-    branches: ["*"]
+    branches: ["**"]
     paths:
       - "examples/eval_in_wasm/**"
       - ".github/workflows/eval_in_wasm_build_test.yml"
 
   pull_request:
-    branches: ["*"]
+    branches: ["**"]
     paths:
       - "examples/eval_in_wasm/**"
       - ".github/workflows/eval_in_wasm_build_test.yml"

--- a/.github/workflows/hello_popcorn_build_test.yml
+++ b/.github/workflows/hello_popcorn_build_test.yml
@@ -7,19 +7,21 @@ name: Hello Popcorn - Build & test
 
 on:
   push:
-    branches: ["*"]
+    branches: ["**"]
     paths:
-      - "*"
-      - "!examples"
+      - "**"
+      - "!examples/**"
       - "examples/hello_popcorn/**"
+      - "!.github/**"
       - ".github/workflows/hello_popcorn_build_test.yml"
 
   pull_request:
-    branches: ["*"]
+    branches: ["**"]
     paths:
-      - "*"
-      - "!examples"
+      - "**"
+      - "!examples/**"
       - "examples/hello_popcorn/**"
+      - "!.github/**"
       - ".github/workflows/hello_popcorn_build_test.yml"
 
 permissions:

--- a/.github/workflows/popcorn_build_test.yml
+++ b/.github/workflows/popcorn_build_test.yml
@@ -7,18 +7,18 @@ name: Popcorn build & test
 
 on:
   push:
-    branches: ["*"]
+    branches: ["**"]
     paths:
-      - "*"
-      - "!examples"
-      - "!.github"
+      - "**"
+      - "!examples/**"
+      - "!.github/**"
       - ".github/workflows/popcorn_build_test.yml"
   pull_request:
-    branches: ["*"]
+    branches: ["**"]
     paths:
-      - "*"
-      - "!examples"
-      - "!.github"
+      - "**"
+      - "!examples/**"
+      - "!.github/**"
       - ".github/workflows/popcorn_build_test.yml"
 
 permissions:


### PR DESCRIPTION
- "*" matches only names without "/" (for both branches and paths)
- filters do not work as gitignore and "**" is needed
- If we want to include only one workflow yml, we have to exclude others