### PR TITLE
Run staging deployment on main push and manual dispatch

### DIFF
--- a/.github/workflows/demo_staging_build_and_deploy.yml
+++ b/.github/workflows/demo_staging_build_and_deploy.yml
@@ -1,8 +1,15 @@
 name: Build and deploy staging demo
 
 on:
+  workflow_dispatch:
   push:
-    branches: [deploy]
+    branches:
+      - main
+    paths:
+      - "misc/landing-page/**"
+      - "misc/language-tour-guide/**"
+      - "misc/landing.nginx.conf"
+      - ".github/workflows/demo_staging_build_and_deploy.yml"
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
This triggers staging deployment when something is pushed to the appropriate misc subfolders.
In case we wanted a staging deployment with newer popcorn version, we can trigger it manually with added trigger