### PR TITLE
js: fix iframe imports

### DIFF
--- a/js/popcorn/package.json
+++ b/js/popcorn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/popcorn",
-  "version": "0.2.0-rc.3",
+  "version": "0.2.0-rc.4",
   "description": "JS bindings for Popcorn",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
The funny thing with using iframes is that they may have different base url [1]. There's also a bundling process on the end user's project. Combined, this breaks iframe imports pretty badly - iframe isn't processed so it expects script that may not be served and if they even survive bundling, they may live in different directory.

To avoid all that, we prebundle iframe script.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#:~:text=about%3Ablank%20page%20uses%20the-,embedding%20document's%20URL,-as%20its%20base