### PR TITLE
[iex_wasm] Change prompt prefix from 'avm_iex' to 'local_iex'

### DIFF
--- a/patches/elixir/iex/server.ex
+++ b/patches/elixir/iex/server.ex
@@ -10,7 +10,7 @@ defmodule IEx.Server do
     #     {:popcorn_module.prompt_mode(status, :default), :popcorn_module.default_prefix(status, prefix)}
     #   end
 
-    prompt = "browser_iex(#{to_string(counter)})>"
+    prompt = "local_iex(#{to_string(counter)})>"
     # apply(IEx.Config, mode, [])
     # |> String.replace("%counter", to_string(counter))
     # |> String.replace("%prefix", to_string(prefix))


### PR DESCRIPTION
I know that this can be run on Unix as well, but IMO it's more important to make it clearer on the web that it runs in the browser. I also thought about `wasm_iex` or `local_iex`.