### PR TITLE
Improve type checking of popcorn events

### DIFF
--- a/priv/static-template/wasm/popcorn.js
+++ b/priv/static-template/wasm/popcorn.js
@@ -271,7 +271,10 @@ export class Popcorn {
     const handler = handlers[data.type];
     if (handler !== undefined) {
       handler(data.value);
-    } else if (data.type?.startsWith("popcorn")) {
+    } else if (
+      typeof data.type === "string" &&
+      data.type?.startsWith("popcorn")
+    ) {
       console.warn(
         `Received unhandled event: ${JSON.stringify(data, null, 4)}`,
       );


### PR DESCRIPTION
Fixed a TypeError that occurred when an external event (e.g., from a browser extension) had a non-string `data.type` field. Added type checking for the `data.type` property before checking if it starts with the 'popcorn' prefix.