### PR TITLE
js: use npm to publish

### DIFF
--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -37,5 +37,5 @@ jobs:
           version: 10
 
       - name: Publish to NPM
-        run: pnpm -F popcorn publish --no-git-checks --provenance --access public
-        working-directory: ./js
+        run: npm publish swmansion-popcorn-*.tgz --provenance --access public
+        working-directory: ./js/popcorn


### PR DESCRIPTION
pnpm fails with "The requested resource '@swmansion/popcorn@0.2.0-rc.2' could not be found or you do not have permission to access it.". Trying to use `npm` with tarball name directly.