### PR TITLE
js: use correct dir for tgz package (final v4)

### DIFF
--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -38,5 +38,5 @@ jobs:
 
       - name: Publish to NPM
         run: |
-          npm publish "$(ls output/swmansion-popcorn-*.tgz)" --provenance --access public
-        working-directory: ./js/popcorn
+          npm publish "$(ls swmansion-popcorn-*.tgz)" --provenance --access public
+        working-directory: ./js/popcorn/output


### PR DESCRIPTION
Looks like npm thinks output/pkg.tgz is a remote URL. Lovely.