### PR TITLE
Fix module redefinition

### DIFF
--- a/patches/otp/kernel/code.erl
+++ b/patches/otp/kernel/code.erl
@@ -106,10 +106,10 @@ ensure_loaded(_Module) ->
 get_mode() ->
     embedded.
 
-%% Patch reason: there is no code server and code module is implemented differently in AtomVM
-%% eventually the latter should be implemented in AtomVM.
+%% Patch reason: `code_server:is_loaded` in AtomVM returns boolean instead
+%% of `{file, String} | false`. The value of the String is stubbed.
 is_loaded(Module) ->
-    case popcorn_module:which(Module) of
-        File when is_list(File) -> {file, File};
-        _ -> false
+    case code_server:is_loaded(Module) of
+        true -> {file, ""};
+        false -> false
     end.

--- a/test/popcorn/eval_test.exs
+++ b/test/popcorn/eval_test.exs
@@ -199,7 +199,6 @@ defmodule Popcorn.EvalTest do
     |> AtomVM.assert_is_module()
   end
 
-  @tag :skip
   async_test "Module redefinition", %{tmp_dir: dir} do
     info =
       """
@@ -219,11 +218,6 @@ defmodule Popcorn.EvalTest do
       |> AtomVM.try_eval(:elixir, run_dir: dir)
 
     assert %{exit_status: 0, result: {{10, 20}, {20, 30}}} = info
-    # FIXME: Warnings are disabled due to GC problems
-    # logs = File.read!(info.log_path)
-    # assert String.contains?(logs, "warning: {unused_var,c,false}")
-    # assert String.contains?(logs, "warning: {module_defined,'Elixir.RunExpr.W'}")
-    # assert String.contains?(logs, "warning: {unused_var,a,false}")
   end
 
   async_test "Adder Erlang", %{tmp_dir: dir} do


### PR DESCRIPTION
Our `code:is_loaded` patch calls `code:which`, which calls `code:is_loaded`, which leads to infinite recursion. This makes module redefinition hang (in many cases at least).