### PR TITLE
js: disable git checks when releasing

### DIFF
--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -37,5 +37,5 @@ jobs:
           version: 10
 
       - name: Publish to NPM
-        run: pnpm -F popcorn publish --provenance --access public
+        run: pnpm -F popcorn publish --no-git-checks --provenance --access public
         working-directory: ./js


### PR DESCRIPTION
CI checks out code without git info. This isn't really needed since we will be always running release from one branch only and only under specific conditions.