### PR TITLE
Fix maps:take

### DIFF
--- a/popcorn/elixir/patches/otp/stdlib/maps.erl
+++ b/popcorn/elixir/patches/otp/stdlib/maps.erl
@@ -494,8 +494,8 @@ remove(_Key, Map) when not is_map(Map) ->
 take(Key, Map) when is_map(Map) ->
     case ?MODULE:is_key(Key, Map) of
         true ->
-            {_K, V, _It} = Next = maps:next(maps:iterator(Map)),
-            Map2 = iterate_remove(Key, Next, ?MODULE:new()),
+            V = ?MODULE:get(Key, Map),
+            Map2 = iterate_remove(Key, maps:next(maps:iterator(Map)), ?MODULE:new()),
             {V, Map2};
         _ ->
             Map

--- a/popcorn/elixir/test/popcorn/eval_test.exs
+++ b/popcorn/elixir/test/popcorn/eval_test.exs
@@ -859,4 +859,13 @@ defmodule Popcorn.EvalTest do
     |> AtomVM.eval(:elixir, run_dir: dir)
     |> AtomVM.assert_result("21.37")
   end
+
+  async_test "Map.pop", %{tmp_dir: dir} do
+    quote do
+      Map.pop(%{a: 1, b: 2}, :b)
+    end
+    |> Macro.to_string()
+    |> AtomVM.eval(:elixir, run_dir: dir)
+    |> AtomVM.assert_result({2, %{a: 1}})
+  end
 end


### PR DESCRIPTION
`maps:take` returned some random value from the map instead of the correct one... This made `Map.pop*` functions work incorrectly