### PR TITLE
Langtour: Fix navigation not reopening collapsible items when page changes

### DIFF
--- a/misc/language-tour-guide/src/components/navigation/Navigation.tsx
+++ b/misc/language-tour-guide/src/components/navigation/Navigation.tsx
@@ -9,8 +9,12 @@ import { FeedbackButton } from "./FeedbackButton";
 
 import { navigationTree } from "../../utils/content/navigation-builder";
 
-export function Navigation() {
+function CurrentPath() {
   const location = useLocation();
+  return <span className="ml-6 text-sm sm:text-base">{location.pathname}</span>;
+}
+
+export function Navigation() {
   const [isOpen, setIsOpen] = useState(false);
 
   const openMenu = () => {
@@ -30,7 +34,7 @@ export function Navigation() {
         <span className="sr-only">Open menu</span>
         <Hamburger className="h-full w-5.5 text-white" />
       </button>
-      <span className="ml-6 text-sm sm:text-base">{location.pathname}</span>
+      <CurrentPath />
       <FeedbackButton className="hidden lg:block" />
       <ul
         className={`scrollbar bg-light-20 fixed top-16 left-0 z-30 m-0 h-[calc(100%-theme(space.16))] list-none overflow-y-auto px-4 py-3 pr-12 transition-all duration-300 ease-in-out ${

--- a/misc/language-tour-guide/src/components/navigation/NavigationList.tsx
+++ b/misc/language-tour-guide/src/components/navigation/NavigationList.tsx
@@ -1,10 +1,10 @@
-import { NavLink, useMatch } from "react-router";
+import { NavLink, useLocation, useMatch } from "react-router";
 
 import ChevronDown from "../../assets/chevron-down.svg?react";
 import ChevronRight from "../../assets/chevron-right.svg?react";
 import Circle from "../../assets/circle.svg?react";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { NavigationTreeItem } from "../../utils/content/types";
 
 type NavigationListProps = {
@@ -17,7 +17,9 @@ export function NavigationList({ items, onClick }: NavigationListProps) {
       {items.map((item) => {
         const hasChildren = item.children.length > 0;
         if (hasChildren) {
-          return <CollapsibleItem key={item.path} item={item} onClick={onClick} />;
+          return (
+            <CollapsibleItem key={item.path} item={item} onClick={onClick} />
+          );
         }
         return <TopLevelItem key={item.path} item={item} onClick={onClick} />;
       })}
@@ -34,8 +36,18 @@ const baseItemStyle =
   "text-brown-80 flex cursor-pointer items-center rounded-md px-3 py-0.5 text-sm hover:bg-orange-100/10 ";
 
 function CollapsibleItem({ item, onClick }: NavigationItemProps) {
+  const { pathname } = useLocation();
   const onChildPage = useMatch({ path: item.path, end: false }) !== null;
-  const [isOpen, toggleOpen] = useToggle(onChildPage);
+
+  const [isOpen, setIsOpen] = useState(onChildPage);
+
+  const toggleOpen = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  useEffect(() => {
+    setIsOpen(onChildPage);
+  }, [onChildPage, pathname]);
 
   return (
     <li className="my-1">
@@ -111,14 +123,4 @@ function NavigationIcon({ type }: NavigationIconProps) {
       {type === "item" && <Circle className="w-1.5" />}
     </span>
   );
-}
-
-function useToggle(initial: boolean): [boolean, () => void] {
-  const [state, setState] = useState(initial);
-
-  const toggle = useCallback(() => {
-    setState((prev) => !prev);
-  }, [setState]);
-
-  return [state, toggle];
 }


### PR DESCRIPTION
Previously, when navigating between pages, collapsible navigation items would not automatically expand based on the current route.