### PR TITLE
[LocalLiveView] Refactor Phoenix and Local LV communication

### DIFF
--- a/examples/local-lv-compare/.gitignore
+++ b/examples/local-lv-compare/.gitignore
@@ -27,7 +27,6 @@ compare_live_views-*.tar
 
 # Ignore assets that are produced by build tools.
 /priv/static/assets/
-/priv/static/local_live_view/
 
 # Ignore digested assets cache.
 /priv/static/cache_manifest.json

--- a/examples/local-lv-forms/.gitignore
+++ b/examples/local-lv-forms/.gitignore
@@ -27,7 +27,6 @@ form_demo-*.tar
 
 # Ignore assets that are produced by build tools.
 /priv/static/assets/
-/priv/static/local_live_view/
 
 # Ignore digested assets cache.
 /priv/static/cache_manifest.json
@@ -37,4 +36,3 @@ npm-debug.log
 /assets/node_modules/
 
 /assets/vendor/local_live_view
-

--- a/examples/local-lv-forms/assets/js/app.js
+++ b/examples/local-lv-forms/assets/js/app.js
@@ -30,13 +30,9 @@ const Hooks = {};
 Hooks.ServerSendHook = {
   mounted() {
     this.el.addEventListener("serverSend", (e) => {
-      this.pushEvent(
-        e.detail.event_name,
-        { payload: e.detail.payload, view: e.detail.view },
-        (reply) => {
-          console.debug(reply.message);
-        },
-      );
+      this.pushEvent(e.detail.event_name, e.detail.payload, (reply) => {
+        console.debug(reply.message);
+      });
     });
   },
 };

--- a/examples/local-lv-forms/assets/js/app.js
+++ b/examples/local-lv-forms/assets/js/app.js
@@ -31,7 +31,7 @@ Hooks.ServerSendHook = {
   mounted() {
     this.el.addEventListener("serverSend", (e) => {
       this.pushEvent(
-        "llv_local_message",
+        e.detail.event_name,
         { payload: e.detail.payload, view: e.detail.view },
         (reply) => {
           console.debug(reply.message);

--- a/examples/local-lv-forms/lib/form_demo_web.ex
+++ b/examples/local-lv-forms/lib/form_demo_web.ex
@@ -52,6 +52,8 @@ defmodule FormDemoWeb do
     quote do
       use Phoenix.LiveView
 
+      import FormDemoWeb.LocalLiveView
+
       unquote(html_helpers())
     end
   end

--- a/examples/local-lv-forms/lib/form_demo_web/live/form_demo_live.ex
+++ b/examples/local-lv-forms/lib/form_demo_web/live/form_demo_live.ex
@@ -24,18 +24,18 @@ defmodule FormDemoWeb.FormDemoLive do
     {:ok, assign(socket, users: [])}
   end
 
-  def handle_event(
-        "llv_local_message",
-        %{"payload" => %{"type" => "new_user", "user" => user}},
-        socket
-      ) do
+  def handle_event("llv_local_message", %{"payload" => %{"type" => type} = payload}, socket) do
+    handle_local(type, payload, socket)
+  end
+
+  defp handle_local("new_user", %{"user" => user}, socket) do
     new_users = socket.assigns.users ++ [user]
     Application.put_env(FormDemo, :users, new_users)
     socket = push_event(socket, "llv_rerender", %{"view" => "FormDemoLocal"})
     {:noreply, assign(socket, users: new_users)}
   end
 
-  def handle_event("llv_local_message", %{"payload" => %{"type" => "sync_request"}}, socket) do
+  defp handle_local("sync_request", _params, socket) do
     users = Application.get_env(FormDemo, :users, [])
     payload = %{"type" => "synchronize", "users" => users}
 

--- a/examples/local-lv-forms/lib/form_demo_web/live/form_demo_live.ex
+++ b/examples/local-lv-forms/lib/form_demo_web/live/form_demo_live.ex
@@ -1,5 +1,5 @@
 defmodule FormDemoWeb.FormDemoLive do
-  use Phoenix.LiveView
+  use FormDemoWeb, :live_view
 
   def render(assigns) do
     ~H"""
@@ -26,7 +26,7 @@ defmodule FormDemoWeb.FormDemoLive do
 
   def handle_event(
         "new_user",
-        %{"payload" => %{"user" => user}},
+        %{"user" => user},
         socket
       ) do
     new_users = socket.assigns.users ++ [user]

--- a/examples/local-lv-forms/lib/form_demo_web/live/form_demo_live.ex
+++ b/examples/local-lv-forms/lib/form_demo_web/live/form_demo_live.ex
@@ -24,23 +24,23 @@ defmodule FormDemoWeb.FormDemoLive do
     {:ok, assign(socket, users: [])}
   end
 
-  def handle_event("llv_local_message", %{"payload" => %{"type" => type} = payload}, socket) do
-    handle_local(type, payload, socket)
-  end
-
-  defp handle_local("new_user", %{"user" => user}, socket) do
+  def handle_event(
+        "new_user",
+        %{"payload" => %{"user" => user}},
+        socket
+      ) do
     new_users = socket.assigns.users ++ [user]
     Application.put_env(FormDemo, :users, new_users)
     socket = push_event(socket, "llv_rerender", %{"view" => "FormDemoLocal"})
     {:noreply, assign(socket, users: new_users)}
   end
 
-  defp handle_local("sync_request", _params, socket) do
+  def handle_event("sync_request", _, socket) do
     users = Application.get_env(FormDemo, :users, [])
     payload = %{"type" => "synchronize", "users" => users}
 
     socket =
-      push_event(socket, "llv_server_message", %{"view" => "FormDemoLocal", "payload" => payload})
+      push_to_local(socket, "FormDemoLocal", payload)
 
     socket = assign(socket, users: users)
     {:noreply, socket}
@@ -55,7 +55,7 @@ defmodule FormDemoWeb.FormDemoLive do
     payload = %{"type" => "synchronize", "users" => users}
 
     socket =
-      push_event(socket, "llv_server_message", %{"view" => "FormDemoLocal", "payload" => payload})
+      push_to_local(socket, "FormDemoLocal", payload)
 
     assign(socket, users: users)
   end

--- a/examples/local-lv-forms/lib/form_demo_web/local_live_view.ex
+++ b/examples/local-lv-forms/lib/form_demo_web/local_live_view.ex
@@ -1,0 +1,9 @@
+defmodule FormDemoWeb.LocalLiveView do
+  @moduledoc false
+
+  import Phoenix.LiveView, only: [push_event: 3]
+
+  def push_to_local(socket, view, payload) do
+    push_event(socket, "llv_server_message", %{"view" => view, "payload" => payload})
+  end
+end

--- a/examples/local-lv-forms/local/lib/form_demo_local.ex
+++ b/examples/local-lv-forms/local/lib/form_demo_local.ex
@@ -67,11 +67,7 @@ defmodule FormDemoLocal do
     end
   end
 
-  def handle_event(
-        "llv_server_message",
-        %{"type" => "synchronize", "users" => server_users},
-        socket
-      ) do
+  def handle_server("synchronize", %{"users" => server_users}, socket) do
     filtered_users =
       Enum.filter(socket.assigns.users, fn user ->
         case validate_already_existing(user, server_users) do

--- a/examples/local-lv-forms/local/lib/form_demo_local.ex
+++ b/examples/local-lv-forms/local/lib/form_demo_local.ex
@@ -52,7 +52,7 @@ defmodule FormDemoLocal do
     case validate(user_params, users) do
       [] ->
         blank_user = %{"email" => "", "username" => ""}
-        send_to_phoenix(%{"type" => "new_user", "user" => user_params})
+        send_to_phoenix("new_user", %{"user" => user_params})
 
         {:noreply,
          assign(socket,
@@ -72,7 +72,7 @@ defmodule FormDemoLocal do
       Enum.filter(socket.assigns.users, fn user ->
         case validate_already_existing(user, server_users) do
           [] ->
-            send_to_phoenix(%{"type" => "new_user", "user" => user})
+            send_to_phoenix("new_user", %{"user" => user})
             true
 
           _ ->
@@ -90,7 +90,7 @@ defmodule FormDemoLocal do
   end
 
   def handle_info(:sync, socket) do
-    send_to_phoenix(%{"type" => "sync_request"})
+    send_to_phoenix("sync_request", %{})
     {:noreply, socket}
   end
 
@@ -144,7 +144,7 @@ defmodule FormDemoLocal do
     end
   end
 
-  defp send_to_phoenix(message) do
-    LocalLiveView.ServerSocket.send(message, __MODULE__)
+  defp send_to_phoenix(event, payload) do
+    LocalLiveView.ServerSocket.send(event, payload, __MODULE__)
   end
 end

--- a/examples/local-lv-forms/local/lib/form_demo_local.ex
+++ b/examples/local-lv-forms/local/lib/form_demo_local.ex
@@ -67,7 +67,7 @@ defmodule FormDemoLocal do
     end
   end
 
-  def handle_server("synchronize", %{"users" => server_users}, socket) do
+  def handle_server_event("synchronize", %{"users" => server_users}, socket) do
     filtered_users =
       Enum.filter(socket.assigns.users, fn user ->
         case validate_already_existing(user, server_users) do

--- a/examples/local-lv-thermostat/.gitignore
+++ b/examples/local-lv-thermostat/.gitignore
@@ -35,5 +35,4 @@ local_thermostat-*.tar
 npm-debug.log
 /assets/node_modules/
 
-/priv/static/local_live_view/
 /assets/vendor/local_live_view

--- a/local-live-view/.gitignore
+++ b/local-live-view/.gitignore
@@ -34,8 +34,6 @@ config.secret.exs
 # wasm build dir
 /static/wasm/
 
-/static/local_live_view/
-
 /static/assets/
 
 # npm

--- a/local-live-view/lib/local_live_view/local_live_view.ex
+++ b/local-live-view/lib/local_live_view/local_live_view.ex
@@ -34,6 +34,10 @@ defmodule LocalLiveView do
 
       alias LocalLiveView.Message
       use Phoenix.Component, global_prefixes: ~w(pop-)
+
+      def handle_event("llv_server_message", %{"type" => type} = params, socket) do
+        handle_server(type, params, socket)
+      end
     end
   end
 
@@ -93,4 +97,9 @@ defmodule LocalLiveView do
 
   @callback handle_event(event :: binary, unsigned_params(), socket :: Socket.t()) ::
               {:noreply, Socket.t()} | {:reply, map, Socket.t()}
+
+  @callback handle_server(event :: binary, unsigned_params(), socket :: Socket.t()) ::
+              {:noreply, Socket.t()} | {:reply, map, Socket.t()}
+
+  @optional_callbacks handle_server: 3
 end

--- a/local-live-view/lib/local_live_view/local_live_view.ex
+++ b/local-live-view/lib/local_live_view/local_live_view.ex
@@ -1,6 +1,6 @@
 defmodule LocalLiveView do
   @moduledoc ~S'''
-  LocalLiveView is a module that implements functionality of Phoenix.LiveView inside the browser in  
+  LocalLiveView is a module that implements functionality of Phoenix.LiveView inside the browser in
   Popcorn runtime.
   LocalLiveView should be used exactly like its Phoenix equivalent:
   ```
@@ -36,7 +36,7 @@ defmodule LocalLiveView do
       use Phoenix.Component, global_prefixes: ~w(pop-)
 
       def handle_event("llv_server_message", %{"type" => type} = params, socket) do
-        handle_server(type, params, socket)
+        handle_server_event(type, params, socket)
       end
     end
   end

--- a/local-live-view/lib/local_live_view/server_socket.ex
+++ b/local-live-view/lib/local_live_view/server_socket.ex
@@ -3,7 +3,7 @@ defmodule LocalLiveView.ServerSocket do
   #  Module responsible for rendering a local live view in DOM.
 
   @doc false
-  def send(payload, view, attribute \\ "data-pop-view") do
+  def send(event, payload, view, attribute \\ "data-pop-view") do
     view = view |> Module.split() |> List.last()
 
     Popcorn.Wasm.run_js(
@@ -12,11 +12,11 @@ defmodule LocalLiveView.ServerSocket do
         const view_nodes = document.querySelectorAll(`[#{attribute}=${args.view}]`);
         if(view_nodes.length == 1) {
           let view_el = view_nodes[0];
-          view_el.dispatchEvent(new CustomEvent("serverSend", { detail: { payload: args.payload, view: args.view } }));
+          view_el.dispatchEvent(new CustomEvent("serverSend", { detail: { payload: args.payload, view: args.view, event_name: args.event_name } }));
         }
       }
       """,
-      %{payload: payload, view: view}
+      %{payload: payload, view: view, event_name: event}
     )
   end
 end


### PR DESCRIPTION
Added handle_local and handle_server clauses.
task analysis description:
Refactoring a callback handling local-side sync-messages and a callback handling server-side sync-message.
Description: https://github.com/software-mansion/popcorn/pull/440#discussion_r2626496996 and https://github.com/software-mansion/popcorn/pull/440#discussion_r2626457718
Why is it important: This is an improvement that makes the API more user-friendly and improves how end-users interact with local+Phoenix projects.