### PR TITLE
[Lang tour] Set filename to 'playground' when calling Code.eval_string

### DIFF
--- a/misc/language-tour-guide/elixir_tour/lib/elixir_tour.ex
+++ b/misc/language-tour-guide/elixir_tour/lib/elixir_tour.ex
@@ -47,7 +47,9 @@ defmodule ElixirTour do
 
   defp eval(code) do
     try do
-      {evaluated, _new_bindings} = Code.eval_string(code, [], __ENV__)
+      {evaluated, _new_bindings} =
+        Code.eval_string(code, [], %Macro.Env{__ENV__ | file: "playground", line: 1})
+
       {:ok, evaluated}
     rescue
       e ->


### PR DESCRIPTION
before:
<img width="791" height="194" alt="image" src="https://github.com/user-attachments/assets/a41ec48c-1476-49d3-9373-ec9c81293e9e" />

after:
<img width="791" height="176" alt="image" src="https://github.com/user-attachments/assets/12259007-eb08-43be-acd7-45979220ab3c" />
