### PR TITLE
js: replace bundlePath with bundlePaths array (support multi-bundle)

### DIFF
--- a/examples/eval-in-wasm/assets/index.js
+++ b/examples/eval-in-wasm/assets/index.js
@@ -46,7 +46,7 @@ const Elements = {
 async function setup() {
   const popcorn = await Popcorn.init({
     debug: true,
-    bundlePath: "/wasm/bundle.avm",
+    bundlePaths: ["/wasm/bundle.avm"],
     onStdout: (text) => displayLog(text, { isError: false }),
     onStderr: (text) => displayLog(text, { isError: true }),
   });

--- a/examples/game-of-life/assets/index.js
+++ b/examples/game-of-life/assets/index.js
@@ -2,7 +2,7 @@ import { Popcorn } from "@swmansion/popcorn";
 
 const popcorn = await Popcorn.init({
   debug: true,
-  bundlePath: "/wasm/bundle.avm",
+  bundlePaths: ["/wasm/bundle.avm"],
   onStdout: console.log,
   onStderr: console.error,
 });

--- a/examples/hello-popcorn/assets/index.js
+++ b/examples/hello-popcorn/assets/index.js
@@ -1,6 +1,6 @@
 import { Popcorn } from "@swmansion/popcorn";
 
 await Popcorn.init({
-  bundlePath: "/wasm/bundle.avm",
+  bundlePaths: ["/wasm/bundle.avm"],
   onStdout: console.log,
 });

--- a/examples/iex-wasm/assets/index.js
+++ b/examples/iex-wasm/assets/index.js
@@ -30,7 +30,7 @@ async function setup() {
 
   const popcorn = await Popcorn.init({
     debug: true,
-    bundlePath: "/wasm/bundle.avm",
+    bundlePaths: ["/wasm/bundle.avm"],
     onStdout: (text) => displayLog(text, { isError: false }),
     onStderr: (text) => displayLog(text, { isError: true }),
   });

--- a/examples/local-lv-compare/assets/js/app.js
+++ b/examples/local-lv-compare/assets/js/app.js
@@ -39,7 +39,7 @@ window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 
 // setup local live views, which will override the default pushWithReply and join functions of the live view to instead call popcorn
 import { setup } from "local_live_view"
-setup(liveSocket, { Socket, bundlePath: "bundle.avm" });
+setup(liveSocket, { Socket, bundlePaths: ["bundle.avm"] });
 
 // connect if there are any LiveViews on the page
 liveSocket.connect()

--- a/examples/local-lv-forms/assets/js/app.js
+++ b/examples/local-lv-forms/assets/js/app.js
@@ -46,7 +46,7 @@ liveSocket.connect();
 
 // setup local live views, which will override the default pushWithReply and join functions of the live view to instead call popcorn
 import { setup } from "local_live_view";
-setup(liveSocket, { Socket, bundlePath: "bundle.avm" });
+setup(liveSocket, { Socket, bundlePaths: ["bundle.avm"] });
 
 // expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()

--- a/examples/local-lv-thermostat/assets/js/app.js
+++ b/examples/local-lv-thermostat/assets/js/app.js
@@ -39,7 +39,7 @@ window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 
 // setup local live views, which will override the default pushWithReply and join functions of the live view to instead call popcorn
 import { setup } from "local_live_view"
-setup(liveSocket, { Socket, bundlePath: "bundle.avm" });
+setup(liveSocket, { Socket, bundlePaths: ["bundle.avm"] });
 
 // connect if there are any LiveViews on the page
 liveSocket.connect()

--- a/landing-page/src/components/LiveDemo.astro
+++ b/landing-page/src/components/LiveDemo.astro
@@ -101,7 +101,7 @@ const exampleButtonClass =
     window.terminal = term;
 
     const POPCORN_CONFIG = {
-      bundlePath: "/wasm/iex.avm",
+      bundlePaths: ["/wasm/iex.avm"],
       debug: true,
       onStdout: (text: string) => displayLog(text, { term, isError: false }),
       onStderr: (text: string) => displayLog(text, { term, isError: true }),

--- a/landing-page/src/pages/demos/eval.astro
+++ b/landing-page/src/pages/demos/eval.astro
@@ -133,7 +133,7 @@ end"
   async function setup() {
     try {
       popcorn = await Popcorn.init({
-        bundlePath: "/wasm/eval.avm",
+        bundlePaths: ["/wasm/eval.avm"],
         debug: true,
         onStdout: (text) => displayLog(text, { isError: false }),
         onStderr: (text) => displayLog(text, { isError: true }),

--- a/landing-page/src/pages/demos/game-of-life.astro
+++ b/landing-page/src/pages/demos/game-of-life.astro
@@ -139,7 +139,7 @@ import Section from "../../components/Section.astro";
   async function init() {
     try {
       await Popcorn.init({
-        bundlePath: "/wasm/gol.avm",
+        bundlePaths: ["/wasm/gol.avm"],
         debug: false,
         onStdout: (text: string) => console.log(text),
         onStderr: (text: string) => console.error(text),

--- a/landing-page/src/pages/demos/local-forms.astro
+++ b/landing-page/src/pages/demos/local-forms.astro
@@ -259,7 +259,7 @@ end
 
     await setup(liveSocket, {
       Socket,
-      bundlePath: "/wasm/local_forms.avm",
+      bundlePaths: ["/wasm/local_forms.avm"],
     });
 
     liveSocket.connect();

--- a/landing-page/src/pages/demos/local-thermostat.astro
+++ b/landing-page/src/pages/demos/local-thermostat.astro
@@ -141,7 +141,7 @@ end
 
     await setup(liveSocket, {
       Socket,
-      bundlePath: "/wasm/local_thermostat.avm",
+      bundlePaths: ["/wasm/local_thermostat.avm"],
     });
 
     liveSocket.connect();

--- a/local-live-view/assets/local_live_view.js
+++ b/local-live-view/assets/local_live_view.js
@@ -19,7 +19,7 @@ export async function setup(liveSocket, opts = {}) {
 
   popcorn = await Popcorn.init({
     debug: opts.debug ?? false,
-    bundlePath: opts.bundlePath ?? "wasm/bundle.avm",
+    bundlePaths: opts.bundlePaths ?? ["wasm/bundle.avm"],
   });
   window.__popcorn = popcorn;
 

--- a/popcorn/elixir/lib/mix/tasks/popcorn.gen.js.ex
+++ b/popcorn/elixir/lib/mix/tasks/popcorn.gen.js.ex
@@ -65,7 +65,7 @@ defmodule Mix.Tasks.Popcorn.Gen.Js do
   embed_text(:index_js, """
   import { Popcorn } from "@swmansion/popcorn";
 
-  await Popcorn.init({ bundlePath: "/wasm/bundle.avm", onStdout: console.log });
+  await Popcorn.init({ bundlePaths: ["/wasm/bundle.avm"], onStdout: console.log });
   """)
 
   embed_text(:index_html, """

--- a/popcorn/elixir/pages/getting_started/first_steps.md
+++ b/popcorn/elixir/pages/getting_started/first_steps.md
@@ -101,10 +101,10 @@ The generated `index.js` looks like this:
 // assets/index.js
 import { Popcorn } from "@swmansion/popcorn";
 
-await Popcorn.init({ bundlePath: "/wasm/bundle.avm", onStdout: console.log });
+await Popcorn.init({ bundlePaths: ["/wasm/bundle.avm"], onStdout: console.log });
 ```
 
-`bundlePath` tells Popcorn where to find the compiled Elixir bytecode, matching the `out_dir` you configured earlier. `onStdout` receives anything your Elixir code prints with `IO.puts/1`.
+`bundlePaths` tells Popcorn where to find the compiled Elixir bytecode, matching the `out_dir` you configured earlier. `onStdout` receives anything your Elixir code prints with `IO.puts/1`.
 
 Install the npm dependencies and build:
 

--- a/popcorn/elixir/test/fixtures/wasm/assets/index.js
+++ b/popcorn/elixir/test/fixtures/wasm/assets/index.js
@@ -7,7 +7,7 @@ window.createPopcornInstance = async function (bundlePath) {
   const logs = [];
 
   const popcorn = await Popcorn.init({
-    bundlePath,
+    bundlePaths: [bundlePath],
     onStdout: (output) => logs.push(`[popcorn stdout] ${output}\n`),
   });
 

--- a/popcorn/js/package.json
+++ b/popcorn/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/popcorn",
-  "version": "0.3.0-rc1",
+  "version": "0.3.0-rc2",
   "description": "JS bindings for Popcorn",
   "type": "module",
   "license": "Apache-2.0",

--- a/popcorn/js/src/iframe.ts
+++ b/popcorn/js/src/iframe.ts
@@ -52,23 +52,17 @@ declare const globalThis: { TrackedValue: typeof TrackedValue };
 globalThis.TrackedValue = TrackedValue;
 
 export async function initVm(): Promise<void> {
-  const bundlePaths: string[] = [];
-  for (let i = 0; ; i++) {
-    const metaElement = document.querySelector(
-      `meta[name="bundle-path-${i}"]`,
-    ) as HTMLMetaElement | null;
-    if (!metaElement) break;
-    bundlePaths.push(metaElement.content);
-  }
-  if (bundlePaths.length === 0) {
-    throw new Error("Missing meta[name='bundle-path-0'] element");
-  }
+  const bundlePaths = Array.from(
+    document.querySelectorAll<HTMLMetaElement>('meta[name^="bundle-path-"]'),
+    (el) => el.content,
+  );
+
   const bundles = await Promise.all(
-    bundlePaths.map((p) =>
-      fetch(p)
-        .then((resp) => resp.arrayBuffer())
-        .then((buf) => new Int8Array(buf)),
-    ),
+    bundlePaths.map(async (p) => {
+      const resp = await fetch(p);
+      const buf = await resp.arrayBuffer();
+      return new Int8Array(buf);
+    }),
   );
 
   await startVm(bundles);

--- a/popcorn/js/src/iframe.ts
+++ b/popcorn/js/src/iframe.ts
@@ -52,18 +52,26 @@ declare const globalThis: { TrackedValue: typeof TrackedValue };
 globalThis.TrackedValue = TrackedValue;
 
 export async function initVm(): Promise<void> {
-  const metaElement = document.querySelector(
-    'meta[name="bundle-path"]',
-  ) as HTMLMetaElement | null;
-  if (!metaElement) {
-    throw new Error("Missing meta[name='bundle-path'] element");
+  const bundlePaths: string[] = [];
+  for (let i = 0; ; i++) {
+    const metaElement = document.querySelector(
+      `meta[name="bundle-path-${i}"]`,
+    ) as HTMLMetaElement | null;
+    if (!metaElement) break;
+    bundlePaths.push(metaElement.content);
   }
-  const bundlePath = metaElement.content;
-  const bundleBuffer = await fetch(bundlePath).then((resp) =>
-    resp.arrayBuffer(),
+  if (bundlePaths.length === 0) {
+    throw new Error("Missing meta[name='bundle-path-0'] element");
+  }
+  const bundles = await Promise.all(
+    bundlePaths.map((p) =>
+      fetch(p)
+        .then((resp) => resp.arrayBuffer())
+        .then((buf) => new Int8Array(buf)),
+    ),
   );
-  const bundle = new Int8Array(bundleBuffer);
-  await startVm(bundle);
+
+  await startVm(bundles);
 
   window.addEventListener(
     "message",
@@ -84,15 +92,18 @@ export async function initVm(): Promise<void> {
   );
 }
 
-async function startVm(avmBundle: Int8Array): Promise<void> {
+async function startVm(avmBundles: Int8Array[]): Promise<void> {
+  const bundleFilePaths = avmBundles.map((_, i) => `/data/bundle-${i}.avm`);
   const moduleInstance: AtomVMModule = await init({
     preRun: [
       function ({ FS }: { FS: EmscriptenFS }) {
         FS.mkdir("/data");
-        FS.writeFile("/data/bundle.avm", avmBundle);
+        avmBundles.forEach((bundle, i) => {
+          FS.writeFile(bundleFilePaths[i], bundle);
+        });
       },
     ],
-    arguments: ["/data/bundle.avm"],
+    arguments: bundleFilePaths,
     print(text: string) {
       sendIframeResponse(MESSAGES.STDOUT, text);
     },

--- a/popcorn/js/src/popcorn.ts
+++ b/popcorn/js/src/popcorn.ts
@@ -134,7 +134,7 @@ export class Popcorn {
 
     this.bridgeConfig = {
       container: params.container,
-      script: { url: IFRAME_URL, entrypoint: "runIFrame" },
+      script: { url: IFRAME_URL, entrypoint: "initVm" },
       config: Object.fromEntries(
         this.bundleURLs.map((url, i) => [`bundle-path-${i}`, url]),
       ),
@@ -163,9 +163,10 @@ export class Popcorn {
     const { container, ...constructorParams } = options;
     const containerWithDefault = container ?? document.documentElement;
 
-    const bundlePaths = constructorParams.bundlePaths
-      ? constructorParams.bundlePaths
-      : [await resolveBundleURL("/bundle.avm", "/assets/bundle.avm")];
+    const bundlePaths =
+      constructorParams.bundlePaths && constructorParams.bundlePaths.length > 0
+        ? constructorParams.bundlePaths
+        : [await resolveBundleURL("/bundle.avm", "/assets/bundle.avm")];
 
     const popcorn = new Popcorn(
       { ...constructorParams, bundlePaths, container: containerWithDefault },

--- a/popcorn/js/src/popcorn.ts
+++ b/popcorn/js/src/popcorn.ts
@@ -25,8 +25,8 @@ export type { PopcornErrorCode, PopcornInternalErrorCode };
 export type PopcornInitOptions = {
   /** DOM element to mount an iframe */
   container?: HTMLElement;
-  /** Path to compiled Elixir bundle (`.avm` file). */
-  bundlePath?: string;
+  /** Paths to compiled Elixir bundles (`.avm` files). */
+  bundlePaths?: string[];
   /** Handler for stderr messages. */
   onStderr?: (message: string) => void;
   /** Handler for stdout messages. */
@@ -104,7 +104,7 @@ export class Popcorn {
   private bridge: IframeBridge | null = null;
   private bridgeConfig: IframeBridgeArgs;
   private debug = false;
-  private bundleURL: string;
+  private bundleURLs: string[];
   private state: State = { status: "uninitialized" };
   private defaultReceiver: string | null = null;
 
@@ -126,17 +126,18 @@ export class Popcorn {
   ) {
     if (token !== INIT_TOKEN) throwError({ t: "private_constructor" });
 
-    const bundlePath = params.bundlePath ?? "/bundle.avm";
-    const bundleURL = new URL(bundlePath, import.meta.url);
+    const bundlePaths = params.bundlePaths ?? ["/bundle.avm"];
+    this.bundleURLs = bundlePaths.map((p) => new URL(p, import.meta.url).href);
 
     this.onReloadCallback = params.onReload ?? noop;
     this.debug = params.debug ?? false;
-    this.bundleURL = bundleURL.href;
 
     this.bridgeConfig = {
       container: params.container,
-      script: { url: IFRAME_URL, entrypoint: "initVm" },
-      config: { "bundle-path": this.bundleURL },
+      script: { url: IFRAME_URL, entrypoint: "runIFrame" },
+      config: Object.fromEntries(
+        this.bundleURLs.map((url, i) => [`bundle-path-${i}`, url]),
+      ),
       debug: true,
       onMessage: this.iframeHandler.bind(this),
     };
@@ -162,12 +163,12 @@ export class Popcorn {
     const { container, ...constructorParams } = options;
     const containerWithDefault = container ?? document.documentElement;
 
-    const bundlePath = constructorParams.bundlePath
-      ? constructorParams.bundlePath
-      : await resolveBundleURL("/bundle.avm", "/assets/bundle.avm");
+    const bundlePaths = constructorParams.bundlePaths
+      ? constructorParams.bundlePaths
+      : [await resolveBundleURL("/bundle.avm", "/assets/bundle.avm")];
 
     const popcorn = new Popcorn(
-      { ...constructorParams, bundlePath, container: containerWithDefault },
+      { ...constructorParams, bundlePaths, container: containerWithDefault },
       INIT_TOKEN,
     );
     popcorn.trace("Main: init, params: ", { container, ...constructorParams });


### PR DESCRIPTION
Add support for loading multiple .avm bundles in the Popcorn class. The `bundlePath` option is replaced by `bundlePaths: string[]`. Each bundle is served via a numbered meta tag (bundle-path-0, bundle-path-1, ...)