### PR TITLE
Introduce concurrency groups

### DIFF
--- a/.github/workflows/eval_in_wasm_build_test.yml
+++ b/.github/workflows/eval_in_wasm_build_test.yml
@@ -18,6 +18,11 @@ on:
       - "examples/eval_in_wasm/**"
       - ".github/workflows/eval_in_wasm_build_test.yml"
 
+# This ensures, that, except for the main branch, only one instance of workflow is executed on a branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/main' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/hello_popcorn_build_test.yml
+++ b/.github/workflows/hello_popcorn_build_test.yml
@@ -26,6 +26,11 @@ on:
       - "!.github/**"
       - ".github/workflows/hello_popcorn_build_test.yml"
 
+# This ensures, that, except for the main branch, only one instance of workflow is executed on a branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/main' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/popcorn_build_test.yml
+++ b/.github/workflows/popcorn_build_test.yml
@@ -23,6 +23,11 @@ on:
       - "!.github/**"
       - ".github/workflows/popcorn_build_test.yml"
 
+# This ensures, that, except for the main branch, only one instance of workflow is executed on a branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/main' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
This prevents from running two instances of workflows when they are triggered by both push and pull_request