### PR TITLE
Reload Popcorn iframe on abort

### DIFF
--- a/priv/static-template/wasm/popcorn.js
+++ b/priv/static-template/wasm/popcorn.js
@@ -158,6 +158,10 @@ export class Popcorn {
     this._iframe = null;
     this._mountPromise = null;
     this._listenerRef = null;
+    for (const [_id, callData] of this._calls) {
+      const durationMs = performance.now() - callData.startTimeMs;
+      callData.reject({ error: "PopcornDeinit", durationMs })
+    }
   }
 
   /**
@@ -313,7 +317,7 @@ export class Popcorn {
   }
 }
 
-function noop() {}
+function noop() { }
 
 async function withTimeout(promise, ms) {
   let timeout = null;

--- a/priv/static-template/wasm/popcorn_iframe.js
+++ b/priv/static-template/wasm/popcorn_iframe.js
@@ -118,6 +118,10 @@ export async function initVm() {
     onVmInit(initProcess);
     Module["onElixirReady"] = null;
   };
+  Module["onWorkerError"] = () => {
+    // Wait until errors are logged and reload
+    setTimeout(() => send(MESSAGES.RELOAD, null), 0);
+  }
 }
 
 function ensureFunctionEval(maybeFunction) {
@@ -150,7 +154,7 @@ function onVmInit(initProcess) {
         const result = await Module.call(process, args);
         send(MESSAGES.CALL, { requestId, data: Module.deserialize(result) });
       } catch (error) {
-        if(error == "noproc") {
+        if (error == "noproc") {
           send(MESSAGES.RELOAD, null);
           console.error("Runtime VM crashed, popcorn iframe reloaded.");
           return;


### PR DESCRIPTION
Requires https://github.com/software-mansion-labs/FissionVM/pull/149

This PR reloads the Popcorn iframe on abort. It requires setting `Module["onAbort"]` in `atomvm.pre.js`, because if we set it in `popcorn.js`, it's sometimes not called for unknown reasons. Also, since onAbort is called within a web worker, we need to use a private Emscripten API to communicate with the main JS thread to be able to handle the error.

Another approach I tried was to have a 'heartbeat' process within the AtomVM, but it turned out that when a worker terminates, other workers may still run, and thus the 'heartbeat' may run even if a worker aborts 🫠

Another change introduced is to reject all promises awaiting reply with a `PopcornDeinit` error when Popcorn is reloaded/deinitialized.