### PR TITLE
Enhance styling of code editor

### DIFF
--- a/misc/language-tour-guide/src/components/code-editor/CodeEditor.styles.css
+++ b/misc/language-tour-guide/src/components/code-editor/CodeEditor.styles.css
@@ -1,5 +1,15 @@
 .cm-editor {
   border-bottom-left-radius: 0.375rem;
+  height: 100%;
+  min-height: 500px;
+}
+
+.cm-scroller {
+  flex-grow: 1;
+}
+
+.cm-focused {
+  outline: none !important;
 }
 
 .cm-gutters {

--- a/misc/language-tour-guide/src/components/code-editor/CodeEditor.tsx
+++ b/misc/language-tour-guide/src/components/code-editor/CodeEditor.tsx
@@ -30,7 +30,7 @@ export function CodeEditor() {
 
   return (
     <CodeMirror
-      className="border-orange-20 scrollbar h-full min-h-[500px] overflow-scroll rounded-md border bg-[#FDF6E3] lg:min-h-0"
+      className="border-orange-20 scrollbar overflow-scroll rounded-md border bg-[#FDF6E3]"
       autoFocus
       value={code}
       extensions={[elixir(), keymapExtension]}


### PR DESCRIPTION
- Remove outline on CodeEditor component focus
- Move horizontal scrollbar to bottom of codeEditor component

<img width="1824" height="1538" alt="image" src="https://github.com/user-attachments/assets/0b9145d5-c8dc-4750-a4e6-aad3ad550317" />