### PR TITLE
Fix binary module literals

### DIFF
--- a/patches/otp/compiler/core_parse.hrl
+++ b/patches/otp/compiler/core_parse.hrl
@@ -1,0 +1,112 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 1999-2023. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+%% Purpose : Core Erlang syntax trees as records.
+
+%% It would be nice to incorporate some generic functions as well but
+%% this could make including this file difficult.
+
+%% Note: the annotation list is *always* the first record field.
+%% Thus it is possible to define the macros:
+%% -define(get_ann(X), element(2, X)).
+%% -define(set_ann(X, Y), setelement(2, X, Y)).
+
+%% The record definitions appear alphabetically
+
+-record(c_alias, {anno=[] :: list(), var :: cerl:cerl(),
+		  pat :: cerl:cerl()}).
+
+-record(c_apply, {anno=[] :: list(), op :: cerl:cerl(),
+		  args :: [cerl:cerl()]}).
+
+-record(c_binary, {anno=[] :: list(), segments :: [cerl:c_bitstr()]}).
+
+-record(c_bitstr, {anno=[] :: list(), val :: cerl:cerl(),
+		   size :: cerl:cerl(),
+		   unit :: cerl:cerl(),
+		   type :: cerl:cerl(),
+		   flags :: cerl:cerl()}).
+
+-record(c_call, {anno=[] :: list(), module :: cerl:cerl(),
+		 name :: cerl:cerl(),
+		 args :: [cerl:cerl()]}).
+
+-record(c_case, {anno=[] :: list(), arg :: cerl:cerl(),
+		 clauses :: [cerl:cerl()]}).
+
+-record(c_catch, {anno=[] :: list(), body :: cerl:cerl()}).
+
+-record(c_clause, {anno=[] :: list(), pats :: [cerl:cerl()],
+		   guard :: cerl:cerl(),
+		   body :: cerl:cerl() | any()}). % TODO
+
+-record(c_cons, {anno=[] :: list(), hd :: cerl:cerl(),
+		 tl :: cerl:cerl()}).
+
+-record(c_fun, {anno=[] :: list(), vars :: [cerl:cerl()],
+		body :: cerl:cerl()}).
+
+-record(c_let, {anno=[] :: list(), vars :: [cerl:cerl()],
+		arg :: cerl:cerl(),
+		body :: cerl:cerl()}).
+
+-record(c_letrec, {anno=[] :: list(),
+                   defs :: [{cerl:cerl(), cerl:cerl()}],
+		   body :: cerl:cerl()}).
+
+-record(c_literal, {anno=[] :: list(), val :: any()}).
+
+-record(c_map, {anno=[] :: list(),
+		arg=#c_literal{val=#{}} :: cerl:c_var() | cerl:c_literal(),
+		es :: [cerl:c_map_pair()],
+		is_pat=false :: boolean()}).
+
+-record(c_map_pair, {anno=[] :: list(),
+	             op :: #c_literal{val::'assoc'} | #c_literal{val::'exact'},
+		     key :: any(),              % TODO
+		     val :: any()}).            % TODO
+
+-record(c_module, {anno=[] :: list(), name :: cerl:cerl(),
+		   exports :: [cerl:cerl()],
+		   attrs :: [{cerl:cerl(), cerl:cerl()}],
+		   defs :: [{cerl:cerl(), cerl:cerl()}]}).
+
+-record(c_opaque, {anno=[] :: list(), val :: any()}).
+
+-record(c_primop, {anno=[] :: list(), name :: cerl:cerl(),
+		   args :: [cerl:cerl()]}).
+
+-record(c_receive, {anno=[] :: list(), clauses :: [cerl:cerl()],
+		    timeout :: cerl:cerl(),
+		    action :: cerl:cerl()}).
+
+-record(c_seq, {anno=[] :: list(), arg :: cerl:cerl() | any(), % TODO
+		body :: cerl:cerl()}).
+
+-record(c_try, {anno=[] :: list(), arg :: cerl:cerl(),
+		vars :: [cerl:cerl()],
+		body :: cerl:cerl(),
+		evars :: [cerl:cerl()],
+		handler :: cerl:cerl()}).
+
+-record(c_tuple, {anno=[] :: list(), es :: [cerl:cerl()]}).
+
+-record(c_values, {anno=[] :: list(), es :: [cerl:cerl()]}).
+
+-record(c_var, {anno=[] :: list(), name :: cerl:var_name()}).

--- a/patches/otp/compiler/v3_core.erl
+++ b/patches/otp/compiler/v3_core.erl
@@ -1,0 +1,20 @@
+-module(v3_core).
+
+-compile({popcorn_patch_private, bin_expand_string/5}).
+
+% Patch reason: for some reason, the compiler converts binaries
+% smaller than this to integers (and probably reconstructs them
+% later somehow). Since AtomVM doesn't support big ints, it cuts
+% off parts of binaries, so we need to limit it to fit in a regular
+% integer, and patch functions that rely on it.
+
+%% Matches expansion max segment in v3_kernel.
+-define(COLLAPSE_MAX_SIZE_SEGMENT, 64).
+
+bin_expand_string(S, Line, Val, Size, Last) when Size >= ?COLLAPSE_MAX_SIZE_SEGMENT ->
+    Combined = popcorn_module:make_combined(Line, Val, Size),
+    [Combined|bin_expand_string(S, Line, 0, 0, Last)];
+bin_expand_string([H|T], Line, Val, Size, Last) ->
+    bin_expand_string(T, Line, (Val bsl 8) bor H, Size+8, Last);
+bin_expand_string([], Line, Val, Size, Last) ->
+    [popcorn_module:make_combined(Line, Val, Size) | Last].

--- a/patches/otp/compiler/v3_kernel.erl
+++ b/patches/otp/compiler/v3_kernel.erl
@@ -1,0 +1,52 @@
+-module(v3_kernel).
+
+-compile({popcorn_patch_private, integer_fits_and_is_expandable/2}).
+-compile({popcorn_patch_private, select_bin_int/1}).
+
+-include("v3_kernel.hrl").
+-include("core_parse.hrl").
+
+% Patch reason: for some reason, the compiler converts binaries
+% smaller than this to integers (and probably reconstructs them
+% later somehow). Since AtomVM doesn't support big ints, it cuts
+% off parts of binaries, so we need to limit it to fit in a regular
+% integer, and patch functions that rely on it.
+
+%% Matches expansion max segment in v3_core.
+-define(EXPAND_MAX_SIZE_SEGMENT, 64).
+
+-record(ivalues, {anno=[],args}).
+-record(ifun, {anno=[],vars,body}).
+-record(iset, {anno=[],vars,arg,body}).
+-record(iletrec, {anno=[],defs}).
+-record(ialias, {anno=[],vars,pat}).
+-record(iclause, {anno=[],isub,osub,pats,guard,body}).
+
+integer_fits_and_is_expandable(Int, Size) when is_integer(Int), is_integer(Size),
+                                               0 < Size, Size =< ?EXPAND_MAX_SIZE_SEGMENT ->
+    case <<Int:Size>> of
+	<<Int:Size>> -> true;
+	_ -> false
+    end;
+integer_fits_and_is_expandable(_Int, _Size) ->
+    false.
+
+select_bin_int([#iclause{pats=[#k_bin_seg{anno=A,type=integer,
+                                          size=#k_literal{val=Bits0}=Sz,unit=U,
+                                          flags=Fl,seg=#k_literal{val=Val},
+                                          next=N}|Ps]}=C|Cs0]) when is_integer(Bits0) ->
+    Bits = U * Bits0,
+    if
+	Bits > ?EXPAND_MAX_SIZE_SEGMENT -> throw(not_possible); %Expands the code too much.
+	true -> ok
+    end,
+    popcorn_module:select_assert_match_possible(Bits, Val, Fl),
+    P = #k_bin_int{anno=A,size=Sz,unit=U,flags=Fl,val=Val,next=N},
+    case lists:member(native, Fl) of
+	true -> throw(not_possible);
+	false -> ok
+    end,
+    Cs1 = [C#iclause{pats=[P|Ps]}|popcorn_module:select_bin_int_1(Cs0, Bits, Fl, Val)],
+    Cs = popcorn_module:reorder_bin_ints(Cs1),
+    [{k_bin_int,Cs}];
+select_bin_int(_) -> throw(not_possible).

--- a/patches/otp/compiler/v3_kernel.hrl
+++ b/patches/otp/compiler/v3_kernel.hrl
@@ -1,0 +1,76 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 1999-2023. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+
+%% Purpose : Kernel Erlang as records.
+
+%% It would be nice to incorporate some generic functions as well but
+%% this could make including this file difficult.
+%% N.B. the annotation field is ALWAYS the first field!
+
+%% Literals
+%% NO CHARACTERS YET.
+%%-record(k_char, {anno=[],val}).
+-record(k_literal, {anno=[],val}).
+
+-record(k_tuple, {anno=[],es}).
+-record(k_map, {anno=[],var=#k_literal{val=#{}},op,es}).
+-record(k_map_pair, {anno=[],key,val}).
+-record(k_cons, {anno=[],hd,tl}).
+-record(k_binary, {anno=[],segs}).
+-record(k_bin_seg, {anno=[],size,unit,type,flags,seg,next}).
+-record(k_bin_int, {anno=[],size,unit,flags,val,next}).
+-record(k_bin_end, {anno=[]}).
+-record(k_var, {anno=[],name}).
+
+-record(k_local, {anno=[],name,arity}).
+-record(k_remote, {anno=[],mod,name,arity}).
+-record(k_internal, {anno=[],name,arity}).
+
+-record(k_mdef, {anno=[],name,exports,attributes,body}).
+-record(k_fdef, {anno=[],func,arity,vars,body}).
+
+-record(k_seq, {anno=[],arg,body}).
+-record(k_put, {anno=[],arg,ret=[]}).
+-record(k_bif, {anno=[],op,args,ret=[]}).
+-record(k_test, {anno=[],op,args}).
+-record(k_call, {anno=[],op,args,ret=[]}).
+-record(k_enter, {anno=[],op,args}).
+-record(k_try, {anno=[],arg,vars,body,evars,handler,ret=[]}).
+-record(k_try_enter, {anno=[],arg,vars,body,evars,handler}).
+-record(k_catch, {anno=[],body,ret=[]}).
+
+-record(k_letrec_goto, {anno=[],label,vars=[],first,then,ret=[]}).
+-record(k_goto, {anno=[],label,args=[]}).
+
+-record(k_match, {anno=[],body,ret=[]}).
+-record(k_alt, {anno=[],first,then}).
+-record(k_select, {anno=[],var,types}).
+-record(k_type_clause, {anno=[],type,values}).
+-record(k_val_clause, {anno=[],val,body}).
+-record(k_guard, {anno=[],clauses}).
+-record(k_guard_clause, {anno=[],guard,body}).
+
+-record(k_break, {anno=[],args=[]}).
+-record(k_return, {anno=[],args=[]}).
+
+-record(k_opaque, {anno=[],val}).
+
+%%k_get_anno(Thing) -> element(2, Thing).
+%%k_set_anno(Thing, Anno) -> setelement(2, Thing, Anno).

--- a/test/popcorn/eval_test.exs
+++ b/test/popcorn/eval_test.exs
@@ -752,4 +752,19 @@ defmodule Popcorn.EvalTest do
     |> AtomVM.eval(:elixir, run_dir: dir)
     |> AtomVM.assert_result([{1, 1}, {2, 1}])
   end
+
+  async_test "module binary literals", %{tmp_dir: dir} do
+    quote do
+      defmodule MyApp do
+        def main(x) do
+          "string literal" <> x
+        end
+      end
+
+      MyApp.main(" another string")
+    end
+    |> Macro.to_string()
+    |> AtomVM.eval(:elixir, run_dir: dir)
+    |> AtomVM.assert_result("string literal another string")
+  end
 end


### PR DESCRIPTION
closes #274 

So it turns out that the compiler, due to some wild optimisations I suppose, converts some binary literals to very big integers... Seems like it only happens when compiling modules