### PR TITLE
Add single-line logs when building bundles

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,7 @@
 import Config
 
+config :logger, :default_formatter, metadata: [:app_name]
+
 if File.exists?("#{__DIR__}/config.secret.exs") do
   # Put the following configuration in config.secret.exs:
   # config :popcorn, runtime_path: ...

--- a/lib/popcorn/build_log_formatter.ex
+++ b/lib/popcorn/build_log_formatter.ex
@@ -1,0 +1,58 @@
+defmodule Popcorn.BuildLogFormatter do
+  @moduledoc """
+  Used in Popcorn build and patch process to keep logs short.
+  """
+  require Logger
+
+  @clear_line "\e[2K\r"
+  @overrides [
+    format: {__MODULE__, :format},
+    colors: [enabled: true],
+    metadata: [:app_name]
+  ]
+
+  def with_build_logger(f) do
+    original_formatter = Logger.default_formatter()
+    formatter = Logger.default_formatter(@overrides)
+    :logger.update_handler_config(:default, :formatter, formatter)
+    f.()
+    :logger.update_handler_config(:default, :formatter, original_formatter)
+  end
+
+  @spec format(Logger.level(), Logger.message(), Logger.Formatter.date_time_ms(), keyword()) ::
+          IO.chardata()
+  def format(level, message, timestamp, metadata) do
+    {prefix, suffix} = format_control_chars()
+    app_name = format_app_name(metadata)
+
+    "#{prefix}[$level#{app_name}] $message#{suffix}"
+    |> Logger.Formatter.compile()
+    |> Logger.Formatter.format(
+      level,
+      message,
+      timestamp,
+      metadata
+    )
+  end
+
+  defp format_app_name(metadata) do
+    case Keyword.fetch(metadata, :app_name) do
+      {:ok, app} -> " | #{app}"
+      :error -> ""
+    end
+  end
+
+  defp format_control_chars do
+    if interactive_terminal?(), do: {@clear_line, ""}, else: {"", "\n"}
+  end
+
+  defp interactive_terminal? do
+    with {:ok, true} <- :standard_io |> :io.getopts() |> Keyword.fetch(:terminal),
+         true <- IO.ANSI.enabled?(),
+         nil <- System.get_env("CI") do
+      true
+    else
+      _ -> false
+    end
+  end
+end


### PR DESCRIPTION
Prints all operations in the same line (in interactive terminals) which limits log spam.

## Screencast

Click to play.

[![asciicast](https://asciinema.org/a/BfXBCK37hOpT0ncDukTpt4za8.svg)](https://asciinema.org/a/BfXBCK37hOpT0ncDukTpt4za8)