### PR TITLE
js: fix glob expansion on publish

### DIFF
--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -37,5 +37,5 @@ jobs:
           version: 10
 
       - name: Publish to NPM
-        run: npm publish swmansion-popcorn-*.tgz --provenance --access public
+        run: npm publish $(echo swmansion-popcorn-*.tgz) --provenance --access public
         working-directory: ./js/popcorn


### PR DESCRIPTION
Seems like runner took our `*` quite literally. `echo` should work around that.