### PR TITLE
Refactor bundling logic

### DIFF
--- a/lib/popcorn/artifacts_cache.ex
+++ b/lib/popcorn/artifacts_cache.ex
@@ -13,6 +13,8 @@ defmodule Popcorn.ArtifactsCache do
       ...
     }
   }
+
+  See `Popcorn.Build`.
   """
 
   @app_path Mix.Project.app_path()

--- a/lib/popcorn/artifacts_cache.ex
+++ b/lib/popcorn/artifacts_cache.ex
@@ -1,21 +1,20 @@
 defmodule Popcorn.ArtifactsCache do
-  @moduledoc """
-  Artifacts cache is a map, stored in external term format on disk. Stores input files with hashes for the previous build.
-  Used to skip building parts of input files if they did not change.
+  @moduledoc false
+  # Artifacts cache is a map, stored in external term format on disk. Stores input files with hashes for the previous build.
+  # Used to skip building parts of input files if they did not change.
 
-  The stored map has following structure:
-  %{
-    app1: %{
-      file_path1: hash1,
-      file_path2: hash2
-    },
-    app2: %{
-      ...
-    }
-  }
+  # The stored map has following structure:
+  # %{
+  #   app1: %{
+  #     file_path1: hash1,
+  #     file_path2: hash2
+  #   },
+  #   app2: %{
+  #     ...
+  #   }
+  # }
 
-  See `Popcorn.Build`.
-  """
+  # See `Popcorn.Build`.
 
   @app_path Mix.Project.app_path()
   @cache_path "#{@app_path}/popcorn_patch_cache"
@@ -100,10 +99,7 @@ defmodule Popcorn.ArtifactsCache do
         %{}
 
       {:error, reason} ->
-        raise(File.Error,
-          reason: reason,
-          path: @cache_path
-        )
+        raise File.Error, reason: reason, path: @cache_path
     end
   end
 
@@ -127,10 +123,7 @@ defmodule Popcorn.ArtifactsCache do
         :ok
 
       {:error, reason} ->
-        raise(File.Error,
-          reason: reason,
-          path: @cache_path
-        )
+        raise File.Error, reason: reason, path: @cache_path
     end
   end
 end

--- a/lib/popcorn/artifacts_cache.ex
+++ b/lib/popcorn/artifacts_cache.ex
@@ -1,0 +1,134 @@
+defmodule Popcorn.ArtifactsCache do
+  @moduledoc """
+  Artifacts cache is a map, stored in external term format on disk. Stores input files with hashes for the previous build.
+  Used to skip building parts of input files if they did not change.
+
+  The stored map has following structure:
+  %{
+    app1: %{
+      file_path1: hash1,
+      file_path2: hash2
+    },
+    app2: %{
+      ...
+    }
+  }
+  """
+
+  @app_path Mix.Project.app_path()
+  @cache_path "#{@app_path}/popcorn_patch_cache"
+
+  @doc """
+  Checks if cache is a subset of files to build.
+
+  This is used to quickly check if cache is viable to use – if any cached file was deleted, we treat cache as invalidated.
+  """
+  def subset_of_sources?(cache, source_paths) do
+    all_cached_paths =
+      cache
+      |> Map.values()
+      |> Enum.flat_map(&Map.keys/1)
+      |> MapSet.new()
+
+    MapSet.subset?(all_cached_paths, source_paths)
+  end
+
+  @doc """
+  Returns a map of apps from new cache with files changed compared to current cache.
+  If app's files did not change, the app is not included.
+
+  ## Examples
+
+  ```elixir
+  iex> cache = %{
+  ...>   app1: %{
+  ...>     "file1.ex" => "hash1",
+  ...>     "file2.ex" => "hash2"
+  ...>   },
+  ...>   app2: %{
+  ...>     "file3.ex" => "hash3"
+  ...>   }
+  ...> }
+  iex> new_cache = %{
+  ...>   app1: %{
+  ...>     "file1.ex" => "new_hash1",
+  ...>     "file2.ex" => "hash2"
+  ...>   },
+  ...>   app2: %{
+  ...>     "file3.ex" => "hash3"
+  ...>   },
+  ...>   app3: %{
+  ...>     "file4.ex" => "hash4"
+  ...>   }
+  ...> }
+  iex> get_modified_apps(cache, new_cache)
+  %{app1: ["file1.ex"], app3: ["file4.ex"]}
+  ```
+  """
+  def get_modified_apps(cache, new_cache) do
+    Enum.map(new_cache, fn {app, new_file_hashes} ->
+      modified_paths = get_modified_paths(cache[app], new_file_hashes)
+
+      {app, modified_paths}
+    end)
+    |> Enum.filter(fn {_app, modified_paths} -> modified_paths != [] end)
+    |> Map.new()
+  end
+
+  def get_modified_paths(nil, new_file_hashes), do: Map.keys(new_file_hashes)
+
+  def get_modified_paths(file_hashes, new_file_hashes) do
+    new_file_hashes
+    |> Map.filter(fn {new_path, new_hash} ->
+      hash_changed = file_hashes[new_path] != new_hash
+      hash_changed
+    end)
+    |> Map.keys()
+  end
+
+  @doc """
+  Reads the map from disk or returns empty map if not persisted.
+  """
+  def read_from_disk!() do
+    case File.read(@cache_path) do
+      {:ok, cache} ->
+        :erlang.binary_to_term(cache)
+
+      {:error, :enoent} ->
+        %{}
+
+      {:error, reason} ->
+        raise(File.Error,
+          reason: reason,
+          path: @cache_path
+        )
+    end
+  end
+
+  @doc """
+  Writes the map to disk in external term format.
+  """
+  def write_to_disk!(cache) do
+    File.write!(@cache_path, :erlang.term_to_binary(cache))
+    :ok
+  end
+
+  @doc """
+  Removes persisted cache or does nothing if already doesn't exist.
+  """
+  def drop_cache!() do
+    case File.rm(@cache_path) do
+      :ok ->
+        :ok
+
+      {:error, :enoent} ->
+        :ok
+
+      {:error, reason} ->
+        raise(File.Error,
+          reason: reason,
+          path: @cache_path
+        )
+    end
+  end
+end

--- a/lib/popcorn/build.ex
+++ b/lib/popcorn/build.ex
@@ -1,5 +1,8 @@
 defmodule Popcorn.Build do
-  @moduledoc false
+  @moduledoc """
+  Uses system OTP and Elixir applications to create .avm bundles used in user bundles.
+  Applies Popcorn patches to .beam files in the applications.
+  """
   require Popcorn.Config
   require Logger
   alias Popcorn.CoreErlangUtils
@@ -84,17 +87,14 @@ defmodule Popcorn.Build do
   def builtin_app_names() do
     otp_apps =
       :code.lib_dir()
-      |> IO.chardata_to_string()
+      |> to_string()
       |> File.ls!()
       |> Enum.map(fn app_dir ->
-        app_dir
-        |> String.split("-")
-        |> hd()
+        [app_name, _version] = String.split(app_dir, "-", parts: 2)
+        app_name
       end)
 
-    elixir_apps =
-      Path.expand("..", Application.app_dir(:elixir))
-      |> File.ls!()
+    elixir_apps = Path.expand("..", Application.app_dir(:elixir)) |> File.ls!()
 
     otp_apps ++ elixir_apps
   end
@@ -196,10 +196,10 @@ defmodule Popcorn.Build do
 
           patch_path
           |> compile_patch(tmp_dir)
+          # credo:disable-for-lines:3 Credo.Check.Refactor.Nesting
           |> Enum.map(fn patch_beam_path ->
             name = Path.basename(patch_beam_path)
             do_patch(app, name, beams_by_name[name], patch_beam_path, out_dir)
-            name
           end)
         end)
       end)

--- a/lib/popcorn/build.ex
+++ b/lib/popcorn/build.ex
@@ -47,9 +47,10 @@ defmodule Popcorn.Build do
 
     patches_srcs = Path.wildcard("patches/**/*.{ex,erl,yrl,S}") |> MapSet.new()
     cache = ArtifactsCache.read_from_disk!()
+    is_cache_invalid = not ArtifactsCache.subset_of_sources?(cache, patches_srcs)
 
     cache =
-      if not ArtifactsCache.subset_of_sources?(cache, patches_srcs) do
+      if is_cache_invalid do
         File.rm_rf!(@patches_path)
         File.mkdir_p!(@patches_path)
         %{}

--- a/lib/popcorn/build.ex
+++ b/lib/popcorn/build.ex
@@ -58,7 +58,7 @@ defmodule Popcorn.Build do
 
     new_cache =
       process_async(
-        @available_apps,
+        [:popcorn_lib | @available_apps],
         fn app ->
           app_cache = build_app(app, Map.get(cache, app, %{}))
           {app, app_cache}
@@ -67,9 +67,6 @@ defmodule Popcorn.Build do
         max_concurrency: 2
       )
       |> Map.new()
-
-    popcorn_lib_cache = build_popcorn(cache[:popcorn_lib])
-    new_cache = Map.put(new_cache, :popcorn_lib, popcorn_lib_cache)
 
     ArtifactsCache.write_to_disk!(new_cache)
 
@@ -125,45 +122,37 @@ defmodule Popcorn.Build do
     |> Enum.map(&String.to_charlist/1)
   end
 
+  defp patchable_app_beams(:popcorn_lib), do: []
+
+  defp patchable_app_beams(app) do
+    app
+    |> Application.app_dir()
+    |> Path.join("ebin/**/*.beam")
+    |> Path.wildcard()
+  end
+
+  defp patches_source(:popcorn_lib), do: Path.wildcard("patches/popcorn_lib/**/*.{ex,erl,yrl,S}")
+
+  defp patches_source(app) do
+    Path.wildcard("patches/{otp,elixir}/#{app}/*.{ex,erl,yrl,S}")
+  end
+
   defp build_app(application, cache) do
     build_dir = bundle_ebin_dir(application)
     File.mkdir_p!(build_dir)
 
-    app_beams =
-      application
-      |> Application.app_dir()
-      |> Path.join("ebin/**/*.beam")
-      |> Path.wildcard()
+    app_beams = patchable_app_beams(application)
 
-    patches_srcs = Path.wildcard("patches/{otp,elixir}/#{application}/*.{ex,erl,yrl,S}")
-
+    # update cache hashes
+    patches_srcs = patches_source(application)
     {modified_srcs, cache} = update_cache(patches_srcs, cache)
 
     patched_beams = patch(application, app_beams, modified_srcs, build_dir)
-
     transferred_beams = transfer_stdlib(application, app_beams, build_dir)
 
     if patched_beams != [] or transferred_beams != [] do
       Logger.info("Bundling #{application}.avm", app_name: application)
       :packbeam_api.create(to_charlist(bundle_path(application)), bundle_beams(application))
-    end
-
-    cache
-  end
-
-  defp build_popcorn(cache) do
-    bundle = :popcorn_lib
-    build_dir = bundle_ebin_dir(bundle)
-    File.mkdir_p!(build_dir)
-    srcs = Path.wildcard("patches/#{bundle}/**/*.{ex,erl,yrl,S}")
-
-    {modified_srcs, cache} = update_cache(srcs, cache)
-
-    popcorn_lib_beams = patch(bundle, [], modified_srcs, build_dir)
-
-    if popcorn_lib_beams != [] do
-      Logger.info("Bundling #{bundle}.avm", app_name: bundle)
-      :packbeam_api.create(to_charlist(bundle_path(bundle)), bundle_beams(bundle))
     end
 
     cache

--- a/lib/popcorn/build.ex
+++ b/lib/popcorn/build.ex
@@ -73,11 +73,11 @@ defmodule Popcorn.Build do
 
     ArtifactsCache.write_to_disk!(new_cache)
 
-    :ok
     BuildLogFormatter.disable(original_formatter)
     end_time = DateTime.utc_now()
     duration = DateTime.diff(end_time, start_time, :microsecond)
     Logger.info("Bundling finished (took #{to_human_duration(duration)})")
+    :ok
   end
 
   @doc """

--- a/lib/popcorn/build.ex
+++ b/lib/popcorn/build.ex
@@ -115,13 +115,6 @@ defmodule Popcorn.Build do
 
   defp bundle_ebin_dir(bundle), do: Path.join([@patches_path, to_string(bundle), "ebin"])
 
-  defp bundle_beams(bundle) do
-    bundle_ebin_dir(bundle)
-    |> Path.join("*.beam")
-    |> Path.wildcard()
-    |> Enum.map(&String.to_charlist/1)
-  end
-
   defp patchable_app_beams(:popcorn_lib), do: []
 
   defp patchable_app_beams(app) do
@@ -152,10 +145,23 @@ defmodule Popcorn.Build do
 
     if patched_beams != [] or transferred_beams != [] do
       Logger.info("Bundling #{application}.avm", app_name: application)
-      :packbeam_api.create(to_charlist(bundle_path(application)), bundle_beams(application))
+      create_bundle!(application)
     end
 
     cache
+  end
+
+  defp create_bundle!(app) do
+    out_path = app |> bundle_path() |> to_charlist()
+    beams = app |> bundle_beams() |> Enum.map(&String.to_charlist/1)
+
+    :ok = :packbeam_api.create(out_path, beams)
+  end
+
+  defp bundle_beams(bundle) do
+    bundle_ebin_dir(bundle)
+    |> Path.join("*.beam")
+    |> Path.wildcard()
   end
 
   # Updates hash of each patch and returns only paths that have different hash
@@ -184,9 +190,7 @@ defmodule Popcorn.Build do
     # Compiling together may break something, as these modules
     # will override stdlib modules.
     process_async(patch_srcs, fn src ->
-      tmp_dir = setup_tmp_dir(out_dir)
-
-      try do
+      with_tmp_dir(out_dir, fn tmp_dir ->
         Logger.info("Compiling #{src}", app_name: app)
         compile_patch(src, tmp_dir)
 
@@ -196,11 +200,9 @@ defmodule Popcorn.Build do
           do_patch(app, name, stdlib_beams_by_name[name], path, out_dir)
           name
         end)
-      after
-        File.rm_rf!(tmp_dir)
-      end
+      end)
+      |> List.flatten()
     end)
-    |> List.flatten()
   end
 
   defp compile_patch(path, tmp_dir) do
@@ -235,24 +237,20 @@ defmodule Popcorn.Build do
   # To be replaced with File.cp when we improve tracing in AtomVM
   defp do_patch(app_name, name, nil, patch, out_dir) do
     Logger.info("Patching #{name}", app_name: app_name)
-    ast = File.read!(patch) |> CoreErlangUtils.parse()
-    ast = if @config.add_tracing, do: CoreErlangUtils.add_simple_tracing(ast), else: ast
-    beam = CoreErlangUtils.serialize(ast)
-    File.write!(Path.join(out_dir, name), beam)
+
+    transform_beam_ast(patch, out_dir, fn patch_ast ->
+      maybe_add_tracing(patch_ast, @config.add_tracing)
+    end)
   end
 
   defp do_patch(app_name, name, stdlib, patch, out_dir) do
     Logger.info("Patching #{name}", app_name: app_name)
+    patch_ast = CoreErlangUtils.parse(File.read!(patch))
 
-    ast =
-      CoreErlangUtils.merge_modules(
-        CoreErlangUtils.parse(File.read!(stdlib)),
-        CoreErlangUtils.parse(File.read!(patch))
-      )
-
-    ast = if @config.add_tracing, do: CoreErlangUtils.add_simple_tracing(ast), else: ast
-    beam = CoreErlangUtils.serialize(ast)
-    File.write!(Path.join(out_dir, name), beam)
+    transform_beam_ast(stdlib, out_dir, fn stdlib_ast ->
+      CoreErlangUtils.merge_modules(stdlib_ast, patch_ast)
+      |> maybe_add_tracing(@config.add_tracing)
+    end)
   end
 
   # This is only needed to add tracing
@@ -266,13 +264,29 @@ defmodule Popcorn.Build do
     |> process_async(fn path ->
       name = Path.basename(path)
       Logger.info("Transferring #{name}", app_name: app_name)
-      ast = File.read!(path) |> CoreErlangUtils.parse()
-      ast = if @config.add_tracing, do: CoreErlangUtils.add_simple_tracing(ast), else: ast
-      beam = CoreErlangUtils.serialize(ast)
-      File.write!(Path.join(out_dir, name), beam)
+
+      transform_beam_ast(path, out_dir, fn ast ->
+        maybe_add_tracing(ast, @config.add_tracing)
+      end)
+
       name
     end)
   end
+
+  defp transform_beam_ast(beam_path, out_dir, transform) do
+    name = Path.basename(beam_path)
+    out_path = Path.join(out_dir, name)
+
+    beam_path
+    |> File.read!()
+    |> CoreErlangUtils.parse()
+    |> transform.()
+    |> CoreErlangUtils.serialize()
+    |> then(&File.write!(out_path, &1))
+  end
+
+  defp maybe_add_tracing(ast, true), do: CoreErlangUtils.add_simple_tracing(ast)
+  defp maybe_add_tracing(ast, false), do: ast
 
   defp process_async(enum, fun, opts \\ []) do
     enum
@@ -280,11 +294,16 @@ defmodule Popcorn.Build do
     |> Enum.map(fn {:ok, result} -> result end)
   end
 
-  defp setup_tmp_dir(path) do
+  defp with_tmp_dir(path, f) do
     tmp_dir = Path.join(path, "tmp_#{:erlang.unique_integer([:positive])}")
     File.rm_rf!(tmp_dir)
     File.mkdir!(tmp_dir)
-    tmp_dir
+
+    try do
+      f.(tmp_dir)
+    after
+      File.rm_rf!(tmp_dir)
+    end
   end
 
   defp to_human_duration(us) do

--- a/lib/popcorn/build.ex
+++ b/lib/popcorn/build.ex
@@ -1,8 +1,8 @@
 defmodule Popcorn.Build do
-  @moduledoc """
-  Uses system OTP and Elixir applications to create .avm bundles used in user bundles.
-  Applies Popcorn patches to .beam files in the applications.
-  """
+  @moduledoc false
+  # Uses system OTP and Elixir applications to create .avm bundles used in user bundles.
+  # Applies Popcorn patches to .beam files in the applications.
+
   require Popcorn.Config
   require Logger
   alias Popcorn.CoreErlangUtils

--- a/lib/popcorn/build.ex
+++ b/lib/popcorn/build.ex
@@ -141,9 +141,9 @@ defmodule Popcorn.Build do
     {modified_srcs, cache} = update_cache(patches_srcs, cache)
 
     patched_beams = patch(application, app_beams, modified_srcs, build_dir)
-    transferred_beams = transfer_stdlib(application, app_beams, build_dir)
+    copied_beams = copy_beams(application, app_beams, build_dir)
 
-    if patched_beams != [] or transferred_beams != [] do
+    if patched_beams != [] or copied_beams != [] do
       Logger.info("Bundling #{application}.avm", app_name: application)
       create_bundle!(application)
     end
@@ -183,8 +183,8 @@ defmodule Popcorn.Build do
   # The patching works by replacing original functions implementations
   # with custom ones.
   # The sources of the patches reside in the `patches` directory.
-  defp patch(app, stdlib_beams, patch_srcs, out_dir) do
-    stdlib_beams_by_name = Map.new(stdlib_beams, &{Path.basename(&1), &1})
+  defp patch(app, beams, patch_srcs, out_dir) do
+    beams_by_name = Map.new(beams, &{Path.basename(&1), &1})
 
     # Compiling each file separately, like AtomVM does it.
     # Compiling together may break something, as these modules
@@ -197,7 +197,7 @@ defmodule Popcorn.Build do
         Path.wildcard("#{tmp_dir}/*")
         |> Enum.map(fn path ->
           name = Path.basename(path)
-          do_patch(app, name, stdlib_beams_by_name[name], path, out_dir)
+          do_patch(app, name, beams_by_name[name], path, out_dir)
           name
         end)
       end)
@@ -226,7 +226,7 @@ defmodule Popcorn.Build do
 
   # prim_eval fails to be parsed, probably because it's compiled from an asm (*.S) file
   # so we just copy it
-  defp do_patch(app_name, "prim_eval.beam" = name, _stdlib, patch, out_dir) do
+  defp do_patch(app_name, "prim_eval.beam" = name, _beam, patch, out_dir) do
     Logger.info("Patching #{name}", app_name: app_name)
 
     File.cp!(patch, Path.join(out_dir, name))
@@ -243,12 +243,12 @@ defmodule Popcorn.Build do
     end)
   end
 
-  defp do_patch(app_name, name, stdlib, patch, out_dir) do
+  defp do_patch(app_name, name, beam, patch, out_dir) do
     Logger.info("Patching #{name}", app_name: app_name)
     patch_ast = CoreErlangUtils.parse(File.read!(patch))
 
-    transform_beam_ast(stdlib, out_dir, fn stdlib_ast ->
-      CoreErlangUtils.merge_modules(stdlib_ast, patch_ast)
+    transform_beam_ast(beam, out_dir, fn ast ->
+      CoreErlangUtils.merge_modules(ast, patch_ast)
       |> maybe_add_tracing(@config.add_tracing)
     end)
   end
@@ -256,10 +256,10 @@ defmodule Popcorn.Build do
   # This is only needed to add tracing
   # but we execute it always for consistency
   # To be removed when we improve tracing in AtomVM
-  defp transfer_stdlib(app_name, stdlib_beams, out_dir) do
+  defp copy_beams(app_name, beams, out_dir) do
     already_transferred = MapSet.new(File.ls!(out_dir))
 
-    stdlib_beams
+    beams
     |> Enum.reject(&(Path.basename(&1) in already_transferred))
     |> process_async(fn path ->
       name = Path.basename(path)

--- a/lib/popcorn/build_log_formatter.ex
+++ b/lib/popcorn/build_log_formatter.ex
@@ -1,7 +1,7 @@
 defmodule Popcorn.BuildLogFormatter do
-  @moduledoc """
-  Used in Popcorn build and patch process to keep logs short.
-  """
+  @moduledoc false
+  # Used in Popcorn build and patch process to keep logs short.
+
   require Logger
 
   @clear_line "#{IO.ANSI.clear_line()}\r"


### PR DESCRIPTION
~⚠️ Merge after #329~

## Old description

This PR changes caching strategy for patches and beams from stdlib to improve build-times and simplify the logic.

The old behavior loaded cache manifest (with structure`Map<app_name, Map<beam_name, hash>>`) and checked if it's loaded correctly and isn't stale compared to patches file set (and hashes). If it's stale, we drop all build directories and start from scratch.
Patch hashes were calculated async, at the time when app was building.

The new behavior works by pre-calculating hashes and extracting set of changes between cache and current files state.
We run build process for changed files. Then, we make sure that all input beams are located in output directory.
