### PR TITLE
Fix double action runs

### DIFF
--- a/.github/workflows/eval_in_wasm_build_test.yml
+++ b/.github/workflows/eval_in_wasm_build_test.yml
@@ -12,17 +12,6 @@ on:
       - "examples/eval_in_wasm/**"
       - ".github/workflows/eval_in_wasm_build_test.yml"
 
-  pull_request:
-    branches: ["**"]
-    paths:
-      - "examples/eval_in_wasm/**"
-      - ".github/workflows/eval_in_wasm_build_test.yml"
-
-# This ensures, that, except for the main branch, only one instance of workflow is executed on a branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/main' && github.ref || github.run_id }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/.github/workflows/hello_popcorn_build_test.yml
+++ b/.github/workflows/hello_popcorn_build_test.yml
@@ -16,21 +16,6 @@ on:
       - "!.github/**"
       - ".github/workflows/hello_popcorn_build_test.yml"
 
-  pull_request:
-    branches: ["**"]
-    paths:
-      - "**"
-      - "!misc/**"
-      - "!examples/**"
-      - "examples/hello_popcorn/**"
-      - "!.github/**"
-      - ".github/workflows/hello_popcorn_build_test.yml"
-
-# This ensures, that, except for the main branch, only one instance of workflow is executed on a branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/main' && github.ref || github.run_id }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/.github/workflows/local_live_view_build.yml
+++ b/.github/workflows/local_live_view_build.yml
@@ -14,19 +14,6 @@ on:
       - "examples/compare_live_views/**"
       - ".github/workflows/local_live_view_build.yml"
 
-  pull_request:
-    branches: ["**"]
-    paths:
-      - "examples/local_live_view/**"
-      - "examples/local_thermostat/**"
-      - "examples/compare_live_views/**"
-      - ".github/workflows/local_live_view_build.yml"
-
-# This ensures, that, except for the main branch, only one instance of workflow is executed on a branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/main' && github.ref || github.run_id }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/.github/workflows/popcorn_build_test.yml
+++ b/.github/workflows/popcorn_build_test.yml
@@ -14,19 +14,6 @@ on:
       - "!misc/**"
       - "!.github/**"
       - ".github/workflows/popcorn_build_test.yml"
-  pull_request:
-    branches: ["**"]
-    paths:
-      - "**"
-      - "!examples/**"
-      - "!misc/**"
-      - "!.github/**"
-      - ".github/workflows/popcorn_build_test.yml"
-
-# This ensures, that, except for the main branch, only one instance of workflow is executed on a branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/main' && github.ref || github.run_id }}
-  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
When updating PRs, we push to branches and it should cover mostly everything.

Fixes #394.