### PR TITLE
js: add tag when publishing

### DIFF
--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -38,5 +38,5 @@ jobs:
 
       - name: Publish to NPM
         run: |
-          npm publish "$(ls swmansion-popcorn-*.tgz)" --provenance --access public
+          npm publish "$(ls swmansion-popcorn-*.tgz)" --provenance --access public --tag latest
         working-directory: ./js/popcorn/output


### PR DESCRIPTION
npm really wants a tag when trying to make a pre-release.