### PR TITLE
fix(docs): update urls in readme banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
   <img alt="Popcorn" src="https://raw.githubusercontent.com/software-mansion/popcorn/refs/heads/main/assets/fallback-logo-text.svg">
 </picture>
 
-[![Ad](https://swm-delivery.com/www/images/zone-gh-popcorn-1?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-popcorn-1&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-popcorn-2?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-popcorn-2&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-popcorn-3?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-popcorn-3&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-popcorn-1?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-popcorn-1&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-popcorn-2?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-popcorn-2&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-popcorn-3?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-popcorn-3&n=1)
 
 **Popcorn is a library that allows you to run client-side Elixir in browsers, with JavaScript interoperability**
 


### PR DESCRIPTION
Updates url in banner so clicks redirect correctly.