### PR TITLE
otp: refactor error handling

### DIFF
--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-import type { Popcorn } from "@swmansion/popcorn-otp";
+import type { Popcorn, SerializedError } from "@swmansion/popcorn-otp";
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -12,11 +12,7 @@ type InitSnapshot =
   | { ok: true }
   | {
       ok: false;
-      error: {
-        kind: string;
-        message: string;
-        metadata: Record<string, unknown>;
-      };
+      error: SerializedError;
     };
 
 test.beforeEach(async ({ page }) => {
@@ -34,12 +30,15 @@ test("boots with the packaged OTP assets through Popcorn.init", async ({
 
 test("reports a missing boot script through Popcorn.init", async ({ page }) => {
   const result = await initPopcorn(page, "/otp-assets/missing");
-
   expect(result.ok).toBe(false);
-  check(!result.ok);
-  expect(result.error.kind).toBe("boot-failed");
-  expect(result.error.metadata.reason).toBe("missing-boot-script");
-  expect(result.error.metadata.url).toBe("/otp-assets/missing/bin/vm.boot");
+  if (result.ok) {
+    throw new Error("expected Popcorn.init to fail");
+  }
+
+  expect(result.error).toEqual({
+    t: "worker:load",
+    message: "bad-fs",
+  });
 });
 
 async function initPopcorn(
@@ -51,21 +50,10 @@ async function initPopcorn(
       beam: { assetsUrl: beamAssetsUrl },
     });
     if (!result.ok) {
-      return {
-        ok: false,
-        error: {
-          kind: result.error.kind,
-          message: result.error.message,
-          metadata: result.error.metadata,
-        },
-      };
+      return { ok: false, error: result.error.serialize() };
     }
 
     result.popcorn.deinit();
     return { ok: true };
   }, assetsUrl);
-}
-
-function check(ok: boolean): asserts ok {
-  if (!ok) throw new Error("assert");
 }

--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect, type Page } from "@playwright/test";
-import type { Popcorn, SerializedError } from "@swmansion/popcorn-otp";
+import type {
+  Popcorn,
+  SerializedError,
+} from "@swmansion/popcorn-otp";
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -9,11 +12,8 @@ declare global {
 }
 
 type InitSnapshot =
-  | { ok: true }
-  | {
-      ok: false;
-      error: SerializedError;
-    };
+  | { ok: true; data: null }
+  | { ok: false; error: SerializedError };
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/");
@@ -25,35 +25,65 @@ test("boots with the packaged OTP assets through Popcorn.init", async ({
 }) => {
   const result = await initPopcorn(page, "/otp-assets");
 
-  expect(result.ok).toBe(true);
+  expect(result).toEqual({ ok: true, data: null });
 });
 
-test("reports a missing boot script through Popcorn.init", async ({ page }) => {
-  const result = await initPopcorn(page, "/otp-assets/missing");
-  expect(result.ok).toBe(false);
-  if (result.ok) {
-    throw new Error("expected Popcorn.init to fail");
-  }
+test("returns timeout:init through Popcorn.init", async ({ page }) => {
+  const result = await initPopcorn(page, "/otp-assets", 1);
+  expect(result).toEqual({
+    ok: false,
+    error: {
+      t: "timeout:init",
+      data: {
+        timeoutMs: 1,
+      },
+    },
+  });
+});
 
-  expect(result.error).toEqual({
-    t: "worker:load",
-    message: "bad-fs",
+test("returns beam:missing-boot-script through Popcorn.init for setup failures", async ({
+  page,
+}) => {
+  const result = await initPopcorn(page, "/otp-assets/missing");
+  expect(result).toEqual({
+    ok: false,
+    error: {
+      t: "beam:missing-boot-script",
+      data: {
+        url: "/otp-assets/missing/bin/vm.boot",
+      },
+    },
   });
 });
 
 async function initPopcorn(
   page: Page,
   assetsUrl: string,
+  bootTimeoutMs?: number,
 ): Promise<InitSnapshot> {
-  return await page.evaluate(async (beamAssetsUrl): Promise<InitSnapshot> => {
-    const result = await window.Popcorn.init({
-      beam: { assetsUrl: beamAssetsUrl },
-    });
-    if (!result.ok) {
-      return { ok: false, error: result.error.serialize() };
-    }
+  return await page.evaluate(
+    async ({
+      beamAssetsUrl,
+      initTimeoutMs,
+    }: {
+      beamAssetsUrl: string;
+      initTimeoutMs?: number;
+    }): Promise<InitSnapshot> => {
+      const result = await window.Popcorn.init({
+        beam: { assetsUrl: beamAssetsUrl },
+        timeoutsMs:
+          initTimeoutMs === undefined ? undefined : { boot: initTimeoutMs },
+      });
+      if (!result.ok) {
+        return { ok: false, error: result.error.serialize() };
+      }
 
-    result.popcorn.deinit();
-    return { ok: true };
-  }, assetsUrl);
+      result.data.deinit();
+      return { ok: true, data: null };
+    },
+    {
+      beamAssetsUrl: assetsUrl,
+      initTimeoutMs: bootTimeoutMs,
+    },
+  );
 }

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -1,7 +1,8 @@
-import { PopcornError, type AnyPopcornError } from "./errors";
+import { PopcornError, err, isErr, type Result } from "./errors";
 import { extractTar } from "./tar";
 import type { BeamBootOptions, EmscriptenModule } from "./types";
 import {
+  check,
   decompressGzip,
   dirname,
   ensureDir,
@@ -31,18 +32,14 @@ const BASE_ARGS = [
 // must be present to load vm
 const CORE_APPS = ["kernel", "stdlib", "compiler"];
 
-type BootRet =
-  | { ok: true; module: EmscriptenModule }
-  | { ok: false; error: AnyPopcornError };
-
 export async function boot({
   assetsUrl,
   searchPaths,
   extraArgs,
   createModule,
   emit,
-}: BeamBootOptions): Promise<BootRet> {
-  let initError: AnyPopcornError | null = null;
+}: BeamBootOptions): Promise<Result<EmscriptenModule>> {
+  let initError: PopcornError | null = null;
 
   const moduleConfig: Partial<EmscriptenModule> = {
     print: (text) => emit({ type: "otp:stdout", payload: text }),
@@ -66,16 +63,9 @@ export async function boot({
           try {
             await initFs({ module: mod, assetsUrl });
           } catch (error) {
-            // TODO: make it better
-            const err = new PopcornError({
-              t: "worker:load",
-              message: "bad-fs",
-            });
-            initError = err;
-            emit({
-              type: "otp:abort",
-              payload: err.message,
-            });
+            check(error instanceof PopcornError);
+            initError = error;
+            emit({ type: "otp:abort", payload: error.message });
           } finally {
             mod.removeRunDependency("fs");
           }
@@ -83,9 +73,15 @@ export async function boot({
       },
     ],
   };
-  const module = await createModule(moduleConfig);
-  if (initError) return { ok: false, error: initError };
-  return { ok: true, module };
+
+  try {
+    const module = await createModule(moduleConfig);
+    if (initError !== null) return { ok: false, error: initError };
+    return { ok: true, data: module };
+  } catch (error) {
+    check(isErr(error));
+    return { ok: false, error };
+  }
 }
 
 type BuildArgsArgs = {
@@ -137,15 +133,16 @@ async function initFs({ module, assetsUrl }: InitFsArgs): Promise<void> {
   const BOOT_URL = `${assetsUrl}${BOOT_PATH}`;
   const bootFile = await fetchBinary(BOOT_URL);
   if (bootFile === null) {
-    throw new PopcornError({ t: "beam:missing-boot-script", url: BOOT_URL });
+    throw err("beam:missing-boot-script", { url: BOOT_URL });
   }
+
   module.FS.writeFile(BOOT_PATH, bootFile);
 
   // tarballs.json
   const MANIFEST_URL = `${assetsUrl}${MANIFEST_PATH}`;
   const manifest = await fetchJson<TarballManifest>(MANIFEST_URL);
   if (manifest === null) {
-    throw new PopcornError({ t: "beam:missing-manifest", url: MANIFEST_URL });
+    throw err("beam:missing-manifest", { url: MANIFEST_URL });
   }
 
   const createDir = (dirPath: string) => {
@@ -156,31 +153,28 @@ async function initFs({ module, assetsUrl }: InitFsArgs): Promise<void> {
     module.FS.writeFile(path, content);
   };
 
-  await Promise.all(
+  const tarballs = await Promise.all(
     CORE_APPS.map(async (name) => {
       const entry = manifest[name] ?? null;
       if (entry === null) {
-        throw new PopcornError({
-          t: "beam:missing-tarball",
-          name,
-          availableTarballs: tarballNames(manifest),
-        });
+        throw err("beam:missing-tarball", { name, all: getTarballs(manifest) });
       }
+
       const tar = await fetchBinary(`${assetsUrl}${entry.tar}`);
       if (tar === null) {
-        throw new PopcornError({
-          t: "beam:missing-tarball",
-          name,
-          availableTarballs: tarballNames(manifest),
-        });
+        throw err("beam:missing-tarball", { name, all: getTarballs(manifest) });
       }
-      const extractedTar = await maybeDecompressTar(tar);
-      extractTar(extractedTar, createDir, createFile);
+
+      return maybeDecompressTar(tar);
     }),
   );
+
+  for (const tarball of tarballs) {
+    extractTar(tarball, createDir, createFile);
+  }
 }
 
-function tarballNames(manifest: TarballManifest): string[] {
+function getTarballs(manifest: TarballManifest): string[] {
   return Object.keys(manifest).filter((name) => name !== "version");
 }
 

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -1,4 +1,4 @@
-import { buildPopcornError, toPopcornError, type PopcornError } from "./errors";
+import { PopcornError, type AnyPopcornError } from "./errors";
 import { extractTar } from "./tar";
 import type { BeamBootOptions, EmscriptenModule } from "./types";
 import {
@@ -33,7 +33,7 @@ const CORE_APPS = ["kernel", "stdlib", "compiler"];
 
 type BootRet =
   | { ok: true; module: EmscriptenModule }
-  | { ok: false; error: PopcornError };
+  | { ok: false; error: AnyPopcornError };
 
 export async function boot({
   assetsUrl,
@@ -42,7 +42,7 @@ export async function boot({
   createModule,
   emit,
 }: BeamBootOptions): Promise<BootRet> {
-  let initError: PopcornError | null = null;
+  let initError: AnyPopcornError | null = null;
 
   const moduleConfig: Partial<EmscriptenModule> = {
     print: (text) => emit({ type: "otp:stdout", payload: text }),
@@ -66,8 +66,16 @@ export async function boot({
           try {
             await initFs({ module: mod, assetsUrl });
           } catch (error) {
-            initError = toPopcornError(error, { t: "internal-boot-failure" });
-            emit({ type: "otp:abort", payload: initError.message });
+            // TODO: make it better
+            const err = new PopcornError({
+              t: "worker:load",
+              message: "bad-fs",
+            });
+            initError = err;
+            emit({
+              type: "otp:abort",
+              payload: err.message,
+            });
           } finally {
             mod.removeRunDependency("fs");
           }
@@ -129,7 +137,7 @@ async function initFs({ module, assetsUrl }: InitFsArgs): Promise<void> {
   const BOOT_URL = `${assetsUrl}${BOOT_PATH}`;
   const bootFile = await fetchBinary(BOOT_URL);
   if (bootFile === null) {
-    throw buildPopcornError({ t: "missing-boot-script", url: BOOT_URL });
+    throw new PopcornError({ t: "beam:missing-boot-script", url: BOOT_URL });
   }
   module.FS.writeFile(BOOT_PATH, bootFile);
 
@@ -137,7 +145,7 @@ async function initFs({ module, assetsUrl }: InitFsArgs): Promise<void> {
   const MANIFEST_URL = `${assetsUrl}${MANIFEST_PATH}`;
   const manifest = await fetchJson<TarballManifest>(MANIFEST_URL);
   if (manifest === null) {
-    throw buildPopcornError({ t: "missing-manifest", url: MANIFEST_URL });
+    throw new PopcornError({ t: "beam:missing-manifest", url: MANIFEST_URL });
   }
 
   const createDir = (dirPath: string) => {
@@ -152,16 +160,16 @@ async function initFs({ module, assetsUrl }: InitFsArgs): Promise<void> {
     CORE_APPS.map(async (name) => {
       const entry = manifest[name] ?? null;
       if (entry === null) {
-        throw buildPopcornError({
-          t: "missing-tarball",
+        throw new PopcornError({
+          t: "beam:missing-tarball",
           name,
           availableTarballs: tarballNames(manifest),
         });
       }
       const tar = await fetchBinary(`${assetsUrl}${entry.tar}`);
       if (tar === null) {
-        throw buildPopcornError({
-          t: "missing-tarball",
+        throw new PopcornError({
+          t: "beam:missing-tarball",
           name,
           availableTarballs: tarballNames(manifest),
         });

--- a/otp/js/src/errors.ts
+++ b/otp/js/src/errors.ts
@@ -1,145 +1,178 @@
-export type PopcornErrors =
-  | { t: "internal:check"; detail?: string }
-  | { t: "internal:unreachable" }
-  | { t: "timeout:boot"; timeoutMs: number }
-  | { t: "worker:load"; message: string }
-  | { t: "beam:missing-boot-script"; url: string }
-  | { t: "beam:missing-manifest"; url: string }
-  | { t: "beam:missing-tarball"; name: string; availableTarballs: string[] };
+export type Result<T, E extends Tag = Tag> =
+  | { ok: true; data: T }
+  | { ok: false; error: PopcornError<E> };
 
-export type ErrorType = PopcornErrors["t"];
-export type ErrorPayloadFor<T extends ErrorType = ErrorType> = Omit<
-  Extract<PopcornErrors, { t: T }>,
-  "t"
->;
-export type ErrorPayload = {
-  [T in ErrorType]: ErrorPayloadFor<T>;
-}[ErrorType];
-export type SerializedError<T extends ErrorType = ErrorType> = Extract<
-  PopcornErrors,
-  { t: T }
->;
+type Tag = keyof PopcornErrors;
+export type PopcornErrors = {
+  "timeout:init": { timeoutMs: number };
+  "worker:load": { message: string };
+  "bridge:not-started": EmptyData;
+  "beam:missing-boot-script": { url: string };
+  "beam:missing-manifest": { url: string };
+  "beam:missing-tarball": { name: string; all: string[] };
+  "internal:check": { detail?: string };
+  "internal:unreachable": EmptyData;
+};
 
-export type AnyPopcornError = PopcornError<any>;
+export type SerializedError<T extends Tag = Tag> = {
+  [K in T]: { t: K; data: PopcornErrors[K] };
+}[T];
 
-export class PopcornError<T extends ErrorType = ErrorType> extends Error {
-  declare readonly cause: SerializedError;
-  readonly #serialized: SerializedError<T>;
+type EmptyData = Record<never, never>;
+
+export function err<T extends Tag>(
+  t: T,
+  data: PopcornErrors[T],
+): PopcornError<T> {
+  return new PopcornError({ t, data });
+}
+
+export function isErr<T extends Tag = Tag>(
+  error: unknown,
+  t?: T,
+): error is PopcornError<T> {
+  const isInstance = error instanceof PopcornError;
+  if (!isInstance) return false;
+  if (t === undefined) return true;
+  if (error.t === t) return true;
+  return false;
+}
+
+export class PopcornError<T extends Tag = Tag> extends Error {
+  declare readonly cause: SerializedError<T>;
+  private readonly serialized: SerializedError<T>;
 
   constructor(cause: SerializedError<T>) {
     super(message(cause), { cause });
     this.name = "PopcornError";
     Object.setPrototypeOf(this, new.target.prototype);
-    this.#serialized = cause;
+    this.serialized = cause;
   }
 
   public get t(): T {
-    return this.#serialized.t;
+    return this.serialized.t;
   }
 
-  public get payload(): ErrorPayloadFor<T> {
-    const { t: _t, ...payload } = this.#serialized;
-    return payload as ErrorPayloadFor<T>;
+  public get data(): PopcornErrors[T] {
+    return this.serialized.data;
   }
 
   public serialize(): SerializedError<T> {
-    return { ...this.#serialized };
+    return {
+      t: this.serialized.t,
+      data: { ...this.serialized.data },
+    };
   }
 
   public static deserialize(value: unknown): PopcornError {
     return new PopcornError(parse(value));
   }
-
-  public static fromUnknown<T extends ErrorType>(
-    error: unknown,
-    fallback: SerializedError<T>,
-  ): PopcornError<T> {
-    return error instanceof PopcornError ? error : new PopcornError(fallback);
-  }
 }
 
+function message<T extends Tag>(error: SerializedError<T>): string;
 function message(error: SerializedError): string {
   switch (error.t) {
+    case "timeout:init":
+      return `Init timed out after ${error.data.timeoutMs}ms`;
+    case "worker:load":
+      return error.data.message;
+    case "bridge:not-started":
+      return "Bridge did not start";
+    case "beam:missing-boot-script":
+      return `Missing boot script: '${error.data.url}'`;
+    case "beam:missing-manifest":
+      return `Missing tarball manifest: '${error.data.url}'`;
+    case "beam:missing-tarball":
+      return `Missing tarball: '${error.data.name}'. Available tarballs: ${error.data.all.join(", ")}`;
     case "internal:check":
-      return error.detail === undefined
+      return error.data.detail === undefined
         ? "Check failed"
-        : `Check failed: ${error.detail}`;
+        : `Check failed: ${error.data.detail}`;
     case "internal:unreachable":
       return "Entered unreachable code";
-    case "timeout:boot":
-      return `Boot timed out after ${error.timeoutMs}ms`;
-    case "worker:load":
-      return error.message;
-    case "beam:missing-boot-script":
-      return `Missing boot script: '${error.url}'`;
-    case "beam:missing-manifest":
-      return `Missing tarball manifest: '${error.url}'`;
-    case "beam:missing-tarball":
-      return `Missing tarball: '${error.name}'. Available tarballs: ${error.availableTarballs.join(", ")}`;
-    default: {
-      unreachable();
-    }
+    default:
+      return unreachable();
   }
 }
 
 function parse(value: unknown): SerializedError {
-  const data = objectWithKeys(value, ["t"]);
-  check(data !== null);
-
-  switch (data.t) {
-    case "internal:check":
-      if (objectWithKeys(value, ["t"]) !== null) {
-        return value as SerializedError<"internal:check">;
-      }
-      break;
-    case "internal:unreachable":
-      if (objectWithKeys(value, ["t"]) !== null) {
-        return value as SerializedError<typeof data.t>;
-      }
-      break;
-    case "timeout:boot":
-      if (objectWithKeys(value, ["t", "timeoutMs"]) !== null) {
-        return value as SerializedError<"timeout:boot">;
-      }
-      break;
+  check(objectWithKeys(value, ["t", "data"]));
+  switch (value.t) {
+    case "timeout:init":
+      check(isTimeoutInitData(value.data));
+      return { t: value.t, data: value.data };
     case "worker:load":
-      if (objectWithKeys(value, ["t", "message"]) !== null) {
-        return value as SerializedError<"worker:load">;
-      }
-      break;
+      check(isWorkerLoadData(value.data));
+      return { t: value.t, data: value.data };
+    case "bridge:not-started":
+      check(isEmptyData(value.data));
+      return { t: value.t, data: value.data };
     case "beam:missing-boot-script":
     case "beam:missing-manifest":
-      if (objectWithKeys(value, ["t", "url"]) !== null) {
-        return value as
-          | SerializedError<"beam:missing-boot-script">
-          | SerializedError<"beam:missing-manifest">;
-      }
-      break;
+      check(isUrlData(value.data));
+      return { t: value.t, data: value.data };
     case "beam:missing-tarball":
-      if (objectWithKeys(value, ["t", "name", "availableTarballs"]) !== null) {
-        return value as SerializedError<"beam:missing-tarball">;
-      }
-      break;
+      check(isMissingTarballData(value.data));
+      return { t: value.t, data: value.data };
+    case "internal:check":
+      check(isInternalCheckData(value.data));
+      return { t: value.t, data: value.data };
+    case "internal:unreachable":
+      check(isEmptyData(value.data));
+      return { t: value.t, data: value.data };
+    default:
+      return unreachable();
   }
-  unreachable();
 }
 
-// We don't want to create a cycle with utils (which use PopcornError internally).
-function unreachable(): never {
-  throw new PopcornError({ t: "internal:unreachable" });
+function isTimeoutInitData(
+  value: unknown,
+): value is PopcornErrors["timeout:init"] {
+  return objectWithKeys(value, ["timeoutMs"]) !== null;
 }
 
-export function check(ok: boolean, msg?: string): asserts ok {
-  if (!ok) throw new PopcornError({ t: "internal:check", detail: msg });
+function isWorkerLoadData(
+  value: unknown,
+): value is PopcornErrors["worker:load"] {
+  return objectWithKeys(value, ["message"]) !== null;
+}
+
+function isUrlData(
+  value: unknown,
+): value is PopcornErrors["beam:missing-boot-script"] {
+  return objectWithKeys(value, ["url"]) !== null;
+}
+
+function isMissingTarballData(
+  value: unknown,
+): value is PopcornErrors["beam:missing-tarball"] {
+  return objectWithKeys(value, ["name", "all"]) !== null;
+}
+
+function isInternalCheckData(
+  value: unknown,
+): value is PopcornErrors["internal:check"] {
+  return objectWithKeys(value, []) !== null;
+}
+
+function isEmptyData(value: unknown): value is EmptyData {
+  return objectWithKeys(value, []) !== null;
 }
 
 function objectWithKeys<K extends string>(
   value: unknown,
-  keys: K[],
-): null | Record<K, unknown> {
+  keys: readonly K[],
+): value is Record<K, unknown> {
   const isObject = value !== null && typeof value === "object";
-  if (!isObject) return null;
-  const hasAllKeys = keys.every((k) => Object.hasOwn(value, k));
-  if (!hasAllKeys) return null;
-  return value as Record<K, unknown>;
+  return isObject && keys.every((key) => Object.hasOwn(value, key));
+}
+
+function unreachable(): never {
+  throw err("internal:unreachable", {});
+}
+
+function check(ok: boolean, msg?: string): asserts ok {
+  if (!ok) {
+    throw err("internal:check", { detail: msg });
+  }
 }

--- a/otp/js/src/errors.ts
+++ b/otp/js/src/errors.ts
@@ -1,151 +1,145 @@
-import { check, objectWithKeys, unreachable } from "./utils";
+export type PopcornErrors =
+  | { t: "internal:check"; detail?: string }
+  | { t: "internal:unreachable" }
+  | { t: "timeout:boot"; timeoutMs: number }
+  | { t: "worker:load"; message: string }
+  | { t: "beam:missing-boot-script"; url: string }
+  | { t: "beam:missing-manifest"; url: string }
+  | { t: "beam:missing-tarball"; name: string; availableTarballs: string[] };
 
-export type PopcornErrorKind =
-  | "boot-failed"
-  | "worker-failed"
-  | "timeout"
-  | "protocol-error";
+export type ErrorType = PopcornErrors["t"];
+export type ErrorPayloadFor<T extends ErrorType = ErrorType> = Omit<
+  Extract<PopcornErrors, { t: T }>,
+  "t"
+>;
+export type ErrorPayload = {
+  [T in ErrorType]: ErrorPayloadFor<T>;
+}[ErrorType];
+export type SerializedError<T extends ErrorType = ErrorType> = Extract<
+  PopcornErrors,
+  { t: T }
+>;
 
-export type PopcornErrorMetadata = Record<string, unknown>;
+export type AnyPopcornError = PopcornError<any>;
 
-export class PopcornError extends Error {
-  constructor(
-    public readonly kind: PopcornErrorKind,
-    message: string,
-    public readonly metadata: PopcornErrorMetadata = {},
-  ) {
-    super(message);
+export class PopcornError<T extends ErrorType = ErrorType> extends Error {
+  declare readonly cause: SerializedError;
+  readonly #serialized: SerializedError<T>;
+
+  constructor(cause: SerializedError<T>) {
+    super(message(cause), { cause });
     this.name = "PopcornError";
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.#serialized = cause;
+  }
+
+  public get t(): T {
+    return this.#serialized.t;
+  }
+
+  public get payload(): ErrorPayloadFor<T> {
+    const { t: _t, ...payload } = this.#serialized;
+    return payload as ErrorPayloadFor<T>;
+  }
+
+  public serialize(): SerializedError<T> {
+    return { ...this.#serialized };
+  }
+
+  public static deserialize(value: unknown): PopcornError {
+    return new PopcornError(parse(value));
+  }
+
+  public static fromUnknown<T extends ErrorType>(
+    error: unknown,
+    fallback: SerializedError<T>,
+  ): PopcornError<T> {
+    return error instanceof PopcornError ? error : new PopcornError(fallback);
   }
 }
 
-export type SerializedPopcornError = {
-  kind: PopcornErrorKind;
-  message: string;
-  metadata: PopcornErrorMetadata;
-};
-
-type PopcornErrorData =
-  | { t: "boot-timeout"; timeoutMs: number }
-  | { t: "worker-load"; message: string }
-  | { t: "protocol"; reason: string; type?: string }
-  | { t: "missing-boot-script"; url: string }
-  | { t: "missing-manifest"; url: string }
-  | { t: "missing-tarball"; name: string; availableTarballs: string[] }
-  | { t: "internal-boot-failure" }
-  | { t: "internal-worker-failure" };
-
-export function buildPopcornError(data: PopcornErrorData): PopcornError {
-  switch (data.t) {
-    case "boot-timeout":
-      return new PopcornError("timeout", "boot timeout", {
-        operation: "boot",
-        timeoutMs: data.timeoutMs,
-      });
-    case "worker-load":
-      return new PopcornError("worker-failed", data.message, {
-        reason: "load_error",
-      });
-    case "protocol":
-      return new PopcornError(
-        "protocol-error",
-        data.type === undefined
-          ? "Invalid worker event during init"
-          : `Unexpected worker event during init: ${data.type}`,
-        data.type === undefined
-          ? { reason: data.reason }
-          : { reason: data.reason, type: data.type },
-      );
-    case "missing-boot-script":
-      return new PopcornError(
-        "boot-failed",
-        `Missing boot script: '${data.url}'`,
-        {
-          reason: "missing-boot-script",
-          url: data.url,
-        },
-      );
-    case "missing-manifest":
-      return new PopcornError(
-        "boot-failed",
-        `Missing tarball manifest: '${data.url}'`,
-        {
-          reason: "missing-manifest",
-          url: data.url,
-        },
-      );
-    case "missing-tarball":
-      return new PopcornError(
-        "boot-failed",
-        `Missing tarball: '${data.name}'. Available tarballs: ${data.availableTarballs.join(", ")}`,
-        {
-          reason: "missing-tarball",
-          app: data.name,
-          availableTarballs: data.availableTarballs,
-        },
-      );
-    case "internal-boot-failure":
-      return new PopcornError("boot-failed", "OTP boot failed", {
-        reason: "unknown-error",
-      });
-    case "internal-worker-failure":
-      return new PopcornError(
-        "worker-failed",
-        "Popcorn worker failed during init",
-        {
-          reason: "internal-error",
-        },
-      );
-  }
-}
-
-export function serializePopcornError(
-  error: PopcornError,
-): SerializedPopcornError {
-  return {
-    kind: error.kind,
-    message: error.message,
-    metadata: error.metadata,
-  };
-}
-
-export function deserializePopcornError(value: unknown): PopcornError {
-  const data = objectWithKeys(value, ["kind", "message", "metadata"]);
-  check(data !== null);
-  check(isMetadata(data.metadata));
-  check(typeof data.message === "string");
-
-  return new PopcornError(
-    toPopcornErrorKind(data.kind),
-    data.message,
-    data.metadata,
-  );
-}
-
-export function toPopcornError(
-  error: unknown,
-  fallback: PopcornErrorData,
-): PopcornError {
-  if (error instanceof PopcornError) {
-    return error;
-  }
-
-  return buildPopcornError(fallback);
-}
-
-function toPopcornErrorKind(value: unknown): PopcornErrorKind {
-  switch (value) {
-    case "boot-failed":
-    case "worker-failed":
-    case "timeout":
-    case "protocol-error":
-      return value;
-    default:
+function message(error: SerializedError): string {
+  switch (error.t) {
+    case "internal:check":
+      return error.detail === undefined
+        ? "Check failed"
+        : `Check failed: ${error.detail}`;
+    case "internal:unreachable":
+      return "Entered unreachable code";
+    case "timeout:boot":
+      return `Boot timed out after ${error.timeoutMs}ms`;
+    case "worker:load":
+      return error.message;
+    case "beam:missing-boot-script":
+      return `Missing boot script: '${error.url}'`;
+    case "beam:missing-manifest":
+      return `Missing tarball manifest: '${error.url}'`;
+    case "beam:missing-tarball":
+      return `Missing tarball: '${error.name}'. Available tarballs: ${error.availableTarballs.join(", ")}`;
+    default: {
       unreachable();
+    }
   }
 }
 
-function isMetadata(value: unknown): value is PopcornErrorMetadata {
-  const metadata = objectWithKeys(value, []);
-  return metadata !== null;
+function parse(value: unknown): SerializedError {
+  const data = objectWithKeys(value, ["t"]);
+  check(data !== null);
+
+  switch (data.t) {
+    case "internal:check":
+      if (objectWithKeys(value, ["t"]) !== null) {
+        return value as SerializedError<"internal:check">;
+      }
+      break;
+    case "internal:unreachable":
+      if (objectWithKeys(value, ["t"]) !== null) {
+        return value as SerializedError<typeof data.t>;
+      }
+      break;
+    case "timeout:boot":
+      if (objectWithKeys(value, ["t", "timeoutMs"]) !== null) {
+        return value as SerializedError<"timeout:boot">;
+      }
+      break;
+    case "worker:load":
+      if (objectWithKeys(value, ["t", "message"]) !== null) {
+        return value as SerializedError<"worker:load">;
+      }
+      break;
+    case "beam:missing-boot-script":
+    case "beam:missing-manifest":
+      if (objectWithKeys(value, ["t", "url"]) !== null) {
+        return value as
+          | SerializedError<"beam:missing-boot-script">
+          | SerializedError<"beam:missing-manifest">;
+      }
+      break;
+    case "beam:missing-tarball":
+      if (objectWithKeys(value, ["t", "name", "availableTarballs"]) !== null) {
+        return value as SerializedError<"beam:missing-tarball">;
+      }
+      break;
+  }
+  unreachable();
+}
+
+// We don't want to create a cycle with utils (which use PopcornError internally).
+function unreachable(): never {
+  throw new PopcornError({ t: "internal:unreachable" });
+}
+
+export function check(ok: boolean, msg?: string): asserts ok {
+  if (!ok) throw new PopcornError({ t: "internal:check", detail: msg });
+}
+
+function objectWithKeys<K extends string>(
+  value: unknown,
+  keys: K[],
+): null | Record<K, unknown> {
+  const isObject = value !== null && typeof value === "object";
+  if (!isObject) return null;
+  const hasAllKeys = keys.every((k) => Object.hasOwn(value, k));
+  if (!hasAllKeys) return null;
+  return value as Record<K, unknown>;
 }

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -10,7 +10,7 @@ export type WorkerEvent =
   | { type: "otp:abort"; payload: string }
   | { type: "otp:error"; payload: string }
   // response for `popcorn:boot`
-  | { type: "popcorn:boot-end"; payload: null }
+  | { type: "popcorn:boot-end"; payload: {} }
   | { type: "popcorn:boot-fail"; payload: SerializedError };
 
 export type PopcornEvent = {

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -1,4 +1,4 @@
-import type { SerializedPopcornError } from "./errors";
+import type { SerializedError } from "./errors";
 import type { BeamBootOptions } from "./types";
 import { objectWithKeys } from "./utils";
 
@@ -11,7 +11,7 @@ export type WorkerEvent =
   | { type: "otp:error"; payload: string }
   // response for `popcorn:boot`
   | { type: "popcorn:boot-end"; payload: null }
-  | { type: "popcorn:boot-fail"; payload: SerializedPopcornError };
+  | { type: "popcorn:boot-fail"; payload: SerializedError };
 
 export type PopcornEvent = {
   type: "popcorn:boot";

--- a/otp/js/src/index.ts
+++ b/otp/js/src/index.ts
@@ -3,4 +3,11 @@ export { PopcornError } from "./errors";
 export { Popcorn } from "./popcorn";
 export type { PopcornInitResult, PopcornOpts } from "./popcorn";
 export type { BeamBootOptions, BeamEvent } from "./types";
-export type { PopcornErrorKind, PopcornErrorMetadata } from "./errors";
+export type {
+  AnyPopcornError,
+  PopcornErrors,
+  ErrorPayload,
+  ErrorPayloadFor,
+  ErrorType,
+  SerializedError,
+} from "./errors";

--- a/otp/js/src/index.ts
+++ b/otp/js/src/index.ts
@@ -1,13 +1,6 @@
 export { boot } from "./beam";
 export { PopcornError } from "./errors";
 export { Popcorn } from "./popcorn";
-export type { PopcornInitResult, PopcornOpts } from "./popcorn";
+export type { PopcornOpts } from "./popcorn";
 export type { BeamBootOptions, BeamEvent } from "./types";
-export type {
-  AnyPopcornError,
-  PopcornErrors,
-  ErrorPayload,
-  ErrorPayloadFor,
-  ErrorType,
-  SerializedError,
-} from "./errors";
+export type { PopcornErrors, SerializedError } from "./errors";

--- a/otp/js/src/internal-error.ts
+++ b/otp/js/src/internal-error.ts
@@ -1,9 +1,0 @@
-export class PopcornInternalError extends Error {
-  constructor(
-    public readonly code: string,
-    message?: string,
-  ) {
-    super(message ?? `Internal error: ${code}`);
-    this.name = "PopcornInternalError";
-  }
-}

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -1,4 +1,4 @@
-import { PopcornError, type AnyPopcornError } from "./errors";
+import { PopcornError, err, type Result } from "./errors";
 import { toVm } from "./events";
 import type { BeamBootOptions } from "./types";
 import { check, objectWithKeys, unreachable } from "./utils";
@@ -9,10 +9,6 @@ export type PopcornOpts = {
     boot?: number;
   };
 };
-
-export type PopcornInitResult =
-  | { ok: true; popcorn: Popcorn }
-  | { ok: false; error: AnyPopcornError };
 
 type ResolvedTimeouts = Required<NonNullable<PopcornOpts["timeoutsMs"]>>;
 const DEFAULT_TIMEOUTS_MS: ResolvedTimeouts = {
@@ -26,18 +22,17 @@ export class Popcorn {
     this.vmWorker = vmWorker;
   }
 
-  public static async init(opts: PopcornOpts): Promise<PopcornInitResult> {
+  public static async init(opts: PopcornOpts): Promise<Result<Popcorn>> {
     const vmWorkerUrl = new URL("./worker.mjs", import.meta.url);
     const vmWorker = new Worker(vmWorkerUrl, { type: "module" });
 
-    return await new Promise<PopcornInitResult>((resolve) => {
+    return await new Promise<Result<Popcorn>>((resolve) => {
       let isSettled = false;
       const timeoutsMs = { ...DEFAULT_TIMEOUTS_MS, ...opts.timeoutsMs };
       const cleanup = () => {
         vmWorker.removeEventListener("message", onMessage);
-        vmWorker.removeEventListener("error", onError);
       };
-      const settle = (result: PopcornInitResult) => {
+      const settle = (result: Result<Popcorn>) => {
         if (isSettled) return;
         isSettled = true;
         clearTimeout(timer);
@@ -51,29 +46,17 @@ export class Popcorn {
       const timer = setTimeout(() => {
         settle({
           ok: false,
-          error: new PopcornError({
-            t: "timeout:boot",
-            timeoutMs: timeoutsMs.boot,
-          }),
+          error: err("timeout:init", { timeoutMs: timeoutsMs.boot }),
         });
       }, timeoutsMs.boot);
 
-      const onError = (event: ErrorEvent) => {
-        settle({
-          ok: false,
-          error: new PopcornError({
-            t: "worker:load",
-            message: event.message ?? "Worker failed to load",
-          }),
-        });
-      };
       const onMessage = (event: MessageEvent<unknown>) => {
         const data = objectWithKeys(event.data, ["type", "payload"]);
         check(data !== null);
 
         switch (data.type) {
           case "popcorn:boot-end":
-            settle({ ok: true, popcorn: new Popcorn(vmWorker) });
+            settle({ ok: true, data: new Popcorn(vmWorker) });
             break;
           case "popcorn:boot-fail": {
             settle({
@@ -88,7 +71,6 @@ export class Popcorn {
       };
 
       vmWorker.addEventListener("message", onMessage);
-      vmWorker.addEventListener("error", onError);
       toVm(vmWorker, { type: "popcorn:boot", payload: opts.beam });
     });
   }

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -1,8 +1,4 @@
-import {
-  PopcornError,
-  buildPopcornError,
-  deserializePopcornError,
-} from "./errors";
+import { PopcornError, type AnyPopcornError } from "./errors";
 import { toVm } from "./events";
 import type { BeamBootOptions } from "./types";
 import { check, objectWithKeys, unreachable } from "./utils";
@@ -16,7 +12,7 @@ export type PopcornOpts = {
 
 export type PopcornInitResult =
   | { ok: true; popcorn: Popcorn }
-  | { ok: false; error: PopcornError };
+  | { ok: false; error: AnyPopcornError };
 
 type ResolvedTimeouts = Required<NonNullable<PopcornOpts["timeoutsMs"]>>;
 const DEFAULT_TIMEOUTS_MS: ResolvedTimeouts = {
@@ -55,8 +51,8 @@ export class Popcorn {
       const timer = setTimeout(() => {
         settle({
           ok: false,
-          error: buildPopcornError({
-            t: "boot-timeout",
+          error: new PopcornError({
+            t: "timeout:boot",
             timeoutMs: timeoutsMs.boot,
           }),
         });
@@ -65,8 +61,8 @@ export class Popcorn {
       const onError = (event: ErrorEvent) => {
         settle({
           ok: false,
-          error: buildPopcornError({
-            t: "worker-load",
+          error: new PopcornError({
+            t: "worker:load",
             message: event.message ?? "Worker failed to load",
           }),
         });
@@ -82,7 +78,7 @@ export class Popcorn {
           case "popcorn:boot-fail": {
             settle({
               ok: false,
-              error: deserializePopcornError(data.payload),
+              error: PopcornError.deserialize(data.payload),
             });
             break;
           }

--- a/otp/js/src/utils.ts
+++ b/otp/js/src/utils.ts
@@ -1,4 +1,4 @@
-import { PopcornInternalError } from "./internal-error";
+import { PopcornError } from "./errors";
 import type { EmscriptenFS } from "./types";
 
 export function ensureDir(FS: EmscriptenFS, path: string): void {
@@ -38,10 +38,7 @@ export async function fetchJson<T>(url: string): Promise<T | null> {
 
 export function isGzip(data: Uint8Array): boolean {
   return (
-    data.length >= 3 &&
-    data[0] === 0x1f &&
-    data[1] === 0x8b &&
-    data[2] === 0x08
+    data.length >= 3 && data[0] === 0x1f && data[1] === 0x8b && data[2] === 0x08
   );
 }
 
@@ -55,11 +52,11 @@ export async function decompressGzip(data: Uint8Array): Promise<Uint8Array> {
 }
 
 export function check(ok: boolean, msg?: string): asserts ok {
-  if (!ok) throw new PopcornInternalError("check", msg);
+  if (!ok) throw new PopcornError({ t: "internal:check", detail: msg });
 }
 
 export function unreachable(): never {
-  throw new PopcornInternalError("unreachable");
+  throw new PopcornError({ t: "internal:unreachable" });
 }
 
 export function objectWithKeys<K extends string>(

--- a/otp/js/src/utils.ts
+++ b/otp/js/src/utils.ts
@@ -1,4 +1,4 @@
-import { PopcornError } from "./errors";
+import { err } from "./errors";
 import type { EmscriptenFS } from "./types";
 
 export function ensureDir(FS: EmscriptenFS, path: string): void {
@@ -52,11 +52,11 @@ export async function decompressGzip(data: Uint8Array): Promise<Uint8Array> {
 }
 
 export function check(ok: boolean, msg?: string): asserts ok {
-  if (!ok) throw new PopcornError({ t: "internal:check", detail: msg });
+  if (!ok) throw err("internal:check", { detail: msg });
 }
 
 export function unreachable(): never {
-  throw new PopcornError({ t: "internal:unreachable" });
+  throw err("internal:unreachable", {});
 }
 
 export function objectWithKeys<K extends string>(

--- a/otp/js/src/worker.ts
+++ b/otp/js/src/worker.ts
@@ -8,8 +8,8 @@ import { check } from "./utils";
 let instance: EmscriptenModule | null = null;
 
 self.onmessage = async (event: MessageEvent<unknown>) => {
-  check(isPopcornEvent(event), "beam:bad-message");
-  check(instance === null, "beam:double-init");
+  check(isPopcornEvent(event));
+  check(instance === null);
 
   const result = await boot({
     assetsUrl: event.data.payload.assetsUrl,
@@ -20,13 +20,14 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
       // TODO: pass it to main context. For now, swallow all events.
     },
   });
-  if (result.ok) {
-    instance = result.module;
-    toMain({ type: "popcorn:boot-end", payload: null });
-  } else {
+  if (!result.ok) {
     toMain({
       type: "popcorn:boot-fail",
       payload: result.error.serialize(),
     });
+    return;
   }
+
+  instance = result.data;
+  toMain({ type: "popcorn:boot-end", payload: {} });
 };

--- a/otp/js/src/worker.ts
+++ b/otp/js/src/worker.ts
@@ -1,7 +1,6 @@
 import createModule from "../assets/beam.mjs";
 
 import { boot } from "./beam";
-import { buildPopcornError, serializePopcornError } from "./errors";
 import { isPopcornEvent, toMain } from "./events";
 import type { EmscriptenModule } from "./types";
 import { check } from "./utils";
@@ -9,16 +8,7 @@ import { check } from "./utils";
 let instance: EmscriptenModule | null = null;
 
 self.onmessage = async (event: MessageEvent<unknown>) => {
-  if (!isPopcornEvent(event)) {
-    toMain({
-      type: "popcorn:boot-fail",
-      payload: serializePopcornError(
-        buildPopcornError({ t: "protocol", reason: "invalid-init-event" }),
-      ),
-    });
-    return;
-  }
-
+  check(isPopcornEvent(event), "beam:bad-message");
   check(instance === null, "beam:double-init");
 
   const result = await boot({
@@ -36,7 +26,7 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
   } else {
     toMain({
       type: "popcorn:boot-fail",
-      payload: serializePopcornError(result.error),
+      payload: result.error.serialize(),
     });
   }
 };


### PR DESCRIPTION
Idea is to confine the exceptions to known components (e.g. beam) and use errors as values everywhere else (from known set of errors). We intentionally don't catch errors from `check` or `unreachable`, they shouldn't show up in normal usage.