### PR TITLE
otp: bridge

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -2,35 +2,42 @@ name: Setup Playwright
 description: Cache and install Playwright browsers
 
 inputs:
-  cache-prefix:
-    description: Cache key prefix for this workflow
-    required: true
-  lockfile:
-    description: Path to lockfile used for cache key hashing
-    required: true
   version:
-    description: Playwright version to install (default matches Elixir dep)
+    description: >
+      Playwright version to install. Default matches the playwright-elixir.
+      JS e2e workflows override this to match @playwright/test.
     required: false
     default: "1.49.1"
 runs:
   using: composite
   steps:
+    # Browser binaries depend ONLY on the Playwright version, so the cache key
+    # must be the version. No restore-keys: a partial match would restore a
+    # mismatched browser set that `playwright install` then deletes and
+    # re-downloads, defeating the cache (and risking a hung download).
     - name: Cache Playwright browsers
       id: playwright-cache
       uses: actions/cache@v4
       with:
         path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ inputs.cache-prefix }}-${{ hashFiles(inputs.lockfile) }}
-        restore-keys: |
-          ${{ runner.os }}-playwright-${{ inputs.cache-prefix }}-
-          ${{ runner.os }}-playwright-
+        key: ${{ runner.os }}-playwright-${{ inputs.version }}
 
     - name: Install Playwright browsers
       if: steps.playwright-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         if command -v pnpx &> /dev/null; then
-          pnpx playwright@${{ inputs.version }} install chromium
+          runner="pnpx"
         else
-          npx playwright@${{ inputs.version }} install chromium
+          runner="npx"
         fi
+        for attempt in 1 2 3; do
+          echo "Playwright install attempt $attempt"
+          if timeout 300 "$runner" playwright@${{ inputs.version }} install chromium; then
+            exit 0
+          fi
+          echo "Attempt $attempt failed or timed out; retrying..."
+          sleep 5
+        done
+        echo "Playwright install failed after 3 attempts" >&2
+        exit 1

--- a/.github/workflows/eval_in_wasm_build_test.yml
+++ b/.github/workflows/eval_in_wasm_build_test.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          # Node 24.16.0 broke the zip extraction (and subsequently, Playwright).
+          # See https://github.com/nodejs/node/issues/63487.
+          node-version: "24.15.0"
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 
@@ -84,9 +86,6 @@ jobs:
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
-        with:
-          cache-prefix: examples-eval-in-wasm
-          lockfile: examples/eval-in-wasm/mix.lock
 
       - name: Build
         run: mix build

--- a/.github/workflows/hello_popcorn_build_test.yml
+++ b/.github/workflows/hello_popcorn_build_test.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          # Node 24.16.0 broke the zip extraction (and subsequently, Playwright).
+          # See https://github.com/nodejs/node/issues/63487.
+          node-version: "24.15.0"
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 
@@ -78,9 +80,6 @@ jobs:
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
-        with:
-          cache-prefix: examples-hello-popcorn
-          lockfile: examples/hello-popcorn/mix.lock
 
       - name: Build
         run: mix build

--- a/.github/workflows/otp_js_e2e_test.yml
+++ b/.github/workflows/otp_js_e2e_test.yml
@@ -60,7 +60,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          # Node 24.16.0 broke the zip extraction (and subsequently, Playwright).
+          # See https://github.com/nodejs/node/issues/63487.
+          node-version: "24.15.0"
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 
@@ -70,9 +72,7 @@ jobs:
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
-          cache-prefix: otp-js-e2e
-          lockfile: pnpm-lock.yaml
-          version: "1.59.1"
+          version: "1.60.0"
 
       - name: Run e2e tests
         run: pnpm e2e

--- a/.github/workflows/popcorn_build_test.yml
+++ b/.github/workflows/popcorn_build_test.yml
@@ -51,7 +51,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          # Node 24.16.0 broke the zip extraction (and subsequently, Playwright).
+          # See https://github.com/nodejs/node/issues/63487.
+          node-version: "24.15.0"
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 
@@ -71,9 +73,6 @@ jobs:
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
-        with:
-          cache-prefix: popcorn-root
-          lockfile: popcorn/elixir/mix.lock
 
       - name: Lint
         run: mix lint

--- a/.github/workflows/popcorn_js_e2e_test.yml
+++ b/.github/workflows/popcorn_js_e2e_test.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          # Node 24.16.0 broke the zip extraction (and subsequently, Playwright).
+          # See https://github.com/nodejs/node/issues/63487.
+          node-version: "24.15.0"
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 
@@ -54,9 +56,7 @@ jobs:
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
-          cache-prefix: js-e2e
-          lockfile: pnpm-lock.yaml
-          version: "1.59.1"
+          version: "1.60.0"
 
       - name: Run e2e tests
         run: pnpm test:e2e

--- a/.github/workflows/popdoc_e2e_test.yml
+++ b/.github/workflows/popdoc_e2e_test.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          # Node 24.16.0 broke the zip extraction (and subsequently, Playwright).
+          # See https://github.com/nodejs/node/issues/63487.
+          node-version: "24.15.0"
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 
@@ -64,9 +66,7 @@ jobs:
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
-          cache-prefix: popdoc-e2e
-          lockfile: pnpm-lock.yaml
-          version: "1.59.1"
+          version: "1.60.0"
 
       - name: Run e2e tests
         run: bash scripts/test.sh --popdoc

--- a/landing-page/package.json
+++ b/landing-page/package.json
@@ -27,7 +27,7 @@
     "mermaid": "^11.7.0",
     "phoenix": "^1.8.0",
     "phoenix_live_view": "^1.1.0",
-    "playwright": "^1.53.2",
+    "playwright": "^1.60.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "rehype-mermaid": "^3.0.0",

--- a/language-tour/package.json
+++ b/language-tour/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
-    "@playwright/test": "^1.56.1",
+    "@playwright/test": "^1.60.0",
     "@types/mdast": "^4.0.4",
     "@types/node": "^24.9.1",
     "@types/react": "^19.1.9",

--- a/otp/js/e2e/helpers.ts
+++ b/otp/js/e2e/helpers.ts
@@ -81,8 +81,8 @@ export class Otp {
     const popcorn = this.requirePopcorn();
 
     return await popcorn.evaluate(
-      (instance, args) => {
-        const result = instance.send(args.target, args.payload, args.opts);
+      async (instance, args) => {
+        const result = await instance.send(args.target, args.payload, args.opts);
 
         return result.ok
           ? { ok: true, data: null }

--- a/otp/js/e2e/helpers.ts
+++ b/otp/js/e2e/helpers.ts
@@ -3,11 +3,14 @@ import {
   expect,
   test as base,
   type JSHandle,
+  type ConsoleMessage,
   type Page,
 } from "@playwright/test";
 import type {
   Popcorn,
   PopcornOpts,
+  PopcornEvent,
+  PopcornSendOpts,
   SerializedError,
 } from "@swmansion/popcorn-otp";
 
@@ -15,102 +18,163 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Window {
     Popcorn: typeof Popcorn;
+    __recordOtpEvent: (event: PopcornEvent) => Promise<void>;
   }
 }
 
 type InitOptions = PopcornOpts;
+type BootResult = Result<null>;
+type EventWaiter = (event: PopcornEvent) => void;
 
 export type Result<T> =
   | { ok: true; data: T }
   | { ok: false; error: SerializedError };
 
-type BrowserInitResult = Result<Popcorn>;
-type PopcornHandleResult = Result<JSHandle<Popcorn>>;
-type PopcornInputContext = Record<string, unknown> & {
-  popcorn?: never;
-};
-type PopcornEvaluateArg<TContext extends PopcornInputContext> = TContext & {
-  popcorn: JSHandle<Popcorn>;
-};
+export class Otp {
+  public readonly events = new Set<PopcornEvent>();
 
-type PopcornContext<TContext extends PopcornInputContext> = TContext & {
-  popcorn: Popcorn;
-};
+  private popcorn: JSHandle<Popcorn> | null = null;
+  private readonly eventWaiters = new Map<string, Array<EventWaiter>>();
 
-type PopcornRun<TContext extends PopcornInputContext, TResult> = (
-  args: PopcornContext<TContext>,
-) => Promise<TResult> | TResult;
+  public constructor(private readonly page: Page) {}
+
+  public async installEventBridge(): Promise<void> {
+    await this.page.exposeBinding("__recordOtpEvent", (_source, event) => {
+      this.recordEvent(event as PopcornEvent);
+    });
+  }
+
+  public async boot(options: InitOptions): Promise<BootResult> {
+    if (this.popcorn !== null) {
+      throw new Error("OTP is already booted");
+    }
+
+    this.popcorn = await this.page.evaluateHandle(
+      (initOptions: InitOptions): Popcorn => new window.Popcorn(initOptions),
+      options,
+    );
+    await this.popcorn.evaluate((popcorn) => {
+      popcorn.onEvent((event) => {
+        window.__recordOtpEvent(event);
+      });
+    });
+
+    const result = await this.popcorn.evaluate(async (popcorn): Promise<BootResult> => {
+      const boot = await popcorn.boot();
+      return boot.ok
+        ? { ok: true, data: null }
+        : { ok: false, error: boot.error.serialize() };
+    });
+
+    if (!result.ok) {
+      await this.dispose();
+    }
+
+    return result;
+  }
+
+  public async send(
+    target: string,
+    payload?: unknown,
+    opts?: PopcornSendOpts,
+  ): Promise<BootResult> {
+    const popcorn = this.requirePopcorn();
+
+    return await popcorn.evaluate(
+      (instance, args) => {
+        const result = instance.send(args.target, args.payload, args.opts);
+
+        return result.ok
+          ? { ok: true, data: null }
+          : { ok: false, error: result.error.serialize() };
+      },
+      { target, payload, opts },
+    );
+  }
+
+  public async waitForEvent(name: string): Promise<PopcornEvent> {
+    const event = this.findEvent(name);
+    if (event !== null) {
+      return event;
+    }
+
+    return await new Promise<PopcornEvent>((resolve) => {
+      const waiters = this.eventWaiters.get(name) ?? [];
+      waiters.push(resolve);
+      this.eventWaiters.set(name, waiters);
+    });
+  }
+
+  public async waitForStderr(text: string): Promise<ConsoleMessage> {
+    return await this.page.waitForEvent("console", (message) => {
+      return (
+        message.type() === "error" &&
+        message.text().includes("[Popcorn]") &&
+        message.text().includes(text)
+      );
+    });
+  }
+
+  public async dispose(): Promise<void> {
+    const popcorn = this.popcorn;
+    this.popcorn = null;
+    if (popcorn !== null) {
+      await this.page.evaluate((instance) => instance.deinit(), popcorn);
+      await popcorn.dispose();
+    }
+  }
+
+  private requirePopcorn(): JSHandle<Popcorn> {
+    if (this.popcorn === null) {
+      throw new Error("Popcorn has not been booted");
+    }
+
+    return this.popcorn;
+  }
+
+  private recordEvent(event: PopcornEvent): void {
+    this.events.add(event);
+
+    for (const [name, waiters] of this.eventWaiters) {
+      if (hasKey(event, name)) {
+        this.eventWaiters.delete(name);
+        for (const resolve of waiters) {
+          resolve(event);
+        }
+      }
+    }
+  }
+
+  private findEvent(name: string): PopcornEvent | null {
+    for (const event of this.events) {
+      if (hasKey(event, name)) {
+        return event;
+      }
+    }
+
+    return null;
+  }
+}
+
+const hasKey = (event: PopcornEvent, key: string) =>
+  typeof event === "object" && event !== null && key in event;
+
+type Fixtures = {
+  otp: Otp;
+};
 
 export { assert, expect };
 
-export const test = base.extend({
+export const test = base.extend<Fixtures>({
   page: async ({ page }, use) => {
     await page.goto("/");
     await page.waitForFunction(() => window.Popcorn !== undefined);
     await use(page);
   },
+  otp: async ({ page }, use) => {
+    const otp = new Otp(page);
+    await otp.installEventBridge();
+    await use(otp);
+    await otp.dispose();
+  },
 });
-
-export async function withPopcorn<
-  TContext extends PopcornInputContext,
-  TResult,
->(
-  page: Page,
-  options: InitOptions,
-  context: TContext,
-  run: PopcornRun<TContext, TResult>,
-): Promise<Result<TResult>> {
-  const popcorn = await createPopcornHandle(page, options);
-  if (!popcorn.ok) {
-    return popcorn;
-  }
-
-  try {
-    const data = await page.evaluate<TResult, PopcornEvaluateArg<TContext>>(
-      run,
-      { ...context, popcorn: popcorn.data },
-    );
-    return { ok: true, data };
-  } finally {
-    await disposePopcorn(page, popcorn.data);
-  }
-}
-
-async function createPopcornHandle(
-  page: Page,
-  options: InitOptions,
-): Promise<PopcornHandleResult> {
-  const resultHandle = await page.evaluateHandle(
-    async (initOptions: InitOptions): Promise<BrowserInitResult> => {
-      const result = await window.Popcorn.init(initOptions);
-
-      return result.ok
-        ? { ok: true, data: result.data }
-        : { ok: false, error: result.error.serialize() };
-    },
-    options,
-  );
-
-  const okHandle = await resultHandle.getProperty("ok");
-  const ok = (await okHandle.jsonValue()) as boolean;
-  await okHandle.dispose();
-
-  if (!ok) {
-    const errorHandle = await resultHandle.getProperty("error");
-    const error = (await errorHandle.jsonValue()) as SerializedError;
-    await errorHandle.dispose();
-    await resultHandle.dispose();
-    return { ok: false, error };
-  }
-
-  const popcorn = (await resultHandle.getProperty("data")) as JSHandle<Popcorn>;
-  await resultHandle.dispose();
-  return { ok: true, data: popcorn };
-}
-
-async function disposePopcorn(page: Page, popcorn: JSHandle<Popcorn>) {
-  await page.evaluate((instance: Popcorn) => {
-    instance.deinit();
-  }, popcorn);
-  await popcorn.dispose();
-}

--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -1,7 +1,5 @@
 import { assert, expect, test } from "./helpers";
 
-const READY_BOOT_EVAL = "ok = wasm:send(#{ready => true}).";
-
 test("boots", async ({ otp }) => {
   const result = await otp.boot({ beam: { assetsUrl: "/otp-assets" } });
 
@@ -31,6 +29,53 @@ test("handles missing boot script", async ({ otp }) => {
       t: "beam:missing-boot-script",
       data: { url: "/otp-assets/missing/bin/vm.boot" },
     },
+  });
+});
+
+test("reports runtime errors through onError", async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const errors: unknown[] = [];
+    const popcorn = new window.Popcorn({
+      beam: { assetsUrl: "/otp-assets/missing" },
+      onError: (event) => errors.push(event),
+    });
+
+    const boot = await popcorn.boot();
+    return {
+      errors,
+      boot: boot.ok
+        ? { ok: true, data: null }
+        : { ok: false, error: boot.error.serialize() },
+    };
+  });
+
+  expect(result.errors).toContainEqual({
+    kind: "abort",
+    data: "Missing boot script: '/otp-assets/missing/bin/vm.boot'",
+  });
+  expect(result.boot).toEqual({
+    ok: false,
+    error: {
+      t: "beam:missing-boot-script",
+      data: { url: "/otp-assets/missing/bin/vm.boot" },
+    },
+  });
+});
+
+test("does not allow boot after deinit", async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const popcorn = new window.Popcorn({ beam: { assetsUrl: "/otp-assets" } });
+    popcorn.deinit();
+
+    const boot = await popcorn.boot();
+    return boot.ok
+      ? { ok: true, data: null }
+      : { ok: false, error: boot.error.serialize() };
+  });
+
+  expect(result).toEqual({
+    ok: false,
+    error: { t: "vm:exited", data: { reason: "deinit" } },
   });
 });
 
@@ -83,16 +128,15 @@ test("handles events in both directions", async ({ otp }) => {
   });
 });
 
-test("surfaces listener lookup failures from popcorn.send", async ({ otp }) => {
+test("popcorn.send() reports unregistered process", async ({ otp }) => {
+  const READY_BOOT_EVAL = "ok = wasm:send(#{ready => true}).";
   const boot = await otp.boot({
     beam: { assetsUrl: "/otp-assets", extraArgs: ["-eval", READY_BOOT_EVAL] },
   });
-
   assert(boot.ok);
   await otp.waitForEvent("ready");
 
   const send = await otp.send("missing-listener", { ping: true });
-
   expect(send).toEqual({
     ok: false,
     error: {

--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -83,7 +83,7 @@ test("handles events in both directions", async ({ otp }) => {
   });
 });
 
-test("raports non-existent send() targets", async ({ otp }) => {
+test("surfaces listener lookup failures from popcorn.send", async ({ otp }) => {
   const boot = await otp.boot({
     beam: { assetsUrl: "/otp-assets", extraArgs: ["-eval", READY_BOOT_EVAL] },
   });
@@ -92,10 +92,12 @@ test("raports non-existent send() targets", async ({ otp }) => {
   await otp.waitForEvent("ready");
 
   const send = await otp.send("missing-listener", { ping: true });
-  const consoleMessage = await otp.waitForStderr("send failed");
 
-  assert(send.ok);
-  expect(consoleMessage.text()).toContain("send failed");
-  expect(consoleMessage.text()).toContain("Target listener not found");
-  expect(consoleMessage.text()).toContain("missing-listener");
+  expect(send).toEqual({
+    ok: false,
+    error: {
+      t: "bridge:listener-not-found",
+      data: { targetName: "missing-listener" },
+    },
+  });
 });

--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -1,6 +1,24 @@
 import type { PopcornEvent } from "@swmansion/popcorn-otp";
 import { assert, expect, test, withPopcorn } from "./helpers";
 
+const BRIDGE_BOOT_EVAL = [
+  "spawn(fun() ->",
+  "  ok = wasm:register_listener(bridge),",
+  "  Loop = fun(F) ->",
+  "    receive",
+  "      {wasm, PayloadJson, MetaJson} ->",
+  "        Payload = json:decode(PayloadJson),",
+  "        Meta = json:decode(MetaJson),",
+  "        ok = wasm:send(#{reply => Payload, meta => Meta}),",
+  "        F(F)",
+  "    end",
+  "  end,",
+  "  Loop(Loop)",
+  "end).",
+].join(" ");
+
+const WASM_LOAD_EVAL = "code:ensure_loaded(wasm).";
+
 test("boots with the packaged OTP assets through Popcorn.init", async ({
   page,
 }) => {
@@ -52,12 +70,92 @@ test("returns beam:missing-boot-script through Popcorn.init for setup failures",
   });
 });
 
-test("reaches the native bridge from popcorn.send and surfaces bridge readiness errors", async ({
+test("round-trips through the native bridge when a wasm listener is registered", async ({
   page,
 }) => {
   const result = await withPopcorn(
     page,
-    { beam: { assetsUrl: "/otp-assets" } },
+    {
+      beam: {
+        assetsUrl: "/otp-assets",
+        extraArgs: ["-eval", BRIDGE_BOOT_EVAL],
+      },
+    },
+    { settleMs: 250 },
+    async ({ popcorn, settleMs }) => {
+      const messages: unknown[] = [];
+      const events: Array<PopcornEvent> = [];
+      const unsubscribe = popcorn.onMessage((message) => {
+        messages.push(message);
+      });
+      const unsubscribeEvents = popcorn.onEvent((event) => {
+        events.push(event);
+      });
+
+      let sendResult = popcorn.send("bridge", { ping: true }, {
+        meta: { requestId: "req-1" },
+      });
+
+      for (let attempt = 0; attempt < 8; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, settleMs));
+
+        if (
+          messages.some(
+            (message) =>
+              typeof message === "object" &&
+              message !== null &&
+              "reply" in message,
+          )
+        ) {
+          break;
+        }
+
+        sendResult = popcorn.send("bridge", { ping: true }, {
+          meta: { requestId: "req-1" },
+        });
+      }
+
+      unsubscribe();
+      unsubscribeEvents();
+      return {
+        send: sendResult.ok
+          ? { ok: true }
+          : { ok: false, error: sendResult.error.serialize() },
+        messages,
+        events,
+      };
+    },
+  );
+
+  assert(result.ok);
+  assert(result.data.send.ok);
+  if (
+    !result.data.messages.some(
+      (message) =>
+        typeof message === "object" &&
+        message !== null &&
+        "reply" in message,
+    )
+  ) {
+    throw new Error(
+      `No bridge reply received. Events: ${JSON.stringify(result.data.events)}`,
+    );
+  }
+  expect(result.data.messages).toContainEqual({
+    reply: { ping: true },
+    meta: { requestId: "req-1" },
+  });
+});
+
+test("surfaces listener lookup failures from popcorn.send", async ({ page }) => {
+  const result = await withPopcorn(
+    page,
+    {
+      beam: {
+        assetsUrl: "/otp-assets",
+        extraArgs: ["-eval", WASM_LOAD_EVAL],
+      },
+    },
     { settleMs: 250 },
     async ({ popcorn, settleMs }) => {
       const events: Array<PopcornEvent> = [];
@@ -65,7 +163,8 @@ test("reaches the native bridge from popcorn.send and surfaces bridge readiness 
         events.push(event);
       });
 
-      const sendResult = popcorn.send("", { ping: true });
+      await new Promise((resolve) => setTimeout(resolve, settleMs));
+      const sendResult = popcorn.send("missing-listener", { ping: true });
       await new Promise((resolve) => setTimeout(resolve, settleMs));
 
       unsubscribe();
@@ -82,6 +181,7 @@ test("reaches the native bridge from popcorn.send and surfaces bridge readiness 
   assert(result.data.send.ok);
   expect(result.data.events).toContainEqual({
     type: "otp:error",
-    payload: '{"type":"bridge_not_ready","detail":"bridge port is not open"}',
+    payload:
+      '{"type":"listener_not_found","detail":"target listener is not registered"}',
   });
 });

--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -1,242 +1,101 @@
-import type { PopcornEvent } from "@swmansion/popcorn-otp";
-import { assert, expect, test, withPopcorn } from "./helpers";
+import { assert, expect, test } from "./helpers";
 
-const BRIDGE_BOOT_EVAL = [
-  "spawn(fun() ->",
-  "  ok = wasm:register_listener(bridge),",
-  "  Loop = fun(F) ->",
-  "    receive",
-  "      {wasm, PayloadJson, MetaJson} ->",
-  "        Payload = json:decode(PayloadJson),",
-  "        Meta = json:decode(MetaJson),",
-  "        ok = wasm:send(#{reply => Payload, meta => Meta}),",
-  "        F(F)",
-  "    end",
-  "  end,",
-  "  Loop(Loop)",
-  "end).",
-].join(" ");
+const READY_BOOT_EVAL = "ok = wasm:send(#{ready => true}).";
 
-const SEND_TO_JS_BOOT_EVAL = [
-  "spawn(fun() ->",
-  "  ok = wasm:register_listener(direct_sender),",
-  "  receive",
-  "    {wasm, _PayloadJson, _MetaJson} ->",
-  "      ok = wasm:send(#{direct => true, nested => #{count => 1}})",
-  "  end",
-  "end).",
-].join(" ");
-
-test.describe.configure({ mode: "serial" });
-
-test("boots with the packaged OTP assets through Popcorn.init", async ({
-  page,
-}) => {
-  const result = await withPopcorn(
-    page,
-    { beam: { assetsUrl: "/otp-assets" } },
-    {},
-    async () => null,
-  );
+test("boots", async ({ otp }) => {
+  const result = await otp.boot({ beam: { assetsUrl: "/otp-assets" } });
 
   expect(result).toEqual({ ok: true, data: null });
 });
 
-test("returns timeout:init through Popcorn.init", async ({ page }) => {
-  const result = await withPopcorn(
-    page,
-    { beam: { assetsUrl: "/otp-assets" }, timeoutsMs: { boot: 0 } },
-    {},
-    async () => null,
-  );
+test("reports timeouts on init", async ({ otp }) => {
+  const result = await otp.boot({
+    beam: { assetsUrl: "/otp-assets" },
+    timeoutsMs: { boot: 0 },
+  });
+
   expect(result).toEqual({
     ok: false,
-    error: {
-      t: "timeout:init",
-      data: {
-        timeoutMs: 0,
-      },
-    },
+    error: { t: "timeout:init", data: { timeoutMs: 0 } },
   });
 });
 
-test("returns beam:missing-boot-script through Popcorn.init for setup failures", async ({
-  page,
-}) => {
-  const result = await withPopcorn(
-    page,
-    { beam: { assetsUrl: "/otp-assets/missing" } },
-    {},
-    async () => null,
-  );
+test("handles missing boot script", async ({ otp }) => {
+  const result = await otp.boot({
+    beam: { assetsUrl: "/otp-assets/missing" },
+  });
+
   expect(result).toEqual({
     ok: false,
     error: {
       t: "beam:missing-boot-script",
-      data: {
-        url: "/otp-assets/missing/bin/vm.boot",
-      },
+      data: { url: "/otp-assets/missing/bin/vm.boot" },
     },
   });
 });
 
-test("round-trips through the native bridge when a wasm listener is registered", async ({
-  page,
-}) => {
-  const result = await withPopcorn(
-    page,
-    {
-      beam: {
-        assetsUrl: "/otp-assets",
-        extraArgs: ["-eval", BRIDGE_BOOT_EVAL],
-      },
+test("handles events in both directions", async ({ otp }) => {
+  const BRIDGE_BOOT_EVAL = [
+    "spawn(fun() ->",
+    "  ok = wasm:send(#{direct => true, nested => #{count => 1}}),",
+    "  ok = wasm:register_listener(bridge),",
+    "  Loop = fun(F) ->",
+    "    ok = wasm:send(#{bridge_ready => true}),",
+    "    receive",
+    "      {wasm, PayloadJson, MetaJson} ->",
+    "        Payload = json:decode(PayloadJson),",
+    "        Meta = json:decode(MetaJson),",
+    "        ok = wasm:send(#{reply => Payload, meta => Meta})",
+    "    after 100 ->",
+    "        F(F)",
+    "    end",
+    "  end,",
+    "  Loop(Loop)",
+    "end).",
+  ].join(" ");
+  const boot = await otp.boot({
+    beam: {
+      assetsUrl: "/otp-assets",
+      extraArgs: ["-eval", BRIDGE_BOOT_EVAL],
     },
-    { settleMs: 250 },
-    async ({ popcorn, settleMs }) => {
-      const events: Array<PopcornEvent> = [];
-      const unsubscribe = popcorn.onEvent((event) => {
-        events.push(event);
-      });
+  });
 
-      let sendResult = popcorn.send("bridge", { ping: true }, {
-        meta: { requestId: "req-1" },
-      });
+  assert(boot.ok);
+  await otp.waitForEvent("direct");
+  expect(otp.events).toContainEqual({
+    direct: true,
+    nested: { count: 1 },
+  });
 
-      for (let attempt = 0; attempt < 8; attempt += 1) {
-        await new Promise((resolve) => setTimeout(resolve, settleMs));
+  await otp.waitForEvent("bridge_ready");
 
-        if (
-          events.some(
-            (event) =>
-              typeof event === "object" &&
-              event !== null &&
-              "reply" in event,
-          )
-        ) {
-          break;
-        }
-
-        sendResult = popcorn.send("bridge", { ping: true }, {
-          meta: { requestId: "req-1" },
-        });
-      }
-
-      unsubscribe();
-      return {
-        send: sendResult.ok
-          ? { ok: true }
-          : { ok: false, error: sendResult.error.serialize() },
-        events,
-      };
-    },
+  const send = await otp.send(
+    "bridge",
+    { ping: true },
+    { meta: { requestId: "req-1" } },
   );
+  assert(send.ok);
 
-  assert(result.ok);
-  assert(result.data.send.ok);
-  if (
-    !result.data.events.some(
-      (event) =>
-        typeof event === "object" &&
-        event !== null &&
-        "reply" in event,
-    )
-  ) {
-    throw new Error(`No bridge reply received: ${JSON.stringify(result.data.events)}`);
-  }
-  expect(result.data.events).toContainEqual({
+  await otp.waitForEvent("reply");
+  expect(otp.events).toContainEqual({
     reply: { ping: true },
     meta: { requestId: "req-1" },
   });
 });
 
-test("emits wasm:send envelopes as Popcorn events", async ({ page }) => {
-  const result = await withPopcorn(
-    page,
-    {
-      beam: {
-        assetsUrl: "/otp-assets",
-        extraArgs: ["-eval", SEND_TO_JS_BOOT_EVAL],
-      },
-    },
-    { settleMs: 250 },
-    async ({ popcorn, settleMs }) => {
-      const events: Array<PopcornEvent> = [];
-      const unsubscribe = popcorn.onEvent((event) => {
-        events.push(event);
-      });
-
-      let sendResult = popcorn.send("direct_sender");
-
-      for (let attempt = 0; attempt < 8; attempt += 1) {
-        await new Promise((resolve) => setTimeout(resolve, settleMs));
-
-        if (
-          events.some(
-            (event) =>
-              typeof event === "object" &&
-              event !== null &&
-              "direct" in event,
-          )
-        ) {
-          break;
-        }
-
-        sendResult = popcorn.send("direct_sender");
-      }
-
-      unsubscribe();
-      return {
-        send: sendResult.ok
-          ? { ok: true }
-          : { ok: false, error: sendResult.error.serialize() },
-        events,
-      };
-    },
-  );
-
-  assert(result.ok);
-  assert(result.data.send.ok);
-  expect(result.data.events).toContainEqual({
-    direct: true,
-    nested: { count: 1 },
+test("raports non-existent send() targets", async ({ otp }) => {
+  const boot = await otp.boot({
+    beam: { assetsUrl: "/otp-assets", extraArgs: ["-eval", READY_BOOT_EVAL] },
   });
-});
 
-test("surfaces listener lookup failures from popcorn.send", async ({ page }) => {
-  const consoleErrors: string[] = [];
-  const onConsole = (message: { type: () => string; text: () => string }) => {
-    if (message.type() === "error" && message.text().includes("[Popcorn]")) {
-      consoleErrors.push(message.text());
-    }
-  };
-  page.on("console", onConsole);
+  assert(boot.ok);
+  await otp.waitForEvent("ready");
 
-  const result = await withPopcorn(
-    page,
-    {
-      beam: {
-        assetsUrl: "/otp-assets",
-      },
-    },
-    { settleMs: 250 },
-    async ({ popcorn, settleMs }) => {
-      await new Promise((resolve) => setTimeout(resolve, settleMs));
-      const sendResult = popcorn.send("missing-listener", { ping: true });
-      await new Promise((resolve) => setTimeout(resolve, settleMs));
+  const send = await otp.send("missing-listener", { ping: true });
+  const consoleMessage = await otp.waitForStderr("send failed");
 
-      return {
-        send: sendResult.ok
-          ? { ok: true }
-          : { ok: false, error: sendResult.error.serialize() },
-      };
-    },
-  );
-  page.off("console", onConsole);
-
-  assert(result.ok);
-  assert(result.data.send.ok);
-  const sendErrors = consoleErrors.join("\n");
-  expect(sendErrors).toContain("send failed");
-  expect(sendErrors).toContain("Target listener not found");
-  expect(sendErrors).toContain("missing-listener");
+  assert(send.ok);
+  expect(consoleMessage.text()).toContain("send failed");
+  expect(consoleMessage.text()).toContain("Target listener not found");
+  expect(consoleMessage.text()).toContain("missing-listener");
 });

--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -17,7 +17,17 @@ const BRIDGE_BOOT_EVAL = [
   "end).",
 ].join(" ");
 
-const WASM_LOAD_EVAL = "code:ensure_loaded(wasm).";
+const SEND_TO_JS_BOOT_EVAL = [
+  "spawn(fun() ->",
+  "  ok = wasm:register_listener(direct_sender),",
+  "  receive",
+  "    {wasm, _PayloadJson, _MetaJson} ->",
+  "      ok = wasm:send(#{direct => true, nested => #{count => 1}})",
+  "  end",
+  "end).",
+].join(" ");
+
+test.describe.configure({ mode: "serial" });
 
 test("boots with the packaged OTP assets through Popcorn.init", async ({
   page,
@@ -139,6 +149,59 @@ test("round-trips through the native bridge when a wasm listener is registered",
   });
 });
 
+test("emits wasm:send envelopes as Popcorn events", async ({ page }) => {
+  const result = await withPopcorn(
+    page,
+    {
+      beam: {
+        assetsUrl: "/otp-assets",
+        extraArgs: ["-eval", SEND_TO_JS_BOOT_EVAL],
+      },
+    },
+    { settleMs: 250 },
+    async ({ popcorn, settleMs }) => {
+      const events: Array<PopcornEvent> = [];
+      const unsubscribe = popcorn.onEvent((event) => {
+        events.push(event);
+      });
+
+      let sendResult = popcorn.send("direct_sender");
+
+      for (let attempt = 0; attempt < 8; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, settleMs));
+
+        if (
+          events.some(
+            (event) =>
+              typeof event === "object" &&
+              event !== null &&
+              "direct" in event,
+          )
+        ) {
+          break;
+        }
+
+        sendResult = popcorn.send("direct_sender");
+      }
+
+      unsubscribe();
+      return {
+        send: sendResult.ok
+          ? { ok: true }
+          : { ok: false, error: sendResult.error.serialize() },
+        events,
+      };
+    },
+  );
+
+  assert(result.ok);
+  assert(result.data.send.ok);
+  expect(result.data.events).toContainEqual({
+    direct: true,
+    nested: { count: 1 },
+  });
+});
+
 test("surfaces listener lookup failures from popcorn.send", async ({ page }) => {
   const consoleErrors: string[] = [];
   const onConsole = (message: { type: () => string; text: () => string }) => {
@@ -153,7 +216,6 @@ test("surfaces listener lookup failures from popcorn.send", async ({ page }) => 
     {
       beam: {
         assetsUrl: "/otp-assets",
-        extraArgs: ["-eval", WASM_LOAD_EVAL],
       },
     },
     { settleMs: 250 },
@@ -173,7 +235,8 @@ test("surfaces listener lookup failures from popcorn.send", async ({ page }) => 
 
   assert(result.ok);
   assert(result.data.send.ok);
-  expect(consoleErrors.some((text) => text.includes("listener_not_found"))).toBe(
-    true,
-  );
+  const sendErrors = consoleErrors.join("\n");
+  expect(sendErrors).toContain("send failed");
+  expect(sendErrors).toContain("Target listener not found");
+  expect(sendErrors).toContain("missing-listener");
 });

--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -83,12 +83,8 @@ test("round-trips through the native bridge when a wasm listener is registered",
     },
     { settleMs: 250 },
     async ({ popcorn, settleMs }) => {
-      const messages: unknown[] = [];
       const events: Array<PopcornEvent> = [];
-      const unsubscribe = popcorn.onMessage((message) => {
-        messages.push(message);
-      });
-      const unsubscribeEvents = popcorn.onEvent((event) => {
+      const unsubscribe = popcorn.onEvent((event) => {
         events.push(event);
       });
 
@@ -100,11 +96,11 @@ test("round-trips through the native bridge when a wasm listener is registered",
         await new Promise((resolve) => setTimeout(resolve, settleMs));
 
         if (
-          messages.some(
-            (message) =>
-              typeof message === "object" &&
-              message !== null &&
-              "reply" in message,
+          events.some(
+            (event) =>
+              typeof event === "object" &&
+              event !== null &&
+              "reply" in event,
           )
         ) {
           break;
@@ -116,12 +112,10 @@ test("round-trips through the native bridge when a wasm listener is registered",
       }
 
       unsubscribe();
-      unsubscribeEvents();
       return {
         send: sendResult.ok
           ? { ok: true }
           : { ok: false, error: sendResult.error.serialize() },
-        messages,
         events,
       };
     },
@@ -130,24 +124,30 @@ test("round-trips through the native bridge when a wasm listener is registered",
   assert(result.ok);
   assert(result.data.send.ok);
   if (
-    !result.data.messages.some(
-      (message) =>
-        typeof message === "object" &&
-        message !== null &&
-        "reply" in message,
+    !result.data.events.some(
+      (event) =>
+        typeof event === "object" &&
+        event !== null &&
+        "reply" in event,
     )
   ) {
-    throw new Error(
-      `No bridge reply received. Events: ${JSON.stringify(result.data.events)}`,
-    );
+    throw new Error(`No bridge reply received: ${JSON.stringify(result.data.events)}`);
   }
-  expect(result.data.messages).toContainEqual({
+  expect(result.data.events).toContainEqual({
     reply: { ping: true },
     meta: { requestId: "req-1" },
   });
 });
 
 test("surfaces listener lookup failures from popcorn.send", async ({ page }) => {
+  const consoleErrors: string[] = [];
+  const onConsole = (message: { type: () => string; text: () => string }) => {
+    if (message.type() === "error" && message.text().includes("[Popcorn]")) {
+      consoleErrors.push(message.text());
+    }
+  };
+  page.on("console", onConsole);
+
   const result = await withPopcorn(
     page,
     {
@@ -158,30 +158,22 @@ test("surfaces listener lookup failures from popcorn.send", async ({ page }) => 
     },
     { settleMs: 250 },
     async ({ popcorn, settleMs }) => {
-      const events: Array<PopcornEvent> = [];
-      const unsubscribe = popcorn.onEvent((event) => {
-        events.push(event);
-      });
-
       await new Promise((resolve) => setTimeout(resolve, settleMs));
       const sendResult = popcorn.send("missing-listener", { ping: true });
       await new Promise((resolve) => setTimeout(resolve, settleMs));
 
-      unsubscribe();
       return {
         send: sendResult.ok
           ? { ok: true }
           : { ok: false, error: sendResult.error.serialize() },
-        events,
       };
     },
   );
+  page.off("console", onConsole);
 
   assert(result.ok);
   assert(result.data.send.ok);
-  expect(result.data.events).toContainEqual({
-    type: "otp:error",
-    payload:
-      '{"type":"listener_not_found","detail":"target listener is not registered"}',
-  });
+  expect(consoleErrors.some((text) => text.includes("listener_not_found"))).toBe(
+    true,
+  );
 });

--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -32,7 +32,7 @@ test("handles missing boot script", async ({ otp }) => {
   });
 });
 
-test("reports runtime errors through onError", async ({ page }) => {
+test("failures on boot aren't sent to onEvent()", async ({ page }) => {
   const result = await page.evaluate(async () => {
     const errors: unknown[] = [];
     const popcorn = new window.Popcorn({
@@ -49,10 +49,7 @@ test("reports runtime errors through onError", async ({ page }) => {
     };
   });
 
-  expect(result.errors).toContainEqual({
-    kind: "abort",
-    data: "Missing boot script: '/otp-assets/missing/bin/vm.boot'",
-  });
+  expect(result.errors).toEqual([]);
   expect(result.boot).toEqual({
     ok: false,
     error: {
@@ -62,21 +59,107 @@ test("reports runtime errors through onError", async ({ page }) => {
   });
 });
 
-test("does not allow boot after deinit", async ({ page }) => {
+test("can reboot after deinit", async ({ page }) => {
   const result = await page.evaluate(async () => {
     const popcorn = new window.Popcorn({ beam: { assetsUrl: "/otp-assets" } });
+    type BootResult = Awaited<ReturnType<typeof popcorn.boot>>;
+
+    const first = await popcorn.boot();
+    popcorn.deinit();
+    const second = await popcorn.boot();
     popcorn.deinit();
 
-    const boot = await popcorn.boot();
-    return boot.ok
-      ? { ok: true, data: null }
-      : { ok: false, error: boot.error.serialize() };
+    const serialize = (boot: BootResult) => {
+      if (boot.ok) return { ok: true as const, data: null };
+      return { ok: false as const, error: boot.error.serialize() };
+    };
+
+    return { first: serialize(first), second: serialize(second) };
   });
 
-  expect(result).toEqual({
-    ok: false,
-    error: { t: "vm:exited", data: { reason: "deinit" } },
+  expect(result.first).toEqual({ ok: true, data: null });
+  expect(result.second).toEqual({ ok: true, data: null });
+});
+
+test("event hooks preserved after a reboot", async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const READY_BOOT_EVAL = "ok = wasm:send(#{ready => true}).";
+    const opts = {
+      beam: {
+        assetsUrl: "/otp-assets",
+        extraArgs: ["-eval", READY_BOOT_EVAL],
+      },
+    };
+    const hasReadyField = (event: unknown) =>
+      typeof event === "object" &&
+      event !== null &&
+      Object.hasOwn(event, "ready");
+
+    const events: unknown[] = [];
+    let onReady: (() => void) | null = null;
+    const popcorn = new window.Popcorn(opts);
+    popcorn.onEvent((event) => {
+      events.push(event);
+      if (onReady && hasReadyField(event)) {
+        onReady();
+        onReady = null;
+      }
+    });
+
+    const waitForReady = () =>
+      new Promise<void>((resolve) => {
+        if (events.some(hasReadyField)) {
+          resolve();
+          return;
+        }
+        onReady = resolve;
+      });
+
+    await popcorn.boot();
+    await waitForReady();
+    const afterFirstBoot = events.length;
+
+    popcorn.deinit();
+    events.length = 0;
+
+    await popcorn.boot();
+    await waitForReady();
+    popcorn.deinit();
+
+    return { afterFirstBoot, afterReboot: events.length };
   });
+
+  expect(result.afterFirstBoot).toBeGreaterThan(0);
+  expect(result.afterReboot).toBeGreaterThan(0);
+});
+
+test("failing boot fails fast (no timeout)", async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const popcorn = new window.Popcorn({
+      beam: { assetsUrl: "/otp-assets" },
+      workerUrl: "/fault-worker.mjs",
+      timeoutsMs: { boot: 30_000 },
+    });
+
+    const startMs = performance.now();
+    const boot = await popcorn.boot();
+    const elapsedMs = performance.now() - startMs;
+    popcorn.deinit();
+
+    return {
+      elapsedMs,
+      boot: boot.ok
+        ? { ok: true, data: null }
+        : { ok: false, error: boot.error.serialize() },
+    };
+  });
+
+  expect(result.boot).toEqual({
+    ok: false,
+    error: { t: "vm:exited", data: { reason: "abort", data: "boom" } },
+  });
+  // should be less than boot timeoutMs
+  expect(result.elapsedMs).toBeLessThan(5_000);
 });
 
 test("handles events in both directions", async ({ otp }) => {
@@ -143,5 +226,19 @@ test("popcorn.send() reports unregistered process", async ({ otp }) => {
       t: "bridge:listener-not-found",
       data: { targetName: "missing-listener" },
     },
+  });
+});
+
+test("reports timeouts on send", async ({ otp }) => {
+  const boot = await otp.boot({
+    beam: { assetsUrl: "/otp-assets" },
+    timeoutsMs: { send: 0 },
+  });
+  assert(boot.ok);
+
+  const send = await otp.send("any-target", { ping: true });
+  expect(send).toEqual({
+    ok: false,
+    error: { t: "timeout:send", data: { timeoutMs: 0 } },
   });
 });

--- a/otp/js/e2e/setup/fault-worker.mjs
+++ b/otp/js/e2e/setup/fault-worker.mjs
@@ -1,0 +1,13 @@
+// Test double for the VM worker. On boot it emits an otp:error and then goes
+// silent — never sending popcorn:boot-end or popcorn:boot-fail — to reproduce a
+// runtime fault that occurs mid-boot. This exercises Popcorn's path where the
+// boot must be failed by the error itself rather than stalling to its timeout.
+self.onmessage = (event) => {
+  const data = event.data;
+  if (data && data.type === "popcorn:boot") {
+    self.postMessage({
+      type: "otp:error",
+      payload: { kind: "abort", data: "boom" },
+    });
+  }
+};

--- a/otp/js/e2e/tsconfig.json
+++ b/otp/js/e2e/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noUnusedLocals": true,
+    "lib": ["es2023", "DOM"],
+    "types": ["node"],
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@swmansion/popcorn-otp": ["../src/index.ts"]
+    }
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["../node_modules", "../dist"]
+}

--- a/otp/js/package.json
+++ b/otp/js/package.json
@@ -26,6 +26,7 @@
     "setup": "./scripts/setup-assets.sh",
     "build": "pnpm run setup && rollup -c && ./scripts/setup-assets.sh dist",
     "lint": "tsc --noEmit",
+    "lint:e2e": "tsc -p e2e/tsconfig.json",
     "e2e": "env -u FORCE_COLOR -u NO_COLOR playwright test --config e2e/playwright.config.ts"
   },
   "devDependencies": {

--- a/otp/js/package.json
+++ b/otp/js/package.json
@@ -26,7 +26,7 @@
     "setup": "./scripts/setup-assets.sh",
     "build": "pnpm run setup && rollup -c && ./scripts/setup-assets.sh dist",
     "lint": "tsc --noEmit",
-    "e2e": "playwright test --config e2e/playwright.config.ts"
+    "e2e": "env -u FORCE_COLOR -u NO_COLOR playwright test --config e2e/playwright.config.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/otp/js/package.json
+++ b/otp/js/package.json
@@ -30,7 +30,7 @@
     "e2e": "env -u FORCE_COLOR -u NO_COLOR playwright test --config e2e/playwright.config.ts"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.60.0",
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/node": "catalog:",
     "rollup": "^4.55.1",

--- a/otp/js/rollup.config.mjs
+++ b/otp/js/rollup.config.mjs
@@ -15,6 +15,7 @@ export default [
       preserveModulesRoot: "src",
     },
     cache: false,
+    external: (id) => id.startsWith("node:"),
     plugins: [
       typescript({ tsconfig: "./tsconfig.json", outputToFilesystem: true }),
     ],

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -1,7 +1,11 @@
 import { PopcornError, err, isErr, type Result } from "./errors";
 import { deserializeBridgeMessage } from "./events";
 import { extractTar } from "./tar";
-import type { BeamBootOptions, EmscriptenModule } from "./types";
+import type {
+  BeamBootOptions,
+  BeamSendPayload,
+  EmscriptenModule,
+} from "./types";
 import {
   check,
   decompressGzip,
@@ -18,6 +22,7 @@ const FS_DIRS = ["/bin", "/lib", "/etc", "/tmp", "/home", DEFAULT_HOME_DIR];
 const BOOT_NAME = "vm";
 const BOOT_PATH = `/bin/${BOOT_NAME}.boot`;
 const MANIFEST_PATH = "/lib/tarballs.json";
+const UTF8 = new TextEncoder();
 const BASE_ARGS = [
   "--",
   "-root",
@@ -194,18 +199,28 @@ async function maybeDecompressTar(tar: Uint8Array): Promise<Uint8Array> {
 
 export function send(
   module: EmscriptenModule | null,
-  command: string,
+  message: BeamSendPayload,
 ): Result<null> {
   if (module === null) {
     return { ok: false, error: err("bridge:not-started", {}) };
   }
 
-  const byteLength = new TextEncoder().encode(command).length;
   module.ccall(
     "sendVmMessage",
     null,
-    ["string", "number"],
-    [command, byteLength],
+    ["string", "number", "string", "number", "string", "number"],
+    [
+      message.targetName,
+      utf8Length(message.targetName),
+      message.payloadJson,
+      utf8Length(message.payloadJson),
+      message.metaJson,
+      utf8Length(message.metaJson),
+    ],
   );
   return { ok: true, data: null };
+}
+
+function utf8Length(text: string): number {
+  return UTF8.encode(text).length;
 }

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -51,7 +51,10 @@ export async function boot({
       emit({ type: "otp:message", payload: deserializeBridgeMessage(text) });
     },
     onError: (text) => emit({ type: "otp:error", payload: text }),
-    arguments: buildArgs({ searchPaths, extra: extraArgs }),
+    arguments: buildArgs({
+      searchPaths: searchPaths ?? [],
+      extra: extraArgs ?? [],
+    }),
     ENV: {
       BINDIR: "/bin",
       EMU: "beam",

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -53,7 +53,10 @@ export async function boot({
     onExit: (code) => emit({ type: "otp:exit", payload: code }),
     onAbort: (text) => emit({ type: "otp:abort", payload: text }),
     onBeamMessage: (text) => {
-      emit({ type: "otp:message", payload: deserializeBridgeMessage(text) });
+      const event = deserializeBridgeMessage(text);
+      if (event !== null) {
+        emit(event);
+      }
     },
     onError: (text) => emit({ type: "otp:error", payload: text }),
     arguments: buildArgs({
@@ -205,9 +208,9 @@ export function send(
     return { ok: false, error: err("bridge:not-started", {}) };
   }
 
-  module.ccall(
+  const status = module.ccall(
     "sendVmMessage",
-    null,
+    "number",
     ["string", "number", "string", "number", "string", "number"],
     [
       message.targetName,
@@ -218,7 +221,26 @@ export function send(
       utf8Length(message.metaJson),
     ],
   );
-  return { ok: true, data: null };
+
+  if (status === 0) {
+    return { ok: true, data: null };
+  }
+
+  if (status === 1) {
+    return {
+      ok: false,
+      error: err("bridge:listener-not-found", {
+        targetName: message.targetName,
+      }),
+    };
+  }
+
+  return {
+    ok: false,
+    error: err("internal:check", {
+      detail: `Unexpected sendVmMessage status: ${String(status)}`,
+    }),
+  };
 }
 
 function utf8Length(text: string): number {

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -50,15 +50,18 @@ export async function boot({
   const moduleConfig: Partial<EmscriptenModule> = {
     print: (text) => emit({ type: "otp:stdout", payload: text }),
     printErr: (text) => emit({ type: "otp:stderr", payload: text }),
-    onExit: (code) => emit({ type: "otp:exit", payload: code }),
-    onAbort: (text) => emit({ type: "otp:abort", payload: text }),
+    onExit: (code) =>
+      emit({ type: "otp:error", payload: { kind: "exit", data: code } }),
+    onAbort: (text) =>
+      emit({ type: "otp:error", payload: { kind: "abort", data: text } }),
     onBeamMessage: (text) => {
       const event = deserializeBridgeMessage(text);
       if (event !== null) {
         emit(event);
       }
     },
-    onError: (text) => emit({ type: "otp:error", payload: text }),
+    onError: (text) =>
+      emit({ type: "otp:error", payload: { kind: "error", data: text } }),
     arguments: buildArgs({
       searchPaths: searchPaths ?? [],
       extra: extraArgs ?? [],
@@ -79,7 +82,10 @@ export async function boot({
           } catch (error) {
             check(error instanceof PopcornError);
             initError = error;
-            emit({ type: "otp:abort", payload: error.message });
+            emit({
+              type: "otp:error",
+              payload: { kind: "abort", data: error.message },
+            });
           } finally {
             mod.removeRunDependency("fs");
           }

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -7,7 +7,6 @@ import type {
   EmscriptenModule,
 } from "./types";
 import {
-  check,
   decompressGzip,
   dirname,
   ensureDir,
@@ -80,12 +79,7 @@ export async function boot({
           try {
             await initFs({ module: mod, assetsUrl });
           } catch (error) {
-            check(error instanceof PopcornError);
-            initError = error;
-            emit({
-              type: "otp:error",
-              payload: { kind: "abort", data: error.message },
-            });
+            initError = toPopcornError(error);
           } finally {
             mod.removeRunDependency("fs");
           }
@@ -99,9 +93,14 @@ export async function boot({
     if (initError !== null) return { ok: false, error: initError };
     return { ok: true, data: module };
   } catch (error) {
-    check(isErr(error));
-    return { ok: false, error };
+    return { ok: false, error: toPopcornError(error) };
   }
+}
+
+function toPopcornError(error: unknown): PopcornError {
+  if (isErr(error)) return error;
+  const message = error instanceof Error ? error.message : String(error);
+  return err("worker:load", { message });
 }
 
 type BuildArgsArgs = {

--- a/otp/js/src/errors.ts
+++ b/otp/js/src/errors.ts
@@ -6,6 +6,7 @@ type Tag = keyof PopcornErrors;
 export type PopcornErrors = {
   "timeout:init": { timeoutMs: number };
   "worker:load": { message: string };
+  "vm:exited": VmExitedData;
   "bridge:not-started": EmptyData;
   "bridge:invalid-target": EmptyData;
   "bridge:unserializable": EmptyData;
@@ -22,6 +23,11 @@ export type SerializedError<T extends Tag = Tag> = {
 }[T];
 
 type EmptyData = Record<never, never>;
+type VmExitedData =
+  | { reason: "deinit" }
+  | { reason: "abort"; data: string }
+  | { reason: "error"; data: string }
+  | { reason: "exit"; data: number };
 
 export function err<T extends Tag>(
   t: T,
@@ -79,6 +85,8 @@ function message(error: SerializedError): string {
       return `Init timed out after ${error.data.timeoutMs}ms`;
     case "worker:load":
       return error.data.message;
+    case "vm:exited":
+      return "VM exited";
     case "bridge:not-started":
       return "Bridge did not start";
     case "bridge:invalid-target":
@@ -100,7 +108,7 @@ function message(error: SerializedError): string {
     case "internal:unreachable":
       return "Entered unreachable code";
     default:
-      return unreachable();
+      unreachable();
   }
 }
 
@@ -112,6 +120,9 @@ function parse(value: unknown): SerializedError {
       return { t: value.t, data: value.data };
     case "worker:load":
       check(isWorkerLoadData(value.data));
+      return { t: value.t, data: value.data };
+    case "vm:exited":
+      check(isVmExitedData(value.data));
       return { t: value.t, data: value.data };
     case "bridge:not-started":
       check(isEmptyData(value.data));
@@ -139,7 +150,7 @@ function parse(value: unknown): SerializedError {
       check(isEmptyData(value.data));
       return { t: value.t, data: value.data };
     default:
-      return unreachable();
+      unreachable();
   }
 }
 
@@ -153,6 +164,10 @@ function isWorkerLoadData(
   value: unknown,
 ): value is PopcornErrors["worker:load"] {
   return objectWithKeys(value, ["message"]) !== null;
+}
+
+function isVmExitedData(value: unknown): value is PopcornErrors["vm:exited"] {
+  return objectWithKeys(value, ["reason"]) !== null;
 }
 
 function isListenerNotFoundData(

--- a/otp/js/src/errors.ts
+++ b/otp/js/src/errors.ts
@@ -9,6 +9,7 @@ export type PopcornErrors = {
   "bridge:not-started": EmptyData;
   "bridge:invalid-target": EmptyData;
   "bridge:unserializable": EmptyData;
+  "bridge:listener-not-found": { targetName: string };
   "beam:missing-boot-script": { url: string };
   "beam:missing-manifest": { url: string };
   "beam:missing-tarball": { name: string; all: string[] };
@@ -84,6 +85,8 @@ function message(error: SerializedError): string {
       return "Target name must not be empty";
     case "bridge:unserializable":
       return "Message can't be serialized to string";
+    case "bridge:listener-not-found":
+      return `Target listener not found: '${error.data.targetName}'`;
     case "beam:missing-boot-script":
       return `Missing boot script: '${error.data.url}'`;
     case "beam:missing-manifest":
@@ -119,6 +122,9 @@ function parse(value: unknown): SerializedError {
     case "bridge:unserializable":
       check(isEmptyData(value.data));
       return { t: value.t, data: value.data };
+    case "bridge:listener-not-found":
+      check(isListenerNotFoundData(value.data));
+      return { t: value.t, data: value.data };
     case "beam:missing-boot-script":
     case "beam:missing-manifest":
       check(isUrlData(value.data));
@@ -147,6 +153,12 @@ function isWorkerLoadData(
   value: unknown,
 ): value is PopcornErrors["worker:load"] {
   return objectWithKeys(value, ["message"]) !== null;
+}
+
+function isListenerNotFoundData(
+  value: unknown,
+): value is PopcornErrors["bridge:listener-not-found"] {
+  return objectWithKeys(value, ["targetName"]) !== null;
 }
 
 function isUrlData(

--- a/otp/js/src/errors.ts
+++ b/otp/js/src/errors.ts
@@ -5,6 +5,7 @@ export type Result<T, E extends Tag = Tag> =
 type Tag = keyof PopcornErrors;
 export type PopcornErrors = {
   "timeout:init": { timeoutMs: number };
+  "timeout:send": { timeoutMs: number };
   "worker:load": { message: string };
   "vm:exited": VmExitedData;
   "bridge:not-started": EmptyData;
@@ -83,6 +84,8 @@ function message(error: SerializedError): string {
   switch (error.t) {
     case "timeout:init":
       return `Init timed out after ${error.data.timeoutMs}ms`;
+    case "timeout:send":
+      return `Send timed out after ${error.data.timeoutMs}ms`;
     case "worker:load":
       return error.data.message;
     case "vm:exited":
@@ -116,7 +119,8 @@ function parse(value: unknown): SerializedError {
   check(objectWithKeys(value, ["t", "data"]));
   switch (value.t) {
     case "timeout:init":
-      check(isTimeoutInitData(value.data));
+    case "timeout:send":
+      check(isTimeoutData(value.data));
       return { t: value.t, data: value.data };
     case "worker:load":
       check(isWorkerLoadData(value.data));
@@ -154,7 +158,7 @@ function parse(value: unknown): SerializedError {
   }
 }
 
-function isTimeoutInitData(
+function isTimeoutData(
   value: unknown,
 ): value is PopcornErrors["timeout:init"] {
   return objectWithKeys(value, ["timeoutMs"]) !== null;

--- a/otp/js/src/errors.ts
+++ b/otp/js/src/errors.ts
@@ -7,6 +7,7 @@ export type PopcornErrors = {
   "timeout:init": { timeoutMs: number };
   "worker:load": { message: string };
   "bridge:not-started": EmptyData;
+  "bridge:invalid-target": EmptyData;
   "bridge:unserializable": EmptyData;
   "beam:missing-boot-script": { url: string };
   "beam:missing-manifest": { url: string };
@@ -79,6 +80,8 @@ function message(error: SerializedError): string {
       return error.data.message;
     case "bridge:not-started":
       return "Bridge did not start";
+    case "bridge:invalid-target":
+      return "Target name must not be empty";
     case "bridge:unserializable":
       return "Message can't be serialized to string";
     case "beam:missing-boot-script":
@@ -108,6 +111,9 @@ function parse(value: unknown): SerializedError {
       check(isWorkerLoadData(value.data));
       return { t: value.t, data: value.data };
     case "bridge:not-started":
+      check(isEmptyData(value.data));
+      return { t: value.t, data: value.data };
+    case "bridge:invalid-target":
       check(isEmptyData(value.data));
       return { t: value.t, data: value.data };
     case "bridge:unserializable":

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -34,10 +34,15 @@ type RuntimeEvent = BeamEvent | SendFailEvent;
 
 export type VmToMainEvent = RuntimeEvent | BootEndEvent;
 
-type BridgeEnvelope = {
-  type: "vm_message";
-  data?: AnyValue;
-};
+type BridgeEnvelope =
+  | {
+      type: "vm_message";
+      data?: AnyValue;
+    }
+  | {
+      type: "vm_error";
+      data?: unknown;
+    };
 
 export function readMainEvent(value: unknown): MainToVmEvent | null {
   const data = objectWithKeys(value, ["type", "payload"]);
@@ -100,11 +105,25 @@ export function serializeSendPayload(
   }
 }
 
-export function deserializeBridgeMessage(text: string): AnyValue | null {
+export function deserializeBridgeMessage(
+  text: string,
+): Extract<BeamEvent, { type: "otp:message" | "otp:error" }> | null {
   try {
     const parsed = JSON.parse(text) as unknown;
     if (!isBridgeEnvelope(parsed)) return null;
-    return parsed.data;
+
+    switch (parsed.type) {
+      case "vm_message":
+        return { type: "otp:message", payload: parsed.data };
+      case "vm_error":
+        return {
+          type: "otp:error",
+          payload:
+            typeof parsed.data === "string" ? parsed.data : "unknown_vm_error",
+        };
+      default:
+        return null;
+    }
   } catch {
     return null;
   }
@@ -122,7 +141,10 @@ export function toMain(event: VmToMainEvent): void {
 
 function isBridgeEnvelope(value: unknown): value is BridgeEnvelope {
   const data = objectWithKeys(value, ["type"]);
-  return data !== null && data.type === "vm_message";
+  return (
+    data !== null &&
+    (data.type === "vm_message" || data.type === "vm_error")
+  );
 }
 
 function serializeJson(value: AnyValue): string {

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -1,5 +1,10 @@
 import { err, type Result, type SerializedError } from "./errors";
-import type { AnyValue, BeamBootOptions, BeamEvent, BeamTarget } from "./types";
+import type {
+  AnyValue,
+  BeamBootOptions,
+  BeamEvent,
+  BeamSendPayload,
+} from "./types";
 import { objectWithKeys } from "./utils";
 
 type BootEvent = {
@@ -9,9 +14,7 @@ type BootEvent = {
 
 type SendEvent = {
   type: "popcorn:send";
-  payload: {
-    command: string;
-  };
+  payload: BeamSendPayload;
 };
 
 type BootEndEvent =
@@ -25,9 +28,11 @@ type SendFailEvent = {
 
 export type MainToVmEvent = BootEvent | SendEvent;
 
-export type PopcornEvent = BeamEvent | SendFailEvent;
+export type PopcornEvent = AnyValue;
 
-export type VmToMainEvent = PopcornEvent | BootEndEvent;
+type RuntimeEvent = BeamEvent | SendFailEvent;
+
+export type VmToMainEvent = RuntimeEvent | BootEndEvent;
 
 type BridgeEnvelope = {
   type: "vm_message";
@@ -71,23 +76,26 @@ export function readWorkerEvent(value: unknown): VmToMainEvent | null {
   }
 }
 
-export function serializeSendCommand(
-  target: BeamTarget,
+export function serializeSendPayload(
+  targetName: string,
   payload: AnyValue,
   meta: AnyValue,
-): Result<string> {
+): Result<BeamSendPayload> {
+  if (targetName.length === 0) {
+    return { ok: false, error: err("bridge:invalid-target", {}) };
+  }
+
   try {
     return {
       ok: true,
-      data: JSON.stringify({
-        type: "send",
-        target: target,
-        payload: payload,
-        meta: meta,
-      }),
+      data: {
+        targetName,
+        payloadJson: serializeJson(payload),
+        metaJson: serializeJson(meta),
+      },
     };
   } catch {
-    const error = err("bridge:unserializable", { message: payload });
+    const error = err("bridge:unserializable", {});
     return { ok: false, error };
   }
 }
@@ -115,4 +123,9 @@ export function toMain(event: VmToMainEvent): void {
 function isBridgeEnvelope(value: unknown): value is BridgeEnvelope {
   const data = objectWithKeys(value, ["type"]);
   return data !== null && data.type === "vm_message";
+}
+
+function serializeJson(value: AnyValue): string {
+  const serialized = JSON.stringify(value);
+  return serialized === undefined ? "null" : serialized;
 }

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -55,7 +55,7 @@ type BridgeEnvelope =
     }
   | {
       type: "vm_error";
-      data?: unknown;
+      data: string;
     };
 
 export function readMainEvent(value: unknown): MainToVmEvent | null {
@@ -82,9 +82,7 @@ export function readWorkerEvent(value: unknown): VmToMainEvent | null {
   switch (data.type) {
     case "otp:stdout":
     case "otp:stderr":
-    case "otp:abort":
     case "otp:error":
-    case "otp:exit":
     case "otp:message":
     case "popcorn:boot-end":
     case "popcorn:boot-fail":
@@ -132,8 +130,10 @@ export function deserializeBridgeMessage(
       case "vm_error":
         return {
           type: "otp:error",
-          payload:
-            typeof parsed.data === "string" ? parsed.data : "unknown_vm_error",
+          payload: {
+            kind: "error",
+            data: parsed.data,
+          },
         };
       default:
         return null;

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -14,23 +14,37 @@ type BootEvent = {
 
 type SendEvent = {
   type: "popcorn:send";
-  payload: BeamSendPayload;
+  payload: SendRequestPayload;
+};
+
+export type SendRequestPayload = {
+  id: string;
+  message: BeamSendPayload;
+};
+
+export type SerializedSendResult =
+  | { ok: true; data: null }
+  | { ok: false; error: SerializedError };
+
+export type SendCompletionPayload = {
+  id: string;
+  result: SerializedSendResult;
+};
+
+type SendEndEvent = {
+  type: "popcorn:send-end";
+  payload: SendCompletionPayload;
 };
 
 type BootEndEvent =
   | { type: "popcorn:boot-end"; payload: {} }
   | { type: "popcorn:boot-fail"; payload: SerializedError };
 
-type SendFailEvent = {
-  type: "popcorn:send-fail";
-  payload: SerializedError;
-};
-
 export type MainToVmEvent = BootEvent | SendEvent;
 
 export type PopcornEvent = AnyValue;
 
-type RuntimeEvent = BeamEvent | SendFailEvent;
+type RuntimeEvent = BeamEvent | SendEndEvent;
 
 export type VmToMainEvent = RuntimeEvent | BootEndEvent;
 
@@ -74,7 +88,7 @@ export function readWorkerEvent(value: unknown): VmToMainEvent | null {
     case "otp:message":
     case "popcorn:boot-end":
     case "popcorn:boot-fail":
-    case "popcorn:send-fail":
+    case "popcorn:send-end":
       return data as VmToMainEvent;
     default:
       return null;

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -4,7 +4,7 @@ import { objectWithKeys } from "./utils";
 
 type BootEvent = {
   type: "popcorn:boot";
-  payload: Pick<BeamBootOptions, "assetsUrl">;
+  payload: Pick<BeamBootOptions, "assetsUrl" | "searchPaths" | "extraArgs">;
 };
 
 type SendEvent = {

--- a/otp/js/src/index.ts
+++ b/otp/js/src/index.ts
@@ -3,5 +3,10 @@ export { PopcornError } from "./errors";
 export { Popcorn } from "./popcorn";
 export type { PopcornOpts, PopcornSendOpts } from "./popcorn";
 export type { PopcornEvent } from "./events";
-export type { BeamBootOptions, BeamEvent, BeamTarget } from "./types";
+export type {
+  BeamBootOptions,
+  BeamEvent,
+  BeamTarget,
+  OtpErrorPayload,
+} from "./types";
 export type { PopcornErrors, SerializedError } from "./errors";

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -1,7 +1,7 @@
 import { PopcornError, err, type Result } from "./errors";
 import {
   readWorkerEvent,
-  serializeSendCommand,
+  serializeSendPayload,
   toVm,
   type PopcornEvent,
 } from "./events";
@@ -24,13 +24,12 @@ const DEFAULT_TIMEOUTS_MS: ResolvedTimeouts = {
   boot: 10_000,
 };
 
-type MessageHandler = (message: AnyValue) => void;
+const LOG_PREFIX = "[Popcorn]";
 
 export class Popcorn {
   private vmWorker: Worker;
   private isBooted = false;
   private readonly eventHandlers = new Set<(event: PopcornEvent) => void>();
-  private readonly messageHandlers = new Set<MessageHandler>();
   private readonly onWorkerMessage = (event: MessageEvent<unknown>) => {
     const data = readWorkerEvent(event.data);
     check(data !== null);
@@ -40,11 +39,28 @@ export class Popcorn {
       case "popcorn:boot-fail":
         return;
       case "otp:message":
-        this.emit(data);
-        this.emitMessage(data.payload);
+        this.emit(data.payload);
         return;
-      default:
-        this.emit(data);
+      case "otp:stdout":
+        console.log(`${LOG_PREFIX} stdout:`, data.payload);
+        return;
+      case "otp:stderr":
+        console.error(`${LOG_PREFIX} stderr:`, data.payload);
+        return;
+      case "otp:abort":
+        console.error(`${LOG_PREFIX} abort:`, data.payload);
+        return;
+      case "otp:error":
+        console.error(`${LOG_PREFIX} error:`, data.payload);
+        return;
+      case "otp:exit":
+        console.info(`${LOG_PREFIX} exit:`, data.payload);
+        return;
+      case "popcorn:send-fail":
+        console.error(
+          `${LOG_PREFIX} send failed:`,
+          PopcornError.deserialize(data.payload),
+        );
         return;
     }
   };
@@ -121,8 +137,8 @@ export class Popcorn {
       return { ok: false, error: err("bridge:not-started", {}) };
     }
 
-    const command = serializeSendCommand(
-      { name: target },
+    const command = serializeSendPayload(
+      target,
       payload ?? {},
       opts?.meta ?? {},
     );
@@ -132,7 +148,7 @@ export class Popcorn {
 
     toVm(this.vmWorker, {
       type: "popcorn:send",
-      payload: { command: command.data },
+      payload: command.data,
     });
     return { ok: true, data: null };
   }
@@ -144,30 +160,16 @@ export class Popcorn {
     };
   }
 
-  public onMessage(handler: MessageHandler): () => void {
-    this.messageHandlers.add(handler);
-    return () => {
-      this.messageHandlers.delete(handler);
-    };
-  }
-
   public deinit(): void {
     this.isBooted = false;
     this.vmWorker.removeEventListener("message", this.onWorkerMessage);
     this.eventHandlers.clear();
-    this.messageHandlers.clear();
     this.vmWorker.terminate();
   }
 
   private emit(event: PopcornEvent): void {
     for (const handler of this.eventHandlers) {
       handler(event);
-    }
-  }
-
-  private emitMessage(message: AnyValue): void {
-    for (const handler of this.messageHandlers) {
-      handler(message);
     }
   }
 }

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -26,9 +26,12 @@ const DEFAULT_TIMEOUTS_MS: ResolvedTimeouts = {
 
 const LOG_PREFIX = "[Popcorn]";
 
+type PopcornState = "created" | "booting" | "booted";
+
 export class Popcorn {
   private vmWorker: Worker;
-  private isBooted = false;
+  private state: PopcornState = "created";
+  private readonly opts: PopcornOpts;
   private readonly eventHandlers = new Set<(event: PopcornEvent) => void>();
   private readonly onWorkerMessage = (event: MessageEvent<unknown>) => {
     const data = readWorkerEvent(event.data);
@@ -64,24 +67,46 @@ export class Popcorn {
     }
   };
 
-  private constructor(vmWorker: Worker) {
-    this.vmWorker = vmWorker;
-  }
-
-  private startEventLoop(): void {
+  public constructor(opts: PopcornOpts) {
+    const vmWorkerUrl = new URL("./worker.mjs", import.meta.url);
+    this.vmWorker = new Worker(vmWorkerUrl, { type: "module" });
+    this.opts = opts;
     this.vmWorker.addEventListener("message", this.onWorkerMessage);
   }
 
   public static async init(opts: PopcornOpts): Promise<Result<Popcorn>> {
-    const vmWorkerUrl = new URL("./worker.mjs", import.meta.url);
-    const vmWorker = new Worker(vmWorkerUrl, { type: "module" });
-    const popcorn = new Popcorn(vmWorker);
+    const popcorn = new Popcorn(opts);
+    const result = await popcorn.boot();
+
+    if (!result.ok) {
+      return result;
+    }
+
+    return { ok: true, data: popcorn };
+  }
+
+  public async boot(): Promise<Result<Popcorn>> {
+    if (this.state === "booted") {
+      return { ok: true, data: this };
+    }
+
+    if (this.state === "booting") {
+      return {
+        ok: false,
+        error: err("internal:check", { detail: "Boot already in progress" }),
+      };
+    }
+
+    this.state = "booting";
 
     return await new Promise<Result<Popcorn>>((resolve) => {
       let isSettled = false;
-      const timeoutsMs = { ...DEFAULT_TIMEOUTS_MS, ...opts.timeoutsMs };
+      const timeoutsMs = { ...DEFAULT_TIMEOUTS_MS, ...this.opts.timeoutsMs };
       const cleanup = () => {
-        vmWorker.removeEventListener("message", onInitMessage);
+        this.vmWorker.removeEventListener("message", onBootMessage);
+        if (this.state === "booting") {
+          this.state = "created";
+        }
       };
       const settle = (result: Result<Popcorn>) => {
         if (isSettled) return;
@@ -89,7 +114,7 @@ export class Popcorn {
         clearTimeout(timer);
         cleanup();
         if (!result.ok) {
-          popcorn.deinit();
+          this.deinit();
         }
         resolve(result);
       };
@@ -99,15 +124,14 @@ export class Popcorn {
         settle({ ok: false, error });
       }, timeoutsMs.boot);
 
-      const onInitMessage = (event: MessageEvent<unknown>) => {
+      const onBootMessage = (event: MessageEvent<unknown>) => {
         const data = readWorkerEvent(event.data);
         check(data !== null);
 
         switch (data.type) {
           case "popcorn:boot-end":
-            popcorn.isBooted = true;
-            popcorn.startEventLoop();
-            settle({ ok: true, data: popcorn });
+            this.state = "booted";
+            settle({ ok: true, data: this });
             break;
           case "popcorn:boot-fail": {
             const error = PopcornError.deserialize(data.payload);
@@ -115,15 +139,13 @@ export class Popcorn {
             break;
           }
           default:
-            // TODO: decide whether pre-init VM events should be buffered,
-            // exposed, or whether init should wait for a dedicated bridge-ready
-            // message emitted from BEAM.
+            // User-level VM events are handled by the main worker listener.
             break;
         }
       };
 
-      vmWorker.addEventListener("message", onInitMessage);
-      toVm(vmWorker, { type: "popcorn:boot", payload: opts.beam });
+      this.vmWorker.addEventListener("message", onBootMessage);
+      toVm(this.vmWorker, { type: "popcorn:boot", payload: this.opts.beam });
     });
   }
 
@@ -132,7 +154,7 @@ export class Popcorn {
     payload?: AnyValue,
     opts?: PopcornSendOpts,
   ): Result<null> {
-    if (!this.isBooted) {
+    if (this.state !== "booted") {
       return { ok: false, error: err("bridge:not-started", {}) };
     }
 
@@ -160,7 +182,7 @@ export class Popcorn {
   }
 
   public deinit(): void {
-    this.isBooted = false;
+    this.state = "created";
     this.vmWorker.removeEventListener("message", this.onWorkerMessage);
     this.eventHandlers.clear();
     this.vmWorker.terminate();

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -56,12 +56,11 @@ export class Popcorn {
       case "otp:exit":
         console.info(`${LOG_PREFIX} exit:`, data.payload);
         return;
-      case "popcorn:send-fail":
-        console.error(
-          `${LOG_PREFIX} send failed:`,
-          PopcornError.deserialize(data.payload),
-        );
+      case "popcorn:send-fail": {
+        const error = PopcornError.deserialize(data.payload);
+        console.error(`${LOG_PREFIX} send failed:`, error.message, error);
         return;
+      }
     }
   };
 

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -9,7 +9,7 @@ import type { AnyValue, BeamBootOptions } from "./types";
 import { check } from "./utils";
 
 export type PopcornOpts = {
-  beam: Pick<BeamBootOptions, "assetsUrl">;
+  beam: Pick<BeamBootOptions, "assetsUrl" | "searchPaths" | "extraArgs">;
   timeoutsMs?: {
     boot?: number;
   };
@@ -24,10 +24,13 @@ const DEFAULT_TIMEOUTS_MS: ResolvedTimeouts = {
   boot: 10_000,
 };
 
+type MessageHandler = (message: AnyValue) => void;
+
 export class Popcorn {
   private vmWorker: Worker;
   private isBooted = false;
   private readonly eventHandlers = new Set<(event: PopcornEvent) => void>();
+  private readonly messageHandlers = new Set<MessageHandler>();
   private readonly onWorkerMessage = (event: MessageEvent<unknown>) => {
     const data = readWorkerEvent(event.data);
     check(data !== null);
@@ -35,6 +38,10 @@ export class Popcorn {
     switch (data.type) {
       case "popcorn:boot-end":
       case "popcorn:boot-fail":
+        return;
+      case "otp:message":
+        this.emit(data);
+        this.emitMessage(data.payload);
         return;
       default:
         this.emit(data);
@@ -137,16 +144,30 @@ export class Popcorn {
     };
   }
 
+  public onMessage(handler: MessageHandler): () => void {
+    this.messageHandlers.add(handler);
+    return () => {
+      this.messageHandlers.delete(handler);
+    };
+  }
+
   public deinit(): void {
     this.isBooted = false;
     this.vmWorker.removeEventListener("message", this.onWorkerMessage);
     this.eventHandlers.clear();
+    this.messageHandlers.clear();
     this.vmWorker.terminate();
   }
 
   private emit(event: PopcornEvent): void {
     for (const handler of this.eventHandlers) {
       handler(event);
+    }
+  }
+
+  private emitMessage(message: AnyValue): void {
+    for (const handler of this.messageHandlers) {
+      handler(message);
     }
   }
 }

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -6,14 +6,15 @@ import {
   type PopcornEvent,
   type SendCompletionPayload,
 } from "./events";
-import type { AnyValue, BeamBootOptions } from "./types";
-import { check } from "./utils";
+import type { AnyValue, BeamBootOptions, OtpErrorPayload } from "./types";
+import { check, unreachable } from "./utils";
 
 export type PopcornOpts = {
   beam: Pick<BeamBootOptions, "assetsUrl" | "searchPaths" | "extraArgs">;
   timeoutsMs?: {
     boot?: number;
   };
+  onError?: (event: OtpErrorPayload) => void;
 };
 
 export type PopcornSendOpts = {
@@ -27,14 +28,25 @@ const DEFAULT_TIMEOUTS_MS: ResolvedTimeouts = {
 
 const LOG_PREFIX = "[Popcorn]";
 
-type PopcornState = "created" | "booting" | "booted";
+type VmExitReason =
+  | { reason: "deinit" }
+  | { reason: "abort"; data: string }
+  | { reason: "error"; data: string }
+  | { reason: "exit"; data: number };
+
+type PopcornState =
+  | { status: "created" }
+  | { status: "booting" }
+  | { status: "booted" }
+  | { status: "closed"; error: PopcornError<"vm:exited"> };
 type PendingSend = (result: Result<null>) => void;
 
 export class Popcorn {
   private vmWorker: Worker;
-  private state: PopcornState = "created";
+  private state: PopcornState = { status: "created" };
   private readonly opts: PopcornOpts;
   private requestSeq = 0;
+  private settleBoot: ((result: Result<Popcorn>) => void) | null = null;
   private readonly eventHandlers = new Set<(event: PopcornEvent) => void>();
   private readonly pendingSends = new Map<string, PendingSend>();
   private readonly onWorkerMessage = (event: MessageEvent<unknown>) => {
@@ -54,19 +66,15 @@ export class Popcorn {
       case "otp:stderr":
         console.error(`${LOG_PREFIX} stderr:`, data.payload);
         return;
-      case "otp:abort":
-        console.error(`${LOG_PREFIX} abort:`, data.payload);
-        return;
       case "otp:error":
-        console.error(`${LOG_PREFIX} error:`, data.payload);
-        return;
-      case "otp:exit":
-        console.info(`${LOG_PREFIX} exit:`, data.payload);
+        this.handleOtpError(data.payload);
         return;
       case "popcorn:send-end": {
         this.completeSend(data.payload);
         return;
       }
+      default:
+        unreachable();
     }
   };
 
@@ -89,18 +97,22 @@ export class Popcorn {
   }
 
   public async boot(): Promise<Result<Popcorn>> {
-    if (this.state === "booted") {
+    if (this.state.status === "booted") {
       return { ok: true, data: this };
     }
 
-    if (this.state === "booting") {
+    if (this.state.status === "closed") {
+      return { ok: false, error: this.state.error };
+    }
+
+    if (this.state.status === "booting") {
       return {
         ok: false,
         error: err("internal:check", { detail: "Boot already in progress" }),
       };
     }
 
-    this.state = "booting";
+    this.state = { status: "booting" };
 
     return await new Promise<Result<Popcorn>>((resolve) => {
       const timeoutsMs = { ...DEFAULT_TIMEOUTS_MS, ...this.opts.timeoutsMs };
@@ -117,6 +129,7 @@ export class Popcorn {
         }
         resolve(result);
       };
+      this.settleBoot = settle;
 
       const timer = setTimeout(() => {
         const error = err("timeout:init", { timeoutMs: timeoutsMs.boot });
@@ -129,7 +142,7 @@ export class Popcorn {
 
         switch (data.type) {
           case "popcorn:boot-end":
-            this.state = "booted";
+            this.state = { status: "booted" };
             settle({ ok: true, data: this });
             break;
           case "popcorn:boot-fail": {
@@ -144,9 +157,10 @@ export class Popcorn {
       };
 
       const cleanup = () => {
+        this.settleBoot = null;
         this.vmWorker.removeEventListener("message", onBootMessage);
-        if (this.state === "booting") {
-          this.state = "created";
+        if (this.state.status === "booting") {
+          this.state = { status: "created" };
         }
       };
 
@@ -165,7 +179,10 @@ export class Popcorn {
     payload?: AnyValue,
     opts?: PopcornSendOpts,
   ): Promise<Result<null>> {
-    if (this.state !== "booted") {
+    if (this.state.status !== "booted") {
+      if (this.state.status === "closed") {
+        return { ok: false, error: this.state.error };
+      }
       return { ok: false, error: err("bridge:not-started", {}) };
     }
 
@@ -179,7 +196,6 @@ export class Popcorn {
     }
 
     const requestId = this.nextRequestId();
-
     return await new Promise<Result<null>>((resolve) => {
       this.pendingSends.set(requestId, resolve);
       toVm(this.vmWorker, {
@@ -196,8 +212,22 @@ export class Popcorn {
     };
   }
 
-  public deinit(): void {
-    this.state = "created";
+  public deinit(reason: VmExitReason = { reason: "deinit" }): void {
+    if (this.state.status === "closed") {
+      return;
+    }
+
+    const error = err("vm:exited", reason);
+    if (this.settleBoot !== null) {
+      this.settleBoot({ ok: false, error });
+      return;
+    }
+
+    this.state = { status: "closed", error };
+    for (const resolve of this.pendingSends.values()) {
+      resolve({ ok: false, error });
+    }
+    this.pendingSends.clear();
     this.vmWorker.removeEventListener("message", this.onWorkerMessage);
     this.eventHandlers.clear();
     this.vmWorker.terminate();
@@ -211,9 +241,7 @@ export class Popcorn {
 
   private completeSend(payload: SendCompletionPayload): void {
     const resolve = this.pendingSends.get(payload.id) ?? null;
-    if (resolve === null) {
-      return;
-    }
+    check(resolve !== null);
 
     this.pendingSends.delete(payload.id);
     const result = payload.result;
@@ -227,5 +255,45 @@ export class Popcorn {
   private nextRequestId(): string {
     this.requestSeq += 1;
     return `send:${this.requestSeq}`;
+  }
+
+  private handleOtpError(payload: OtpErrorPayload): void {
+    const onError = this.opts.onError ?? defaultOnError;
+    onError(payload);
+
+    check(["booting", "booted"].includes(this.state.status));
+    if (this.state.status === "booting") {
+      return;
+    }
+
+    switch (payload.kind) {
+      case "abort":
+        this.deinit({ reason: "abort", data: payload.data });
+        break;
+      case "error":
+        this.deinit({ reason: "error", data: payload.data });
+        break;
+      case "exit":
+        this.deinit({ reason: "exit", data: payload.data });
+        break;
+      default:
+        unreachable();
+    }
+  }
+}
+
+function defaultOnError(payload: OtpErrorPayload): void {
+  switch (payload.kind) {
+    case "abort":
+      console.error(`${LOG_PREFIX} abort:`, payload.data);
+      return;
+    case "error":
+      console.error(`${LOG_PREFIX} error:`, payload.data);
+      return;
+    case "exit":
+      console.info(`${LOG_PREFIX} exit:`, payload.data);
+      return;
+    default:
+      unreachable();
   }
 }

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -4,6 +4,7 @@ import {
   serializeSendPayload,
   toVm,
   type PopcornEvent,
+  type SendCompletionPayload,
 } from "./events";
 import type { AnyValue, BeamBootOptions } from "./types";
 import { check } from "./utils";
@@ -27,12 +28,15 @@ const DEFAULT_TIMEOUTS_MS: ResolvedTimeouts = {
 const LOG_PREFIX = "[Popcorn]";
 
 type PopcornState = "created" | "booting" | "booted";
+type PendingSend = (result: Result<null>) => void;
 
 export class Popcorn {
   private vmWorker: Worker;
   private state: PopcornState = "created";
   private readonly opts: PopcornOpts;
+  private requestSeq = 0;
   private readonly eventHandlers = new Set<(event: PopcornEvent) => void>();
+  private readonly pendingSends = new Map<string, PendingSend>();
   private readonly onWorkerMessage = (event: MessageEvent<unknown>) => {
     const data = readWorkerEvent(event.data);
     check(data !== null);
@@ -59,9 +63,8 @@ export class Popcorn {
       case "otp:exit":
         console.info(`${LOG_PREFIX} exit:`, data.payload);
         return;
-      case "popcorn:send-fail": {
-        const error = PopcornError.deserialize(data.payload);
-        console.error(`${LOG_PREFIX} send failed:`, error.message, error);
+      case "popcorn:send-end": {
+        this.completeSend(data.payload);
         return;
       }
     }
@@ -100,14 +103,10 @@ export class Popcorn {
     this.state = "booting";
 
     return await new Promise<Result<Popcorn>>((resolve) => {
-      let isSettled = false;
       const timeoutsMs = { ...DEFAULT_TIMEOUTS_MS, ...this.opts.timeoutsMs };
-      const cleanup = () => {
-        this.vmWorker.removeEventListener("message", onBootMessage);
-        if (this.state === "booting") {
-          this.state = "created";
-        }
-      };
+
+      let isSettled = false;
+
       const settle = (result: Result<Popcorn>) => {
         if (isSettled) return;
         isSettled = true;
@@ -144,16 +143,28 @@ export class Popcorn {
         }
       };
 
+      const cleanup = () => {
+        this.vmWorker.removeEventListener("message", onBootMessage);
+        if (this.state === "booting") {
+          this.state = "created";
+        }
+      };
+
       this.vmWorker.addEventListener("message", onBootMessage);
       toVm(this.vmWorker, { type: "popcorn:boot", payload: this.opts.beam });
     });
   }
 
-  public send(
+  /**
+   * Resolves after the VM has attempted to put the event into the target
+   * listener process mailbox. It does not wait for application-level handling by
+   * the receiving Elixir process.
+   */
+  public async send(
     target: string,
     payload?: AnyValue,
     opts?: PopcornSendOpts,
-  ): Result<null> {
+  ): Promise<Result<null>> {
     if (this.state !== "booted") {
       return { ok: false, error: err("bridge:not-started", {}) };
     }
@@ -167,11 +178,15 @@ export class Popcorn {
       return command;
     }
 
-    toVm(this.vmWorker, {
-      type: "popcorn:send",
-      payload: command.data,
+    const requestId = this.nextRequestId();
+
+    return await new Promise<Result<null>>((resolve) => {
+      this.pendingSends.set(requestId, resolve);
+      toVm(this.vmWorker, {
+        type: "popcorn:send",
+        payload: { id: requestId, message: command.data },
+      });
     });
-    return { ok: true, data: null };
   }
 
   public onEvent(handler: (event: PopcornEvent) => void): () => void {
@@ -192,5 +207,25 @@ export class Popcorn {
     for (const handler of this.eventHandlers) {
       handler(event);
     }
+  }
+
+  private completeSend(payload: SendCompletionPayload): void {
+    const resolve = this.pendingSends.get(payload.id) ?? null;
+    if (resolve === null) {
+      return;
+    }
+
+    this.pendingSends.delete(payload.id);
+    const result = payload.result;
+    resolve(
+      result.ok
+        ? { ok: true, data: null }
+        : { ok: false, error: PopcornError.deserialize(result.error) },
+    );
+  }
+
+  private nextRequestId(): string {
+    this.requestSeq += 1;
+    return `send:${this.requestSeq}`;
   }
 }

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -13,8 +13,10 @@ export type PopcornOpts = {
   beam: Pick<BeamBootOptions, "assetsUrl" | "searchPaths" | "extraArgs">;
   timeoutsMs?: {
     boot?: number;
+    send?: number;
   };
   onError?: (event: OtpErrorPayload) => void;
+  workerUrl?: string | URL;
 };
 
 export type PopcornSendOpts = {
@@ -24,6 +26,7 @@ export type PopcornSendOpts = {
 type ResolvedTimeouts = Required<NonNullable<PopcornOpts["timeoutsMs"]>>;
 const DEFAULT_TIMEOUTS_MS: ResolvedTimeouts = {
   boot: 10_000,
+  send: 5_000,
 };
 
 const LOG_PREFIX = "[Popcorn]";
@@ -42,7 +45,7 @@ type PopcornState =
 type PendingSend = (result: Result<null>) => void;
 
 export class Popcorn {
-  private vmWorker: Worker;
+  private vmWorker!: Worker;
   private state: PopcornState = { status: "created" };
   private readonly opts: PopcornOpts;
   private requestSeq = 0;
@@ -79,9 +82,14 @@ export class Popcorn {
   };
 
   public constructor(opts: PopcornOpts) {
-    const vmWorkerUrl = new URL("./worker.mjs", import.meta.url);
-    this.vmWorker = new Worker(vmWorkerUrl, { type: "module" });
     this.opts = opts;
+    this.spawnWorker();
+  }
+
+  private spawnWorker(): void {
+    const defaultWorkerUrl = new URL("./worker.mjs", import.meta.url);
+    const workerUrl = this.opts.workerUrl ?? defaultWorkerUrl;
+    this.vmWorker = new Worker(workerUrl, { type: "module" });
     this.vmWorker.addEventListener("message", this.onWorkerMessage);
   }
 
@@ -101,15 +109,17 @@ export class Popcorn {
       return { ok: true, data: this };
     }
 
-    if (this.state.status === "closed") {
-      return { ok: false, error: this.state.error };
+    if (this.state.status === "booting") {
+      // TODO(jgonet): make it easier to construct check() errors without throwing
+      const error = err("internal:check", {
+        detail: "Boot already in progress",
+      });
+      return { ok: false, error };
     }
 
-    if (this.state.status === "booting") {
-      return {
-        ok: false,
-        error: err("internal:check", { detail: "Boot already in progress" }),
-      };
+    const reboot = this.state.status === "closed";
+    if (reboot) {
+      this.spawnWorker();
     }
 
     this.state = { status: "booting" };
@@ -117,11 +127,8 @@ export class Popcorn {
     return await new Promise<Result<Popcorn>>((resolve) => {
       const timeoutsMs = { ...DEFAULT_TIMEOUTS_MS, ...this.opts.timeoutsMs };
 
-      let isSettled = false;
-
       const settle = (result: Result<Popcorn>) => {
-        if (isSettled) return;
-        isSettled = true;
+        if (this.settleBoot === null) return;
         clearTimeout(timer);
         cleanup();
         if (!result.ok) {
@@ -151,7 +158,7 @@ export class Popcorn {
             break;
           }
           default:
-            // User-level VM events are handled by the main worker listener.
+            // user-level VM events are handled by the main worker listener.
             break;
         }
       };
@@ -159,9 +166,6 @@ export class Popcorn {
       const cleanup = () => {
         this.settleBoot = null;
         this.vmWorker.removeEventListener("message", onBootMessage);
-        if (this.state.status === "booting") {
-          this.state = { status: "created" };
-        }
       };
 
       this.vmWorker.addEventListener("message", onBootMessage);
@@ -170,9 +174,7 @@ export class Popcorn {
   }
 
   /**
-   * Resolves after the VM has attempted to put the event into the target
-   * listener process mailbox. It does not wait for application-level handling by
-   * the receiving Elixir process.
+   * Resolves after VM sent message to registered process.
    */
   public async send(
     target: string,
@@ -196,8 +198,20 @@ export class Popcorn {
     }
 
     const requestId = this.nextRequestId();
+    const timeoutMs = { ...DEFAULT_TIMEOUTS_MS, ...this.opts.timeoutsMs }.send;
+
     return await new Promise<Result<null>>((resolve) => {
-      this.pendingSends.set(requestId, resolve);
+      const timer = setTimeout(() => {
+        const wasMessageStale = this.pendingSends.delete(requestId);
+        if (wasMessageStale) {
+          resolve({ ok: false, error: err("timeout:send", { timeoutMs }) });
+        }
+      }, timeoutMs);
+
+      this.pendingSends.set(requestId, (result) => {
+        clearTimeout(timer);
+        resolve(result);
+      });
       toVm(this.vmWorker, {
         type: "popcorn:send",
         payload: { id: requestId, message: command.data },
@@ -229,8 +243,8 @@ export class Popcorn {
     }
     this.pendingSends.clear();
     this.vmWorker.removeEventListener("message", this.onWorkerMessage);
-    this.eventHandlers.clear();
     this.vmWorker.terminate();
+    // we keep onEvent() callbacks across reboots
   }
 
   private emit(event: PopcornEvent): void {
@@ -241,7 +255,9 @@ export class Popcorn {
 
   private completeSend(payload: SendCompletionPayload): void {
     const resolve = this.pendingSends.get(payload.id) ?? null;
-    check(resolve !== null);
+
+    const didTimeout = resolve === null;
+    if (didTimeout) return;
 
     this.pendingSends.delete(payload.id);
     const result = payload.result;
@@ -261,24 +277,32 @@ export class Popcorn {
     const onError = this.opts.onError ?? defaultOnError;
     onError(payload);
 
-    check(["booting", "booted"].includes(this.state.status));
-    if (this.state.status === "booting") {
+    check(this.state.status === "booting" || this.state.status === "booted");
+
+    // if failed while booting, settle early
+    const booting = this.state.status === "booting";
+    if (booting) {
+      check(this.settleBoot !== null);
+
+      const error = err("vm:exited", exitReason(payload));
+      this.settleBoot({ ok: false, error });
       return;
     }
 
-    switch (payload.kind) {
-      case "abort":
-        this.deinit({ reason: "abort", data: payload.data });
-        break;
-      case "error":
-        this.deinit({ reason: "error", data: payload.data });
-        break;
-      case "exit":
-        this.deinit({ reason: "exit", data: payload.data });
-        break;
-      default:
-        unreachable();
-    }
+    this.deinit(exitReason(payload));
+  }
+}
+
+function exitReason(payload: OtpErrorPayload): VmExitReason {
+  switch (payload.kind) {
+    case "abort":
+      return { reason: "abort", data: payload.data };
+    case "error":
+      return { reason: "error", data: payload.data };
+    case "exit":
+      return { reason: "exit", data: payload.data };
+    default:
+      return unreachable();
   }
 }
 

--- a/otp/js/src/types.ts
+++ b/otp/js/src/types.ts
@@ -6,8 +6,8 @@ export type BeamTarget = { name: string } | { pid: string };
 
 export type BeamBootOptions = {
   assetsUrl: string;
-  searchPaths: string[];
-  extraArgs: string[];
+  searchPaths?: string[];
+  extraArgs?: string[];
   createModule: CreateModuleFn<EmscriptenModule>;
   emit: (event: BeamEvent) => void;
 };

--- a/otp/js/src/types.ts
+++ b/otp/js/src/types.ts
@@ -4,6 +4,12 @@ export type AnyValue = unknown;
 
 export type BeamTarget = { name: string } | { pid: string };
 
+export type BeamSendPayload = {
+  targetName: string;
+  payloadJson: string;
+  metaJson: string;
+};
+
 export type BeamBootOptions = {
   assetsUrl: string;
   searchPaths?: string[];

--- a/otp/js/src/types.ts
+++ b/otp/js/src/types.ts
@@ -21,10 +21,13 @@ export type BeamBootOptions = {
 export type BeamEvent =
   | { type: "otp:stdout"; payload: string }
   | { type: "otp:stderr"; payload: string }
-  | { type: "otp:exit"; payload: number }
-  | { type: "otp:abort"; payload: string }
-  | { type: "otp:error"; payload: string }
+  | { type: "otp:error"; payload: OtpErrorPayload }
   | { type: "otp:message"; payload: AnyValue };
+
+export type OtpErrorPayload =
+  | { kind: "abort"; data: string }
+  | { kind: "error"; data: string }
+  | { kind: "exit"; data: number };
 
 export type EmscriptenFS = {
   mkdir: (path: string) => void;

--- a/otp/js/src/worker.ts
+++ b/otp/js/src/worker.ts
@@ -6,6 +6,7 @@ import type { EmscriptenModule } from "./types";
 import { check, unreachable } from "./utils";
 
 let instance: EmscriptenModule | null = null;
+let state: "created" | "booting" | "booted" = "created";
 
 self.onmessage = async (event: MessageEvent<unknown>) => {
   const data = readMainEvent(event.data);
@@ -13,7 +14,8 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
 
   switch (data.type) {
     case "popcorn:boot": {
-      check(instance === null);
+      check(state === "created");
+      state = "booting";
 
       const result = await boot({
         assetsUrl: data.payload.assetsUrl,
@@ -23,6 +25,7 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
         emit: toMain,
       });
       if (!result.ok) {
+        state = "created";
         toMain({
           type: "popcorn:boot-fail",
           payload: result.error.serialize(),
@@ -31,6 +34,7 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
       }
 
       instance = result.data;
+      state = "booted";
       toMain({ type: "popcorn:boot-end", payload: {} });
       return;
     }
@@ -48,6 +52,6 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
       return;
     }
     default:
-      return unreachable();
+      unreachable();
   }
 };

--- a/otp/js/src/worker.ts
+++ b/otp/js/src/worker.ts
@@ -35,7 +35,7 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
       return;
     }
     case "popcorn:send": {
-      const result = send(instance, data.payload.command);
+      const result = send(instance, data.payload);
       if (!result.ok) {
         toMain({
           type: "popcorn:send-fail",

--- a/otp/js/src/worker.ts
+++ b/otp/js/src/worker.ts
@@ -17,8 +17,8 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
 
       const result = await boot({
         assetsUrl: data.payload.assetsUrl,
-        extraArgs: [],
-        searchPaths: [],
+        extraArgs: data.payload.extraArgs,
+        searchPaths: data.payload.searchPaths,
         createModule,
         emit: toMain,
       });

--- a/otp/js/src/worker.ts
+++ b/otp/js/src/worker.ts
@@ -35,13 +35,16 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
       return;
     }
     case "popcorn:send": {
-      const result = send(instance, data.payload);
-      if (!result.ok) {
-        toMain({
-          type: "popcorn:send-fail",
-          payload: result.error.serialize(),
-        });
-      }
+      const result = send(instance, data.payload.message);
+      toMain({
+        type: "popcorn:send-end",
+        payload: {
+          id: data.payload.id,
+          result: result.ok
+            ? { ok: true, data: null }
+            : { ok: false, error: result.error.serialize() },
+        },
+      });
       return;
     }
     default:

--- a/otp/js/src/worker.ts
+++ b/otp/js/src/worker.ts
@@ -6,7 +6,6 @@ import type { EmscriptenModule } from "./types";
 import { check, unreachable } from "./utils";
 
 let instance: EmscriptenModule | null = null;
-let state: "created" | "booting" | "booted" = "created";
 
 self.onmessage = async (event: MessageEvent<unknown>) => {
   const data = readMainEvent(event.data);
@@ -14,8 +13,7 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
 
   switch (data.type) {
     case "popcorn:boot": {
-      check(state === "created");
-      state = "booting";
+      check(instance === null);
 
       const result = await boot({
         assetsUrl: data.payload.assetsUrl,
@@ -25,7 +23,6 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
         emit: toMain,
       });
       if (!result.ok) {
-        state = "created";
         toMain({
           type: "popcorn:boot-fail",
           payload: result.error.serialize(),
@@ -34,9 +31,8 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
       }
 
       instance = result.data;
-      state = "booted";
       toMain({ type: "popcorn:boot-end", payload: {} });
-      return;
+      break;
     }
     case "popcorn:send": {
       const result = send(instance, data.payload.message);
@@ -49,7 +45,7 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
             : { ok: false, error: result.error.serialize() },
         },
       });
-      return;
+      break;
     }
     default:
       unreachable();

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -98,15 +98,22 @@ index 0000000000000000000000000000000000000000..2e85c729e92e9948fd15302a88ed12a4
 +};
 diff --git a/erts/emulator/js_bridge/js_bridge.js b/erts/emulator/js_bridge/js_bridge.js
 new file mode 100644
-index 0000000000000000000000000000000000000000..0b7996e35e311aa67629a6e54df2820eac4b7438
+index 0000000000000000000000000000000000000000..0b446eedf17294c0c47c2b872bf2fb44a032ff67
 --- /dev/null
 +++ b/erts/emulator/js_bridge/js_bridge.js
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,26 @@
 +mergeInto(LibraryManager.library, {
-+  js_bridge_on_from_beam__proxy: 'sync',
-+  js_bridge_on_from_beam__sig: 'vii',
-+  js_bridge_on_from_beam: function(data, len) {
-+    var envelope = UTF8ToString(data, len);
++  js_bridge_on_from_beam_async__proxy: 'async',
++  js_bridge_on_from_beam_async__sig: 'vii',
++  js_bridge_on_from_beam_async: function(data, len) {
++    var envelope;
++
++    try {
++      envelope = UTF8ToString(data, len);
++    } finally {
++      _free(data);
++    }
++
 +    if (typeof Module['onBeamMessage'] === 'function') {
 +      Module['onBeamMessage'](envelope);
 +    }
@@ -123,10 +130,10 @@ index 0000000000000000000000000000000000000000..0b7996e35e311aa67629a6e54df2820e
 +});
 diff --git a/erts/emulator/nifs/common/wasm_nif.c b/erts/emulator/nifs/common/wasm_nif.c
 new file mode 100644
-index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c563cdd6ed
+index 0000000000000000000000000000000000000000..1ddc7e33577a23a17fbb3230086ac9ae6a7c6505
 --- /dev/null
 +++ b/erts/emulator/nifs/common/wasm_nif.c
-@@ -0,0 +1,463 @@
+@@ -0,0 +1,743 @@
 +/*
 + * %CopyrightBegin%
 + *
@@ -155,25 +162,36 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +#include "erl_nif.h"
 +#include "sys.h"
 +
++#include <limits.h>
 +#include <stddef.h>
-+#include <stdio.h>
++#include <stdlib.h>
 +#include <string.h>
 +
 +#ifdef ERTS_EMSCRIPTEN
 +#include <emscripten/emscripten.h>
 +#endif
 +
++typedef enum {
++  WASM_LISTENER_NAME_OPAQUE = 0,
++  WASM_LISTENER_NAME_REGISTERED = 1,
++} wasm_listener_name_kind_t;
++
++typedef struct wasm_state_s wasm_state_t;
++
 +typedef struct wasm_listener_s {
++  wasm_state_t *state;
++  ErlNifPid pid;
++  ErlNifMonitor monitor;
++  unsigned int name_kind;
 +  ErlNifBinary name;
 +  ErlNifBinary pid_token;
-+  ErlNifPid pid;
 +  struct wasm_listener_s *next;
 +} wasm_listener_t;
 +
-+typedef struct {
-+  ErlNifMutex *lock;
++struct wasm_state_s {
++  unsigned int owner_count;
 +  wasm_listener_t *listeners;
-+} wasm_state_t;
++};
 +
 +static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info);
 +static int upgrade(ErlNifEnv *env, void **priv_data, void **old_priv_data,
@@ -186,6 +204,10 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +                                            const ERL_NIF_TERM argv[]);
 +static ERL_NIF_TERM send_raw_nif(ErlNifEnv *env, int argc,
 +                                 const ERL_NIF_TERM argv[]);
++
++static void wasm_listener_dtor(ErlNifEnv *env, void *obj);
++static void wasm_listener_down(ErlNifEnv *env, void *obj, ErlNifPid *pid,
++                               ErlNifMonitor *mon);
 +
 +static ErlNifFunc nif_funcs[] = {
 +    {"register_listener_nif", 1, register_listener_nif},
@@ -203,19 +225,54 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +static ERL_NIF_TERM am_out_of_memory;
 +static ERL_NIF_TERM am_unsupported;
 +static ERL_NIF_TERM am_wasm;
++static ERL_NIF_TERM am_registered_name;
++static ERL_NIF_TERM am_opaque_name;
 +
++static ErlNifResourceType *wasm_listener_type = NULL;
++/*
++ * The bridge keeps a single active state at a time. Serializing lookups,
++ * callbacks, and unload through one process-wide lock is slower than the
++ * atomic refcount path, but it keeps the lifetime rules straightforward.
++ */
++static ErlNifMutex *erts_wasm_state_lock = NULL;
 +static wasm_state_t *erts_wasm_state = NULL;
 +
 +#ifdef ERTS_EMSCRIPTEN
-+void wasm_bridge_emit_error(const char *envelope, int len);
-+void wasm_bridge_dispatch(const char *target_name,
-+                          int target_name_len,
-+                          const char *payload_json,
-+                          int payload_len,
-+                          const char *meta_json,
-+                          int meta_len);
-+void sendVmMessage(const char *data, int len);
++void sendVmMessage(const char *target_name, int target_name_len,
++                   const char *payload_json, int payload_len,
++                   const char *meta_json, int meta_len);
 +#endif
++
++static void init_atoms(ErlNifEnv *env) {
++  am_ok = enif_make_atom(env, "ok");
++  am_error = enif_make_atom(env, "error");
++  am_already_registered = enif_make_atom(env, "already_registered");
++  am_not_found = enif_make_atom(env, "not_found");
++  am_not_owner = enif_make_atom(env, "not_owner");
++  am_out_of_memory = enif_make_atom(env, "out_of_memory");
++  am_unsupported = enif_make_atom(env, "unsupported");
++  am_wasm = enif_make_atom(env, "wasm");
++  am_registered_name = enif_make_atom(env, "registered_name");
++  am_opaque_name = enif_make_atom(env, "opaque_name");
++}
++
++static int load_listener_resource_type(ErlNifEnv *env,
++                                       ErlNifResourceFlags flags) {
++  ErlNifResourceTypeInit init = {wasm_listener_dtor, NULL, wasm_listener_down};
++
++  wasm_listener_type =
++      enif_open_resource_type_x(env, "wasm_listener", &init, flags, NULL);
++  return wasm_listener_type != NULL;
++}
++
++static int ensure_wasm_state_lock(void) {
++  if (erts_wasm_state_lock != NULL) {
++    return 1;
++  }
++
++  erts_wasm_state_lock = enif_mutex_create("wasm_nif_state_lock");
++  return erts_wasm_state_lock != NULL;
++}
 +
 +static wasm_state_t *create_wasm_state(void) {
 +  wasm_state_t *state;
@@ -225,37 +282,31 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +    return NULL;
 +  }
 +
-+  state->lock = enif_mutex_create("wasm_nif_lock");
-+  if (state->lock == NULL) {
-+    enif_free(state);
-+    return NULL;
-+  }
-+
++  state->owner_count = 1;
 +  state->listeners = NULL;
 +
 +  return state;
 +}
 +
-+static wasm_state_t *ensure_wasm_state(void) {
-+  wasm_state_t *state;
++static void destroy_wasm_state(wasm_state_t *state) {
++  wasm_listener_t *listener;
 +
-+  if (erts_wasm_state != NULL) {
-+    return erts_wasm_state;
-+  }
-+
-+  state = create_wasm_state();
 +  if (state == NULL) {
-+    return NULL;
++    return;
 +  }
 +
-+  if (erts_wasm_state == NULL) {
-+    erts_wasm_state = state;
-+    return state;
++  listener = state->listeners;
++  state->listeners = NULL;
++
++  while (listener != NULL) {
++    wasm_listener_t *next = listener->next;
++    listener->next = NULL;
++    listener->state = NULL;
++    enif_release_resource(listener);
++    listener = next;
 +  }
 +
-+  enif_mutex_destroy(state->lock);
 +  enif_free(state);
-+  return erts_wasm_state;
 +}
 +
 +static int same_name(const unsigned char *lhs_data, size_t lhs_size,
@@ -264,9 +315,8 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +         (lhs_size == 0 || memcmp(lhs_data, rhs_data, lhs_size) == 0);
 +}
 +
-+static int same_pid(ErlNifEnv *env, const ErlNifPid *lhs,
-+                    const ErlNifPid *rhs) {
-+  return enif_is_identical(enif_make_pid(env, lhs), enif_make_pid(env, rhs));
++static int same_pid(const ErlNifPid *lhs, const ErlNifPid *rhs) {
++  return enif_compare_pids(lhs, rhs) == 0;
 +}
 +
 +static ERL_NIF_TERM make_error(ErlNifEnv *env, ERL_NIF_TERM reason) {
@@ -308,10 +358,59 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +  return 1;
 +}
 +
-+static void free_listener(wasm_listener_t *listener) {
-+  enif_release_binary(&listener->name);
-+  enif_release_binary(&listener->pid_token);
-+  enif_free(listener);
++static int inspect_listener_registration(ErlNifEnv *env, ERL_NIF_TERM arg,
++                                         ErlNifBinary *name,
++                                         unsigned int *name_kind) {
++  const ERL_NIF_TERM *tuple_elements;
++  int arity;
++
++  if (!enif_get_tuple(env, arg, &arity, &tuple_elements) || arity != 2) {
++    return 0;
++  }
++
++  if (enif_is_identical(tuple_elements[0], am_registered_name)) {
++    *name_kind = WASM_LISTENER_NAME_REGISTERED;
++  } else if (enif_is_identical(tuple_elements[0], am_opaque_name)) {
++    *name_kind = WASM_LISTENER_NAME_OPAQUE;
++  } else {
++    return 0;
++  }
++
++  return enif_inspect_iolist_as_binary(env, tuple_elements[1], name) &&
++         name->size > 0;
++}
++
++static int listener_registered_name_is_current(ErlNifEnv *env,
++                                               wasm_listener_t *listener) {
++  ERL_NIF_TERM registered_name;
++  ErlNifPid current_pid;
++
++  if (listener->name_kind != WASM_LISTENER_NAME_REGISTERED) {
++    return 1;
++  }
++
++  if (!enif_make_existing_atom_len(env, (const char *)listener->name.data,
++                                   listener->name.size, &registered_name,
++                                   ERL_NIF_UTF8)) {
++    return 0;
++  }
++
++  if (!enif_whereis_pid(env, registered_name, &current_pid)) {
++    return 0;
++  }
++
++  return same_pid(&listener->pid, &current_pid);
++}
++
++static int listener_is_stale(ErlNifEnv *env, wasm_listener_t *listener) {
++  return !enif_is_process_alive(env, &listener->pid) ||
++         !listener_registered_name_is_current(env, listener);
++}
++
++static void release_listener(wasm_listener_t *listener) {
++  listener->next = NULL;
++  listener->state = NULL;
++  enif_release_resource(listener);
 +}
 +
 +static void remove_listener_locked(wasm_state_t *state, wasm_listener_t *prev,
@@ -322,21 +421,20 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +    prev->next = listener->next;
 +  }
 +
-+  free_listener(listener);
++  release_listener(listener);
 +}
 +
-+static wasm_listener_t *find_listener_locked(ErlNifEnv *env,
-+                                             wasm_state_t *state,
-+                                             const unsigned char *name_data,
-+                                             size_t name_size,
-+                                             wasm_listener_t **prev_out) {
++static wasm_listener_t *
++find_listener_by_name_locked(ErlNifEnv *env, wasm_state_t *state,
++                             const unsigned char *name_data, size_t name_size,
++                             wasm_listener_t **prev_out) {
 +  wasm_listener_t *prev = NULL;
 +  wasm_listener_t *listener = state->listeners;
 +
 +  while (listener != NULL) {
 +    wasm_listener_t *next = listener->next;
 +
-+    if (!enif_is_process_alive(env, &listener->pid)) {
++    if (listener_is_stale(env, listener)) {
 +      remove_listener_locked(state, prev, listener);
 +      listener = next;
 +      continue;
@@ -361,16 +459,17 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +  return NULL;
 +}
 +
-+static wasm_listener_t *find_listener_by_pid_token_locked(
-+    ErlNifEnv *env, wasm_state_t *state, const unsigned char *pid_token_data,
-+    size_t pid_token_size) {
++static wasm_listener_t *
++find_listener_by_pid_token_locked(ErlNifEnv *env, wasm_state_t *state,
++                                  const unsigned char *pid_token_data,
++                                  size_t pid_token_size) {
 +  wasm_listener_t *prev = NULL;
 +  wasm_listener_t *listener = state->listeners;
 +
 +  while (listener != NULL) {
 +    wasm_listener_t *next = listener->next;
 +
-+    if (!enif_is_process_alive(env, &listener->pid)) {
++    if (listener_is_stale(env, listener)) {
 +      remove_listener_locked(state, prev, listener);
 +      listener = next;
 +      continue;
@@ -388,38 +487,66 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +  return NULL;
 +}
 +
-+static int resolve_registered_process_pid(ErlNifEnv *env, const char *target_name,
-+                                          size_t target_name_len,
-+                                          ErlNifPid *pid) {
-+  ERL_NIF_TERM target_atom;
++static void remove_listener_by_ptr_locked(wasm_state_t *state,
++                                          wasm_listener_t *target) {
++  wasm_listener_t *prev = NULL;
++  wasm_listener_t *listener = state->listeners;
 +
-+  if (target_name_len == 0) {
-+    return 0;
++  while (listener != NULL) {
++    if (listener == target) {
++      remove_listener_locked(state, prev, listener);
++      return;
++    }
++
++    prev = listener;
++    listener = listener->next;
 +  }
-+
-+  if (!enif_make_existing_atom_len(env, target_name, target_name_len,
-+                                   &target_atom, ERL_NIF_UTF8)) {
-+    return 0;
-+  }
-+
-+  return enif_whereis_pid(env, target_atom, pid);
 +}
 +
-+static ERL_NIF_TERM make_binary_copy(ErlNifEnv *env, const char *data,
-+                                     size_t size) {
++static int make_binary_copy(ErlNifEnv *env, const char *data, size_t size,
++                            ERL_NIF_TERM *term_out) {
 +  unsigned char *dst;
-+  ERL_NIF_TERM term;
 +
-+  dst = enif_make_new_binary(env, size, &term);
++  dst = enif_make_new_binary(env, size, term_out);
 +  if (dst == NULL) {
-+    return enif_make_badarg(env);
++    return 0;
 +  }
 +
 +  if (size > 0) {
 +    memcpy(dst, data, size);
 +  }
 +
-+  return term;
++  return 1;
++}
++
++static void wasm_listener_dtor(ErlNifEnv *env, void *obj) {
++  wasm_listener_t *listener = obj;
++
++  (void)env;
++
++  enif_release_binary(&listener->name);
++  enif_release_binary(&listener->pid_token);
++}
++
++static void wasm_listener_down(ErlNifEnv *env, void *obj, ErlNifPid *pid,
++                               ErlNifMonitor *mon) {
++  wasm_listener_t *listener = obj;
++  wasm_state_t *state;
++
++  (void)env;
++  (void)pid;
++  (void)mon;
++
++  if (erts_wasm_state_lock == NULL) {
++    return;
++  }
++
++  enif_mutex_lock(erts_wasm_state_lock);
++  state = listener->state;
++  if (state != NULL) {
++    remove_listener_by_ptr_locked(state, listener);
++  }
++  enif_mutex_unlock(erts_wasm_state_lock);
 +}
 +
 +static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info) {
@@ -427,19 +554,31 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +
 +  (void)load_info;
 +
-+  state = ensure_wasm_state();
++  state = create_wasm_state();
 +  if (state == NULL) {
 +    return -1;
 +  }
 +
-+  am_ok = enif_make_atom(env, "ok");
-+  am_error = enif_make_atom(env, "error");
-+  am_already_registered = enif_make_atom(env, "already_registered");
-+  am_not_found = enif_make_atom(env, "not_found");
-+  am_not_owner = enif_make_atom(env, "not_owner");
-+  am_out_of_memory = enif_make_atom(env, "out_of_memory");
-+  am_unsupported = enif_make_atom(env, "unsupported");
-+  am_wasm = enif_make_atom(env, "wasm");
++  if (!ensure_wasm_state_lock()) {
++    destroy_wasm_state(state);
++    return -1;
++  }
++
++  if (!load_listener_resource_type(env, ERL_NIF_RT_CREATE)) {
++    destroy_wasm_state(state);
++    return -1;
++  }
++
++  init_atoms(env);
++
++  enif_mutex_lock(erts_wasm_state_lock);
++  if (erts_wasm_state != NULL) {
++    enif_mutex_unlock(erts_wasm_state_lock);
++    destroy_wasm_state(state);
++    return -1;
++  }
++  erts_wasm_state = state;
++  enif_mutex_unlock(erts_wasm_state_lock);
 +
 +  *priv_data = state;
 +
@@ -448,17 +587,42 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +
 +static int upgrade(ErlNifEnv *env, void **priv_data, void **old_priv_data,
 +                   ERL_NIF_TERM load_info) {
-+  (void)old_priv_data;
++  wasm_state_t *state;
 +
-+  if (*priv_data != NULL) {
++  (void)load_info;
++
++  if (old_priv_data == NULL || *old_priv_data == NULL) {
 +    return -1;
 +  }
 +
-+  return load(env, priv_data, load_info);
++  state = *old_priv_data;
++
++  if (!load_listener_resource_type(env, ERL_NIF_RT_TAKEOVER)) {
++    return -1;
++  }
++
++  if (!ensure_wasm_state_lock()) {
++    return -1;
++  }
++
++  init_atoms(env);
++
++  enif_mutex_lock(erts_wasm_state_lock);
++  if (erts_wasm_state != state) {
++    enif_mutex_unlock(erts_wasm_state_lock);
++    return -1;
++  }
++  state->owner_count += 1;
++  enif_mutex_unlock(erts_wasm_state_lock);
++
++  *priv_data = state;
++
++  return 0;
 +}
 +
 +static void unload(ErlNifEnv *env, void *priv_data) {
 +  wasm_state_t *state = priv_data;
++  int destroy_state = 0;
 +  wasm_listener_t *listener;
 +
 +  (void)env;
@@ -467,72 +631,89 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +    return;
 +  }
 +
-+  listener = state->listeners;
-+  while (listener != NULL) {
-+    wasm_listener_t *next = listener->next;
-+    free_listener(listener);
-+    listener = next;
++  if (erts_wasm_state_lock == NULL) {
++    destroy_wasm_state(state);
++    return;
 +  }
 +
-+  enif_mutex_destroy(state->lock);
-+
-+  if (erts_wasm_state == state) {
-+    erts_wasm_state = NULL;
++  enif_mutex_lock(erts_wasm_state_lock);
++  if (state->owner_count > 0) {
++    state->owner_count -= 1;
 +  }
++  if (state->owner_count == 0) {
++    if (erts_wasm_state == state) {
++      erts_wasm_state = NULL;
++    }
++    for (listener = state->listeners; listener != NULL; listener = listener->next) {
++      listener->state = NULL;
++    }
++    destroy_state = 1;
++  }
++  enif_mutex_unlock(erts_wasm_state_lock);
 +
-+  enif_free(state);
++  if (destroy_state) {
++    destroy_wasm_state(state);
++  }
 +}
 +
 +static ERL_NIF_TERM register_listener_nif(ErlNifEnv *env, int argc,
 +                                          const ERL_NIF_TERM argv[]) {
 +  ErlNifBinary name;
 +  ErlNifPid self;
++  unsigned int name_kind;
 +  wasm_listener_t *listener;
 +  wasm_state_t *state = enif_priv_data(env);
 +
-+  if (argc != 1 || !enif_inspect_iolist_as_binary(env, argv[0], &name) ||
-+      name.size == 0) {
++  if (argc != 1 ||
++      !inspect_listener_registration(env, argv[0], &name, &name_kind)) {
 +    return enif_make_badarg(env);
 +  }
 +
 +  enif_self(env, &self);
 +
-+  enif_mutex_lock(state->lock);
-+  listener = find_listener_locked(env, state, name.data, name.size, NULL);
++  enif_mutex_lock(erts_wasm_state_lock);
++  listener =
++      find_listener_by_name_locked(env, state, name.data, name.size, NULL);
 +
 +  if (listener != NULL) {
-+    ERL_NIF_TERM result = same_pid(env, &listener->pid, &self)
++    ERL_NIF_TERM result = same_pid(&listener->pid, &self)
 +                              ? am_ok
 +                              : make_error(env, am_already_registered);
 +
-+    enif_mutex_unlock(state->lock);
++    enif_mutex_unlock(erts_wasm_state_lock);
 +    return result;
 +  }
 +
-+  listener = enif_alloc(sizeof(wasm_listener_t));
++  listener = enif_alloc_resource(wasm_listener_type, sizeof(wasm_listener_t));
 +  if (listener == NULL) {
-+    enif_mutex_unlock(state->lock);
++    enif_mutex_unlock(erts_wasm_state_lock);
 +    return make_error(env, am_out_of_memory);
 +  }
 +
-+  if (!copy_binary(&listener->name, &name)) {
-+    enif_free(listener);
-+    enif_mutex_unlock(state->lock);
-+    return make_error(env, am_out_of_memory);
-+  }
-+
-+  if (!copy_pid_token(env, &listener->pid_token, &self)) {
-+    enif_release_binary(&listener->name);
-+    enif_free(listener);
-+    enif_mutex_unlock(state->lock);
-+    return make_error(env, am_out_of_memory);
-+  }
-+
++  memset(listener, 0, sizeof(wasm_listener_t));
++  listener->state = state;
 +  listener->pid = self;
++  listener->name_kind = name_kind;
++
++  if (!copy_binary(&listener->name, &name) ||
++      !copy_pid_token(env, &listener->pid_token, &self)) {
++    listener->state = NULL;
++    enif_release_resource(listener);
++    enif_mutex_unlock(erts_wasm_state_lock);
++    return make_error(env, am_out_of_memory);
++  }
++
++  if (enif_monitor_process(env, listener, &self, &listener->monitor) != 0) {
++    listener->state = NULL;
++    enif_release_resource(listener);
++    enif_mutex_unlock(erts_wasm_state_lock);
++    return make_error(env, am_not_found);
++  }
++
 +  listener->next = state->listeners;
 +  state->listeners = listener;
 +
-+  enif_mutex_unlock(state->lock);
++  enif_mutex_unlock(erts_wasm_state_lock);
 +
 +  return am_ok;
 +}
@@ -541,143 +722,62 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +                                            const ERL_NIF_TERM argv[]) {
 +  ErlNifBinary name;
 +  ErlNifPid self;
++  unsigned int name_kind;
 +  wasm_listener_t *listener;
 +  wasm_listener_t *prev = NULL;
 +  wasm_state_t *state = enif_priv_data(env);
 +
-+  if (argc != 1 || !enif_inspect_iolist_as_binary(env, argv[0], &name) ||
-+      name.size == 0) {
++  (void)name_kind;
++
++  if (argc != 1 ||
++      !inspect_listener_registration(env, argv[0], &name, &name_kind)) {
 +    return enif_make_badarg(env);
 +  }
 +
 +  enif_self(env, &self);
 +
-+  enif_mutex_lock(state->lock);
-+  listener = find_listener_locked(env, state, name.data, name.size, &prev);
++  enif_mutex_lock(erts_wasm_state_lock);
++  listener =
++      find_listener_by_name_locked(env, state, name.data, name.size, &prev);
 +
 +  if (listener == NULL) {
-+    enif_mutex_unlock(state->lock);
++    enif_mutex_unlock(erts_wasm_state_lock);
 +    return make_error(env, am_not_found);
 +  }
 +
-+  if (!same_pid(env, &listener->pid, &self)) {
-+    enif_mutex_unlock(state->lock);
++  if (!same_pid(&listener->pid, &self)) {
++    enif_mutex_unlock(erts_wasm_state_lock);
 +    return make_error(env, am_not_owner);
 +  }
 +
 +  remove_listener_locked(state, prev, listener);
-+  enif_mutex_unlock(state->lock);
++  enif_mutex_unlock(erts_wasm_state_lock);
 +
 +  return am_ok;
 +}
 +
 +#ifdef ERTS_EMSCRIPTEN
-+extern void js_bridge_on_from_beam(const char *data, int len);
-+extern void js_bridge_on_error(const char *data, int len);
++extern void js_bridge_on_from_beam_async(char *data, int len);
 +
-+static void wasm_emit_error(const char *type, const char *detail) {
-+  char envelope[512];
-+  int written = snprintf(envelope, sizeof(envelope),
-+                         "{\"type\":\"%s\",\"detail\":\"%s\"}", type, detail);
++static void schedule_js_message(const unsigned char *data, size_t size) {
++  char *copy;
 +
-+  if (written <= 0) {
-+    return;
-+  }
-+  if (written >= (int)sizeof(envelope)) {
-+    written = (int)sizeof(envelope) - 1;
-+  }
-+
-+  js_bridge_on_error(envelope, written);
-+}
-+
-+EMSCRIPTEN_KEEPALIVE
-+void wasm_bridge_emit_error(const char *envelope, int len) {
-+  if (envelope == NULL || len <= 0) {
++  if (size > (size_t)INT_MAX) {
 +    return;
 +  }
 +
-+  js_bridge_on_error(envelope, len);
++  copy = malloc(size + 1);
++  if (copy == NULL) {
++    return;
++  }
++
++  if (size > 0) {
++    memcpy(copy, data, size);
++  }
++  copy[size] = '\0';
++
++  js_bridge_on_from_beam_async(copy, (int)size);
 +}
-+
-+EM_JS(void, js_vm_message_parse, (const char *data, int len), {
-+    var message = UTF8ToString(data, len);
-+
-+    function sendError(type, detail) {
-+      var envelope = JSON.stringify({
-+        type: type,
-+        detail: detail,
-+      });
-+      var ptr = Module.stringToNewUTF8(envelope);
-+      _wasm_bridge_emit_error(ptr, Module.lengthBytesUTF8(envelope));
-+      _free(ptr);
-+    }
-+
-+    var command;
-+    try {
-+      command = JSON.parse(message);
-+    } catch (_error) {
-+      sendError("invalid_message", "command is not valid JSON");
-+      return;
-+    }
-+
-+    if (command === null || typeof command !== "object") {
-+      sendError("invalid_message", "command must be a JSON object");
-+      return;
-+    }
-+
-+    if (command.type !== "send") {
-+      sendError("invalid_message", "command.type must be \"send\"");
-+      return;
-+    }
-+
-+    if (command.target === null || typeof command.target !== "object") {
-+      sendError("invalid_message", "command.target must be an object");
-+      return;
-+    }
-+
-+    var targetValue;
-+    if (typeof command.target.name === "string" && command.target.name.length > 0) {
-+      targetValue = command.target.name;
-+    } else if (typeof command.target.pid === "string" && command.target.pid.length > 0) {
-+      targetValue = command.target.pid;
-+    } else {
-+      sendError("invalid_message", "target.name or target.pid must be a non-empty string");
-+      return;
-+    }
-+
-+    var payload;
-+    try {
-+      payload = JSON.stringify(command.payload === undefined ? null : command.payload);
-+    } catch (_error) {
-+      sendError("invalid_message", "payload is not serializable");
-+      return;
-+    }
-+
-+    var meta;
-+    try {
-+      meta = JSON.stringify(command.meta === undefined ? null : command.meta);
-+    } catch (_error) {
-+      sendError("invalid_message", "meta is not serializable");
-+      return;
-+    }
-+
-+    var targetPtr = Module.stringToNewUTF8(targetValue);
-+    var payloadPtr = Module.stringToNewUTF8(payload);
-+    var metaPtr = Module.stringToNewUTF8(meta);
-+
-+    _wasm_bridge_dispatch(
-+      targetPtr,
-+      Module.lengthBytesUTF8(targetValue),
-+      payloadPtr,
-+      Module.lengthBytesUTF8(payload),
-+      metaPtr,
-+      Module.lengthBytesUTF8(meta)
-+    );
-+
-+    _free(targetPtr);
-+    _free(payloadPtr);
-+    _free(metaPtr);
-+});
 +#endif
 +
 +static ERL_NIF_TERM send_raw_nif(ErlNifEnv *env, int argc,
@@ -689,7 +789,7 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +  }
 +
 +#ifdef ERTS_EMSCRIPTEN
-+  js_bridge_on_from_beam((const char *)message.data, (int)message.size);
++  schedule_js_message(message.data, message.size);
 +  return am_ok;
 +#else
 +  return make_error(env, am_unsupported);
@@ -698,81 +798,83 @@ index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c5
 +
 +#ifdef ERTS_EMSCRIPTEN
 +EMSCRIPTEN_KEEPALIVE
-+void wasm_bridge_dispatch(const char *target_name, int target_name_len,
-+                          const char *payload_json, int payload_len,
-+                          const char *meta_json, int meta_len) {
++void sendVmMessage(const char *target_name, int target_name_len,
++                   const char *payload_json, int payload_len,
++                   const char *meta_json, int meta_len) {
 +  ErlNifEnv *env;
++  wasm_state_t *state;
 +  wasm_listener_t *listener;
 +  ErlNifPid pid;
 +  ERL_NIF_TERM payload_term;
 +  ERL_NIF_TERM meta_term;
 +  ERL_NIF_TERM message;
 +
-+  if (ensure_wasm_state() == NULL) {
-+    wasm_emit_error("bridge_error", "failed to initialize bridge state");
++  if (target_name == NULL || target_name_len <= 0 || payload_len < 0 ||
++      meta_len < 0 || (payload_json == NULL && payload_len > 0) ||
++      (meta_json == NULL && meta_len > 0)) {
 +    return;
 +  }
 +
 +  env = enif_alloc_env();
 +  if (env == NULL) {
-+    wasm_emit_error("bridge_error", "failed to allocate message environment");
 +    return;
 +  }
 +
-+  if (!resolve_registered_process_pid(env, target_name, (size_t)target_name_len,
-+                                      &pid)) {
-+    enif_mutex_lock(erts_wasm_state->lock);
-+    listener = find_listener_by_pid_token_locked(
-+        env, erts_wasm_state, (const unsigned char *)target_name,
-+        (size_t)target_name_len);
-+
-+    if (listener == NULL) {
-+      listener = find_listener_locked(env, erts_wasm_state,
-+                                      (const unsigned char *)target_name,
-+                                      (size_t)target_name_len, NULL);
-+    }
-+
-+    if (listener == NULL) {
-+      enif_mutex_unlock(erts_wasm_state->lock);
-+      enif_free_env(env);
-+      wasm_emit_error("listener_not_found",
-+                      "target pid or registered process is not available");
-+      return;
-+    }
-+
-+    pid = listener->pid;
-+    enif_mutex_unlock(erts_wasm_state->lock);
++  if (erts_wasm_state_lock == NULL) {
++    enif_free_env(env);
++    return;
 +  }
 +
-+  payload_term = make_binary_copy(env, payload_json != NULL ? payload_json : "",
-+                                  payload_len > 0 ? (size_t)payload_len : 0);
-+  meta_term = make_binary_copy(env, meta_json != NULL ? meta_json : "",
-+                               meta_len > 0 ? (size_t)meta_len : 0);
++  enif_mutex_lock(erts_wasm_state_lock);
++  state = erts_wasm_state;
++  if (state == NULL) {
++    enif_mutex_unlock(erts_wasm_state_lock);
++    enif_free_env(env);
++    return;
++  }
++
++  listener = find_listener_by_pid_token_locked(
++      env, state, (const unsigned char *)target_name, (size_t)target_name_len);
++
++  if (listener == NULL) {
++    listener = find_listener_by_name_locked(env, state,
++                                            (const unsigned char *)target_name,
++                                            (size_t)target_name_len, NULL);
++  }
++
++  if (listener != NULL) {
++    pid = listener->pid;
++  }
++  enif_mutex_unlock(erts_wasm_state_lock);
++
++  if (listener == NULL) {
++    enif_free_env(env);
++    return;
++  }
++
++  if (!make_binary_copy(env, payload_json != NULL ? payload_json : "",
++                        (size_t)payload_len, &payload_term) ||
++      !make_binary_copy(env, meta_json != NULL ? meta_json : "",
++                        (size_t)meta_len, &meta_term)) {
++    enif_free_env(env);
++    return;
++  }
++
 +  message = enif_make_tuple3(env, am_wasm, payload_term, meta_term);
 +
-+  if (!enif_send(NULL, &pid, env, message)) {
-+    enif_free_env(env);
-+    wasm_emit_error("bridge_error", "failed to deliver message to listener");
-+    return;
-+  }
-+
++  (void)enif_send(NULL, &pid, env, message);
 +  enif_free_env(env);
 +}
-+
-+EMSCRIPTEN_KEEPALIVE
-+void sendVmMessage(const char *data, int len) {
-+  if (data == NULL || len <= 0) {
-+    wasm_emit_error("invalid_message",
-+                    "command must be a non-empty UTF-8 string");
-+    return;
-+  }
-+
-+  js_vm_message_parse(data, len);
-+}
 +#else
-+void sendVmMessage(const char *data, int len) {
-+  (void)data;
-+  (void)len;
++void sendVmMessage(const char *target_name, int target_name_len,
++                   const char *payload_json, int payload_len,
++                   const char *meta_json, int meta_len) {
++  (void)target_name;
++  (void)target_name_len;
++  (void)payload_json;
++  (void)payload_len;
++  (void)meta_json;
++  (void)meta_len;
 +}
 +#endif
 diff --git a/erts/emulator/sys/unix/sys.c b/erts/emulator/sys/unix/sys.c
@@ -945,10 +1047,10 @@ index 7f42f8573765db26e571864972016e29c7ed5e01..c0ae85a462419b6d4ab1641c9f45f304
               zstd]},
 diff --git a/lib/stdlib/src/wasm.erl b/lib/stdlib/src/wasm.erl
 new file mode 100644
-index 0000000000000000000000000000000000000000..e31c87e05a826cb89bf1315e322cb4c4feb33a98
+index 0000000000000000000000000000000000000000..2f4f0a3c2a0f45d47d6b20bed64c8b58e0a412c0
 --- /dev/null
 +++ b/lib/stdlib/src/wasm.erl
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,72 @@
 +%%
 +%% %CopyrightBegin%
 +%%
@@ -979,17 +1081,19 @@ index 0000000000000000000000000000000000000000..e31c87e05a826cb89bf1315e322cb4c4
 +
 +-nifs([register_listener_nif/1, unregister_listener_nif/1, send_raw/1]).
 +
-+-type listener_name() :: atom() | unicode:charlist() | unicode:unicode_binary().
++-type listener_name() ::
++          atom() | pid() | unicode:charlist() | unicode:unicode_binary().
 +
 +-export_type([listener_name/0]).
 +
-+-spec register_listener(listener_name()) -> ok | {error, already_registered}.
++-spec register_listener(listener_name()) ->
++          ok | {error, already_registered | not_found | out_of_memory}.
 +register_listener(Name) ->
-+    register_listener_nif(normalize_name(Name)).
++    register_listener_nif(normalize_registration(Name)).
 +
 +-spec unregister_listener(listener_name()) -> ok | {error, not_found | not_owner}.
 +unregister_listener(Name) ->
-+    unregister_listener_nif(normalize_name(Name)).
++    unregister_listener_nif(normalize_registration(Name)).
 +
 +-spec send(json:encode_value()) -> ok.
 +send(Message) ->
@@ -1009,13 +1113,15 @@ index 0000000000000000000000000000000000000000..e31c87e05a826cb89bf1315e322cb4c4
 +send_raw(_Message) ->
 +    erlang:nif_error(undef).
 +
-+normalize_name(Name) when is_atom(Name) ->
-+    atom_to_binary(Name, utf8);
-+normalize_name(Name) when is_binary(Name) ->
-+    Name;
-+normalize_name(Name) when is_list(Name) ->
-+    unicode:characters_to_binary(Name);
-+normalize_name(Name) ->
++normalize_registration(Name) when is_atom(Name) ->
++    {registered_name, atom_to_binary(Name, utf8)};
++normalize_registration(Name) when is_pid(Name) ->
++    {opaque_name, list_to_binary(erlang:pid_to_list(Name))};
++normalize_registration(Name) when is_binary(Name) ->
++    {opaque_name, Name};
++normalize_registration(Name) when is_list(Name) ->
++    {opaque_name, unicode:characters_to_binary(Name)};
++normalize_registration(Name) ->
 +    erlang:error(badarg, [Name]).
 diff --git a/make/autoconf/otp.m4 b/make/autoconf/otp.m4
 index 2ca07d8d0e79eb5f1c6cdf2b303757b697697b92..839240d5dee15d710bd2d9f527b87ad8bafa90e1 100644

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -123,10 +123,10 @@ index 0000000000000000000000000000000000000000..0b7996e35e311aa67629a6e54df2820e
 +});
 diff --git a/erts/emulator/nifs/common/wasm_nif.c b/erts/emulator/nifs/common/wasm_nif.c
 new file mode 100644
-index 0000000000000000000000000000000000000000..242afa26643ff51ba1565991ff6bdd7c6dd9e8e8
+index 0000000000000000000000000000000000000000..8c520fc9f35f1bdeebe023a1f17f06c563cdd6ed
 --- /dev/null
 +++ b/erts/emulator/nifs/common/wasm_nif.c
-@@ -0,0 +1,610 @@
+@@ -0,0 +1,463 @@
 +/*
 + * %CopyrightBegin%
 + *
@@ -151,8 +151,8 @@ index 0000000000000000000000000000000000000000..242afa26643ff51ba1565991ff6bdd7c
 +
 +#define STATIC_ERLANG_NIF 1
 +
-+#include "erl_nif.h"
 +#include "config.h"
++#include "erl_nif.h"
 +#include "sys.h"
 +
 +#include <stddef.h>
@@ -160,35 +160,31 @@ index 0000000000000000000000000000000000000000..242afa26643ff51ba1565991ff6bdd7c
 +#include <string.h>
 +
 +#ifdef ERTS_EMSCRIPTEN
-+#  include <emscripten/emscripten.h>
++#include <emscripten/emscripten.h>
 +#endif
 +
 +typedef struct wasm_listener_s {
-+    ErlNifBinary name;
-+    ErlNifPid pid;
-+    struct wasm_listener_s *next;
++  ErlNifBinary name;
++  ErlNifBinary pid_token;
++  ErlNifPid pid;
++  struct wasm_listener_s *next;
 +} wasm_listener_t;
 +
 +typedef struct {
-+    ErlNifMutex *lock;
-+    wasm_listener_t *listeners;
++  ErlNifMutex *lock;
++  wasm_listener_t *listeners;
 +} wasm_state_t;
 +
 +static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info);
-+static int upgrade(ErlNifEnv *env,
-+                   void **priv_data,
-+                   void **old_priv_data,
++static int upgrade(ErlNifEnv *env, void **priv_data, void **old_priv_data,
 +                   ERL_NIF_TERM load_info);
 +static void unload(ErlNifEnv *env, void *priv_data);
 +
-+static ERL_NIF_TERM register_listener_nif(ErlNifEnv *env,
-+                                          int argc,
++static ERL_NIF_TERM register_listener_nif(ErlNifEnv *env, int argc,
 +                                          const ERL_NIF_TERM argv[]);
-+static ERL_NIF_TERM unregister_listener_nif(ErlNifEnv *env,
-+                                            int argc,
++static ERL_NIF_TERM unregister_listener_nif(ErlNifEnv *env, int argc,
 +                                            const ERL_NIF_TERM argv[]);
-+static ERL_NIF_TERM send_raw_nif(ErlNifEnv *env,
-+                                 int argc,
++static ERL_NIF_TERM send_raw_nif(ErlNifEnv *env, int argc,
 +                                 const ERL_NIF_TERM argv[]);
 +
 +static ErlNifFunc nif_funcs[] = {
@@ -221,339 +217,386 @@ index 0000000000000000000000000000000000000000..242afa26643ff51ba1565991ff6bdd7c
 +void sendVmMessage(const char *data, int len);
 +#endif
 +
-+static wasm_state_t *create_wasm_state(void)
-+{
-+    wasm_state_t *state;
++static wasm_state_t *create_wasm_state(void) {
++  wasm_state_t *state;
 +
-+    state = enif_alloc(sizeof(wasm_state_t));
-+    if (state == NULL) {
-+        return NULL;
-+    }
++  state = enif_alloc(sizeof(wasm_state_t));
++  if (state == NULL) {
++    return NULL;
++  }
 +
-+    state->lock = enif_mutex_create("wasm_nif_lock");
-+    if (state->lock == NULL) {
-+        enif_free(state);
-+        return NULL;
-+    }
-+
-+    state->listeners = NULL;
-+
-+    return state;
-+}
-+
-+static wasm_state_t *ensure_wasm_state(void)
-+{
-+    wasm_state_t *state;
-+
-+    if (erts_wasm_state != NULL) {
-+        return erts_wasm_state;
-+    }
-+
-+    state = create_wasm_state();
-+    if (state == NULL) {
-+        return NULL;
-+    }
-+
-+    if (erts_wasm_state == NULL) {
-+        erts_wasm_state = state;
-+        return state;
-+    }
-+
-+    enif_mutex_destroy(state->lock);
++  state->lock = enif_mutex_create("wasm_nif_lock");
++  if (state->lock == NULL) {
 +    enif_free(state);
++    return NULL;
++  }
++
++  state->listeners = NULL;
++
++  return state;
++}
++
++static wasm_state_t *ensure_wasm_state(void) {
++  wasm_state_t *state;
++
++  if (erts_wasm_state != NULL) {
 +    return erts_wasm_state;
++  }
++
++  state = create_wasm_state();
++  if (state == NULL) {
++    return NULL;
++  }
++
++  if (erts_wasm_state == NULL) {
++    erts_wasm_state = state;
++    return state;
++  }
++
++  enif_mutex_destroy(state->lock);
++  enif_free(state);
++  return erts_wasm_state;
 +}
 +
-+static int same_name(const unsigned char *lhs_data,
-+                     size_t lhs_size,
-+                     const unsigned char *rhs_data,
-+                     size_t rhs_size)
-+{
-+    return lhs_size == rhs_size
-+        && (lhs_size == 0 || memcmp(lhs_data, rhs_data, lhs_size) == 0);
++static int same_name(const unsigned char *lhs_data, size_t lhs_size,
++                     const unsigned char *rhs_data, size_t rhs_size) {
++  return lhs_size == rhs_size &&
++         (lhs_size == 0 || memcmp(lhs_data, rhs_data, lhs_size) == 0);
 +}
 +
-+static int same_pid(ErlNifEnv *env, const ErlNifPid *lhs, const ErlNifPid *rhs)
-+{
-+    return enif_is_identical(enif_make_pid(env, lhs), enif_make_pid(env, rhs));
++static int same_pid(ErlNifEnv *env, const ErlNifPid *lhs,
++                    const ErlNifPid *rhs) {
++  return enif_is_identical(enif_make_pid(env, lhs), enif_make_pid(env, rhs));
 +}
 +
-+static ERL_NIF_TERM make_error(ErlNifEnv *env, ERL_NIF_TERM reason)
-+{
-+    return enif_make_tuple2(env, am_error, reason);
++static ERL_NIF_TERM make_error(ErlNifEnv *env, ERL_NIF_TERM reason) {
++  return enif_make_tuple2(env, am_error, reason);
 +}
 +
-+static int copy_binary(ErlNifBinary *dst, const ErlNifBinary *src)
-+{
-+    if (!enif_alloc_binary(src->size, dst)) {
-+        return 0;
-+    }
++static int copy_binary(ErlNifBinary *dst, const ErlNifBinary *src) {
++  if (!enif_alloc_binary(src->size, dst)) {
++    return 0;
++  }
 +
-+    if (src->size > 0) {
-+        memcpy(dst->data, src->data, src->size);
-+    }
++  if (src->size > 0) {
++    memcpy(dst->data, src->data, src->size);
++  }
 +
-+    return 1;
++  return 1;
 +}
 +
-+static void free_listener(wasm_listener_t *listener)
-+{
-+    enif_release_binary(&listener->name);
-+    enif_free(listener);
++static int copy_pid_token(ErlNifEnv *env, ErlNifBinary *dst,
++                          const ErlNifPid *pid) {
++  char pid_token[64];
++  ERL_NIF_TERM pid_term;
++  int pid_token_len;
++
++  pid_term = enif_make_pid(env, pid);
++  pid_token_len = enif_snprintf(pid_token, sizeof(pid_token), "%T", pid_term);
++  if (pid_token_len < 0 || pid_token_len >= (int)sizeof(pid_token)) {
++    return 0;
++  }
++
++  if (!enif_alloc_binary((size_t)pid_token_len, dst)) {
++    return 0;
++  }
++
++  if (pid_token_len > 0) {
++    memcpy(dst->data, pid_token, (size_t)pid_token_len);
++  }
++
++  return 1;
 +}
 +
-+static void remove_listener_locked(wasm_state_t *state,
-+                                   wasm_listener_t *prev,
-+                                   wasm_listener_t *listener)
-+{
-+    if (prev == NULL) {
-+        state->listeners = listener->next;
-+    } else {
-+        prev->next = listener->next;
-+    }
++static void free_listener(wasm_listener_t *listener) {
++  enif_release_binary(&listener->name);
++  enif_release_binary(&listener->pid_token);
++  enif_free(listener);
++}
 +
-+    free_listener(listener);
++static void remove_listener_locked(wasm_state_t *state, wasm_listener_t *prev,
++                                   wasm_listener_t *listener) {
++  if (prev == NULL) {
++    state->listeners = listener->next;
++  } else {
++    prev->next = listener->next;
++  }
++
++  free_listener(listener);
 +}
 +
 +static wasm_listener_t *find_listener_locked(ErlNifEnv *env,
 +                                             wasm_state_t *state,
 +                                             const unsigned char *name_data,
 +                                             size_t name_size,
-+                                             wasm_listener_t **prev_out)
-+{
-+    wasm_listener_t *prev = NULL;
-+    wasm_listener_t *listener = state->listeners;
++                                             wasm_listener_t **prev_out) {
++  wasm_listener_t *prev = NULL;
++  wasm_listener_t *listener = state->listeners;
 +
-+    while (listener != NULL) {
-+        wasm_listener_t *next = listener->next;
++  while (listener != NULL) {
++    wasm_listener_t *next = listener->next;
 +
-+        if (!enif_is_process_alive(env, &listener->pid)) {
-+            remove_listener_locked(state, prev, listener);
-+            listener = next;
-+            continue;
-+        }
-+
-+        if (same_name(listener->name.data,
-+                      listener->name.size,
-+                      name_data,
-+                      name_size)) {
-+            if (prev_out != NULL) {
-+                *prev_out = prev;
-+            }
-+            return listener;
-+        }
-+
-+        prev = listener;
-+        listener = next;
++    if (!enif_is_process_alive(env, &listener->pid)) {
++      remove_listener_locked(state, prev, listener);
++      listener = next;
++      continue;
 +    }
 +
-+    if (prev_out != NULL) {
++    if (same_name(listener->name.data, listener->name.size, name_data,
++                  name_size)) {
++      if (prev_out != NULL) {
 +        *prev_out = prev;
++      }
++      return listener;
 +    }
 +
-+    return NULL;
++    prev = listener;
++    listener = next;
++  }
++
++  if (prev_out != NULL) {
++    *prev_out = prev;
++  }
++
++  return NULL;
 +}
 +
-+static ERL_NIF_TERM make_binary_copy(ErlNifEnv *env,
-+                                     const char *data,
-+                                     size_t size)
-+{
-+    unsigned char *dst;
-+    ERL_NIF_TERM term;
++static wasm_listener_t *find_listener_by_pid_token_locked(
++    ErlNifEnv *env, wasm_state_t *state, const unsigned char *pid_token_data,
++    size_t pid_token_size) {
++  wasm_listener_t *prev = NULL;
++  wasm_listener_t *listener = state->listeners;
 +
-+    dst = enif_make_new_binary(env, size, &term);
-+    if (dst == NULL) {
-+        return enif_make_badarg(env);
++  while (listener != NULL) {
++    wasm_listener_t *next = listener->next;
++
++    if (!enif_is_process_alive(env, &listener->pid)) {
++      remove_listener_locked(state, prev, listener);
++      listener = next;
++      continue;
 +    }
 +
-+    if (size > 0) {
-+        memcpy(dst, data, size);
++    if (same_name(listener->pid_token.data, listener->pid_token.size,
++                  pid_token_data, pid_token_size)) {
++      return listener;
 +    }
 +
-+    return term;
++    prev = listener;
++    listener = next;
++  }
++
++  return NULL;
 +}
 +
-+static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info)
-+{
-+    wasm_state_t *state;
++static int resolve_registered_process_pid(ErlNifEnv *env, const char *target_name,
++                                          size_t target_name_len,
++                                          ErlNifPid *pid) {
++  ERL_NIF_TERM target_atom;
 +
-+    (void) load_info;
-+
-+    state = ensure_wasm_state();
-+    if (state == NULL) {
-+        return -1;
-+    }
-+
-+    am_ok = enif_make_atom(env, "ok");
-+    am_error = enif_make_atom(env, "error");
-+    am_already_registered = enif_make_atom(env, "already_registered");
-+    am_not_found = enif_make_atom(env, "not_found");
-+    am_not_owner = enif_make_atom(env, "not_owner");
-+    am_out_of_memory = enif_make_atom(env, "out_of_memory");
-+    am_unsupported = enif_make_atom(env, "unsupported");
-+    am_wasm = enif_make_atom(env, "wasm");
-+
-+    *priv_data = state;
-+
++  if (target_name_len == 0) {
 +    return 0;
++  }
++
++  if (!enif_make_existing_atom_len(env, target_name, target_name_len,
++                                   &target_atom, ERL_NIF_UTF8)) {
++    return 0;
++  }
++
++  return enif_whereis_pid(env, target_atom, pid);
 +}
 +
-+static int upgrade(ErlNifEnv *env,
-+                   void **priv_data,
-+                   void **old_priv_data,
-+                   ERL_NIF_TERM load_info)
-+{
-+    (void) old_priv_data;
++static ERL_NIF_TERM make_binary_copy(ErlNifEnv *env, const char *data,
++                                     size_t size) {
++  unsigned char *dst;
++  ERL_NIF_TERM term;
 +
-+    if (*priv_data != NULL) {
-+        return -1;
-+    }
++  dst = enif_make_new_binary(env, size, &term);
++  if (dst == NULL) {
++    return enif_make_badarg(env);
++  }
 +
-+    return load(env, priv_data, load_info);
++  if (size > 0) {
++    memcpy(dst, data, size);
++  }
++
++  return term;
 +}
 +
-+static void unload(ErlNifEnv *env, void *priv_data)
-+{
-+    wasm_state_t *state = priv_data;
-+    wasm_listener_t *listener;
++static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info) {
++  wasm_state_t *state;
 +
-+    (void) env;
++  (void)load_info;
 +
-+    if (state == NULL) {
-+        return;
-+    }
++  state = ensure_wasm_state();
++  if (state == NULL) {
++    return -1;
++  }
 +
-+    listener = state->listeners;
-+    while (listener != NULL) {
-+        wasm_listener_t *next = listener->next;
-+        free_listener(listener);
-+        listener = next;
-+    }
++  am_ok = enif_make_atom(env, "ok");
++  am_error = enif_make_atom(env, "error");
++  am_already_registered = enif_make_atom(env, "already_registered");
++  am_not_found = enif_make_atom(env, "not_found");
++  am_not_owner = enif_make_atom(env, "not_owner");
++  am_out_of_memory = enif_make_atom(env, "out_of_memory");
++  am_unsupported = enif_make_atom(env, "unsupported");
++  am_wasm = enif_make_atom(env, "wasm");
 +
-+    enif_mutex_destroy(state->lock);
++  *priv_data = state;
 +
-+    if (erts_wasm_state == state) {
-+        erts_wasm_state = NULL;
-+    }
-+
-+    enif_free(state);
++  return 0;
 +}
 +
-+static ERL_NIF_TERM register_listener_nif(ErlNifEnv *env,
-+                                          int argc,
-+                                          const ERL_NIF_TERM argv[])
-+{
-+    ErlNifBinary name;
-+    ErlNifPid self;
-+    wasm_listener_t *listener;
-+    wasm_state_t *state = enif_priv_data(env);
++static int upgrade(ErlNifEnv *env, void **priv_data, void **old_priv_data,
++                   ERL_NIF_TERM load_info) {
++  (void)old_priv_data;
 +
-+    if (argc != 1 || !enif_inspect_iolist_as_binary(env, argv[0], &name) || name.size == 0) {
-+        return enif_make_badarg(env);
-+    }
++  if (*priv_data != NULL) {
++    return -1;
++  }
 +
-+    enif_self(env, &self);
++  return load(env, priv_data, load_info);
++}
 +
-+    enif_mutex_lock(state->lock);
-+    listener = find_listener_locked(env, state, name.data, name.size, NULL);
++static void unload(ErlNifEnv *env, void *priv_data) {
++  wasm_state_t *state = priv_data;
++  wasm_listener_t *listener;
 +
-+    if (listener != NULL) {
-+        ERL_NIF_TERM result =
-+            same_pid(env, &listener->pid, &self)
-+                ? am_ok
-+                : make_error(env, am_already_registered);
++  (void)env;
 +
-+        enif_mutex_unlock(state->lock);
-+        return result;
-+    }
++  if (state == NULL) {
++    return;
++  }
 +
-+    listener = enif_alloc(sizeof(wasm_listener_t));
-+    if (listener == NULL) {
-+        enif_mutex_unlock(state->lock);
-+        return make_error(env, am_out_of_memory);
-+    }
++  listener = state->listeners;
++  while (listener != NULL) {
++    wasm_listener_t *next = listener->next;
++    free_listener(listener);
++    listener = next;
++  }
 +
-+    if (!copy_binary(&listener->name, &name)) {
-+        enif_free(listener);
-+        enif_mutex_unlock(state->lock);
-+        return make_error(env, am_out_of_memory);
-+    }
++  enif_mutex_destroy(state->lock);
 +
-+    listener->pid = self;
-+    listener->next = state->listeners;
-+    state->listeners = listener;
++  if (erts_wasm_state == state) {
++    erts_wasm_state = NULL;
++  }
++
++  enif_free(state);
++}
++
++static ERL_NIF_TERM register_listener_nif(ErlNifEnv *env, int argc,
++                                          const ERL_NIF_TERM argv[]) {
++  ErlNifBinary name;
++  ErlNifPid self;
++  wasm_listener_t *listener;
++  wasm_state_t *state = enif_priv_data(env);
++
++  if (argc != 1 || !enif_inspect_iolist_as_binary(env, argv[0], &name) ||
++      name.size == 0) {
++    return enif_make_badarg(env);
++  }
++
++  enif_self(env, &self);
++
++  enif_mutex_lock(state->lock);
++  listener = find_listener_locked(env, state, name.data, name.size, NULL);
++
++  if (listener != NULL) {
++    ERL_NIF_TERM result = same_pid(env, &listener->pid, &self)
++                              ? am_ok
++                              : make_error(env, am_already_registered);
 +
 +    enif_mutex_unlock(state->lock);
++    return result;
++  }
 +
-+    return am_ok;
++  listener = enif_alloc(sizeof(wasm_listener_t));
++  if (listener == NULL) {
++    enif_mutex_unlock(state->lock);
++    return make_error(env, am_out_of_memory);
++  }
++
++  if (!copy_binary(&listener->name, &name)) {
++    enif_free(listener);
++    enif_mutex_unlock(state->lock);
++    return make_error(env, am_out_of_memory);
++  }
++
++  if (!copy_pid_token(env, &listener->pid_token, &self)) {
++    enif_release_binary(&listener->name);
++    enif_free(listener);
++    enif_mutex_unlock(state->lock);
++    return make_error(env, am_out_of_memory);
++  }
++
++  listener->pid = self;
++  listener->next = state->listeners;
++  state->listeners = listener;
++
++  enif_mutex_unlock(state->lock);
++
++  return am_ok;
 +}
 +
-+static ERL_NIF_TERM unregister_listener_nif(ErlNifEnv *env,
-+                                            int argc,
-+                                            const ERL_NIF_TERM argv[])
-+{
-+    ErlNifBinary name;
-+    ErlNifPid self;
-+    wasm_listener_t *listener;
-+    wasm_listener_t *prev = NULL;
-+    wasm_state_t *state = enif_priv_data(env);
++static ERL_NIF_TERM unregister_listener_nif(ErlNifEnv *env, int argc,
++                                            const ERL_NIF_TERM argv[]) {
++  ErlNifBinary name;
++  ErlNifPid self;
++  wasm_listener_t *listener;
++  wasm_listener_t *prev = NULL;
++  wasm_state_t *state = enif_priv_data(env);
 +
-+    if (argc != 1 || !enif_inspect_iolist_as_binary(env, argv[0], &name) || name.size == 0) {
-+        return enif_make_badarg(env);
-+    }
++  if (argc != 1 || !enif_inspect_iolist_as_binary(env, argv[0], &name) ||
++      name.size == 0) {
++    return enif_make_badarg(env);
++  }
 +
-+    enif_self(env, &self);
++  enif_self(env, &self);
 +
-+    enif_mutex_lock(state->lock);
-+    listener = find_listener_locked(env, state, name.data, name.size, &prev);
++  enif_mutex_lock(state->lock);
++  listener = find_listener_locked(env, state, name.data, name.size, &prev);
 +
-+    if (listener == NULL) {
-+        enif_mutex_unlock(state->lock);
-+        return make_error(env, am_not_found);
-+    }
-+
-+    if (!same_pid(env, &listener->pid, &self)) {
-+        enif_mutex_unlock(state->lock);
-+        return make_error(env, am_not_owner);
-+    }
-+
-+    remove_listener_locked(state, prev, listener);
++  if (listener == NULL) {
 +    enif_mutex_unlock(state->lock);
++    return make_error(env, am_not_found);
++  }
 +
-+    return am_ok;
++  if (!same_pid(env, &listener->pid, &self)) {
++    enif_mutex_unlock(state->lock);
++    return make_error(env, am_not_owner);
++  }
++
++  remove_listener_locked(state, prev, listener);
++  enif_mutex_unlock(state->lock);
++
++  return am_ok;
 +}
 +
 +#ifdef ERTS_EMSCRIPTEN
 +extern void js_bridge_on_from_beam(const char *data, int len);
 +extern void js_bridge_on_error(const char *data, int len);
 +
-+static void wasm_emit_error(const char *type, const char *detail)
-+{
-+    char envelope[512];
-+    int written = snprintf(envelope,
-+                           sizeof(envelope),
-+                           "{\"type\":\"%s\",\"detail\":\"%s\"}",
-+                           type,
-+                           detail);
++static void wasm_emit_error(const char *type, const char *detail) {
++  char envelope[512];
++  int written = snprintf(envelope, sizeof(envelope),
++                         "{\"type\":\"%s\",\"detail\":\"%s\"}", type, detail);
 +
-+    if (written <= 0) {
-+        return;
-+    }
-+    if (written >= (int) sizeof(envelope)) {
-+        written = (int) sizeof(envelope) - 1;
-+    }
++  if (written <= 0) {
++    return;
++  }
++  if (written >= (int)sizeof(envelope)) {
++    written = (int)sizeof(envelope) - 1;
++  }
 +
-+    js_bridge_on_error(envelope, written);
++  js_bridge_on_error(envelope, written);
 +}
 +
 +EMSCRIPTEN_KEEPALIVE
-+void wasm_bridge_emit_error(const char *envelope, int len)
-+{
-+    if (envelope == NULL || len <= 0) {
-+        return;
-+    }
++void wasm_bridge_emit_error(const char *envelope, int len) {
++  if (envelope == NULL || len <= 0) {
++    return;
++  }
 +
-+    js_bridge_on_error(envelope, len);
++  js_bridge_on_error(envelope, len);
 +}
 +
 +EM_JS(void, js_vm_message_parse, (const char *data, int len), {
@@ -592,12 +635,13 @@ index 0000000000000000000000000000000000000000..242afa26643ff51ba1565991ff6bdd7c
 +      return;
 +    }
 +
-+    if (typeof command.target.name !== "string" || command.target.name.length === 0) {
-+      if (typeof command.target.pid === "string") {
-+        sendError("unsupported_target", "pid targets are not supported yet");
-+      } else {
-+        sendError("invalid_message", "target.name must be a non-empty string");
-+      }
++    var targetValue;
++    if (typeof command.target.name === "string" && command.target.name.length > 0) {
++      targetValue = command.target.name;
++    } else if (typeof command.target.pid === "string" && command.target.pid.length > 0) {
++      targetValue = command.target.pid;
++    } else {
++      sendError("invalid_message", "target.name or target.pid must be a non-empty string");
 +      return;
 +    }
 +
@@ -617,124 +661,118 @@ index 0000000000000000000000000000000000000000..242afa26643ff51ba1565991ff6bdd7c
 +      return;
 +    }
 +
-+    var namePtr = Module.stringToNewUTF8(command.target.name);
++    var targetPtr = Module.stringToNewUTF8(targetValue);
 +    var payloadPtr = Module.stringToNewUTF8(payload);
 +    var metaPtr = Module.stringToNewUTF8(meta);
 +
 +    _wasm_bridge_dispatch(
-+      namePtr,
-+      Module.lengthBytesUTF8(command.target.name),
++      targetPtr,
++      Module.lengthBytesUTF8(targetValue),
 +      payloadPtr,
 +      Module.lengthBytesUTF8(payload),
 +      metaPtr,
 +      Module.lengthBytesUTF8(meta)
 +    );
 +
-+    _free(namePtr);
++    _free(targetPtr);
 +    _free(payloadPtr);
 +    _free(metaPtr);
 +});
++#endif
 +
++static ERL_NIF_TERM send_raw_nif(ErlNifEnv *env, int argc,
++                                 const ERL_NIF_TERM argv[]) {
++  ErlNifBinary message;
++
++  if (argc != 1 || !enif_inspect_iolist_as_binary(env, argv[0], &message)) {
++    return enif_make_badarg(env);
++  }
++
++#ifdef ERTS_EMSCRIPTEN
++  js_bridge_on_from_beam((const char *)message.data, (int)message.size);
++  return am_ok;
++#else
++  return make_error(env, am_unsupported);
++#endif
++}
++
++#ifdef ERTS_EMSCRIPTEN
 +EMSCRIPTEN_KEEPALIVE
-+void wasm_bridge_dispatch(const char *target_name,
-+                          int target_name_len,
-+                          const char *payload_json,
-+                          int payload_len,
-+                          const char *meta_json,
-+                          int meta_len)
-+{
-+    ErlNifEnv *env;
-+    wasm_listener_t *listener;
-+    ErlNifPid pid;
-+    ERL_NIF_TERM payload_term;
-+    ERL_NIF_TERM meta_term;
-+    ERL_NIF_TERM message;
++void wasm_bridge_dispatch(const char *target_name, int target_name_len,
++                          const char *payload_json, int payload_len,
++                          const char *meta_json, int meta_len) {
++  ErlNifEnv *env;
++  wasm_listener_t *listener;
++  ErlNifPid pid;
++  ERL_NIF_TERM payload_term;
++  ERL_NIF_TERM meta_term;
++  ERL_NIF_TERM message;
 +
-+    if (ensure_wasm_state() == NULL) {
-+        wasm_emit_error("bridge_error", "failed to initialize bridge state");
-+        return;
-+    }
++  if (ensure_wasm_state() == NULL) {
++    wasm_emit_error("bridge_error", "failed to initialize bridge state");
++    return;
++  }
 +
-+    if (target_name == NULL || target_name_len <= 0) {
-+        wasm_emit_error("invalid_message", "target is missing");
-+        return;
-+    }
++  env = enif_alloc_env();
++  if (env == NULL) {
++    wasm_emit_error("bridge_error", "failed to allocate message environment");
++    return;
++  }
 +
-+    env = enif_alloc_env();
-+    if (env == NULL) {
-+        wasm_emit_error("bridge_error", "failed to allocate message environment");
-+        return;
-+    }
-+
++  if (!resolve_registered_process_pid(env, target_name, (size_t)target_name_len,
++                                      &pid)) {
 +    enif_mutex_lock(erts_wasm_state->lock);
-+    listener = find_listener_locked(env,
-+                                    erts_wasm_state,
-+                                    (const unsigned char *) target_name,
-+                                    (size_t) target_name_len,
-+                                    NULL);
++    listener = find_listener_by_pid_token_locked(
++        env, erts_wasm_state, (const unsigned char *)target_name,
++        (size_t)target_name_len);
 +
 +    if (listener == NULL) {
-+        enif_mutex_unlock(erts_wasm_state->lock);
-+        enif_free_env(env);
-+        wasm_emit_error("listener_not_found", "target listener is not registered");
-+        return;
++      listener = find_listener_locked(env, erts_wasm_state,
++                                      (const unsigned char *)target_name,
++                                      (size_t)target_name_len, NULL);
++    }
++
++    if (listener == NULL) {
++      enif_mutex_unlock(erts_wasm_state->lock);
++      enif_free_env(env);
++      wasm_emit_error("listener_not_found",
++                      "target pid or registered process is not available");
++      return;
 +    }
 +
 +    pid = listener->pid;
 +    enif_mutex_unlock(erts_wasm_state->lock);
++  }
 +
-+    payload_term = make_binary_copy(env,
-+                                    payload_json != NULL ? payload_json : "",
-+                                    payload_len > 0 ? (size_t) payload_len : 0);
-+    meta_term = make_binary_copy(env,
-+                                 meta_json != NULL ? meta_json : "",
-+                                 meta_len > 0 ? (size_t) meta_len : 0);
-+    message = enif_make_tuple3(env, am_wasm, payload_term, meta_term);
++  payload_term = make_binary_copy(env, payload_json != NULL ? payload_json : "",
++                                  payload_len > 0 ? (size_t)payload_len : 0);
++  meta_term = make_binary_copy(env, meta_json != NULL ? meta_json : "",
++                               meta_len > 0 ? (size_t)meta_len : 0);
++  message = enif_make_tuple3(env, am_wasm, payload_term, meta_term);
 +
-+    if (!enif_send(NULL, &pid, env, message)) {
-+        enif_free_env(env);
-+        wasm_emit_error("bridge_error", "failed to deliver message to listener");
-+        return;
-+    }
-+
++  if (!enif_send(NULL, &pid, env, message)) {
 +    enif_free_env(env);
-+}
-+#endif
++    wasm_emit_error("bridge_error", "failed to deliver message to listener");
++    return;
++  }
 +
-+static ERL_NIF_TERM send_raw_nif(ErlNifEnv *env,
-+                                 int argc,
-+                                 const ERL_NIF_TERM argv[])
-+{
-+    ErlNifBinary message;
-+
-+    if (argc != 1 || !enif_inspect_iolist_as_binary(env, argv[0], &message)) {
-+        return enif_make_badarg(env);
-+    }
-+
-+#ifdef ERTS_EMSCRIPTEN
-+    js_bridge_on_from_beam((const char *) message.data, (int) message.size);
-+    return am_ok;
-+#else
-+    return make_error(env, am_unsupported);
-+#endif
++  enif_free_env(env);
 +}
 +
-+#ifdef ERTS_EMSCRIPTEN
 +EMSCRIPTEN_KEEPALIVE
-+void sendVmMessage(const char *data, int len)
-+{
-+    if (data == NULL || len <= 0) {
-+        wasm_emit_error("invalid_message", "command must be a non-empty UTF-8 string");
-+        return;
-+    }
++void sendVmMessage(const char *data, int len) {
++  if (data == NULL || len <= 0) {
++    wasm_emit_error("invalid_message",
++                    "command must be a non-empty UTF-8 string");
++    return;
++  }
 +
-+    js_vm_message_parse(data, len);
++  js_vm_message_parse(data, len);
 +}
 +#else
-+void sendVmMessage(const char *data, int len)
-+{
-+    (void) data;
-+    (void) len;
++void sendVmMessage(const char *data, int len) {
++  (void)data;
++  (void)len;
 +}
 +#endif
 diff --git a/erts/emulator/sys/unix/sys.c b/erts/emulator/sys/unix/sys.c

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -74,6 +74,18 @@ index 5d6c12c8a54493e3550082370288a7d0cc79aded..170b833e8f5c20fab52426010083a9b6
  	$(STATIC_NIF_LIBS) $(STATIC_DRIVER_LIBS) $(LIBS)
  
  endif
+diff --git a/erts/emulator/beam/erl_bif_chksum.c b/erts/emulator/beam/erl_bif_chksum.c
+index a09675e3552f985b3f416dd83f07824f0e5d3860..80e625774c76ad03b804dcc15e9c7162a74114fc 100644
+--- a/erts/emulator/beam/erl_bif_chksum.c
++++ b/erts/emulator/beam/erl_bif_chksum.c
+@@ -34,7 +34,6 @@
+ #include "zlib.h"
+ #include "erl_md5.h"
+ 
+-
+ typedef void (*ChksumFun)(void *sum_in_out, const byte *buf,
+ 			  unsigned buflen);
+ 
 diff --git a/erts/emulator/js_bridge/beam-bridge.pre.js b/erts/emulator/js_bridge/beam-bridge.pre.js
 new file mode 100644
 index 0000000000000000000000000000000000000000..2e85c729e92e9948fd15302a88ed12a4d3bfbe60
@@ -130,10 +142,10 @@ index 0000000000000000000000000000000000000000..0b446eedf17294c0c47c2b872bf2fb44
 +});
 diff --git a/erts/emulator/nifs/common/wasm_nif.c b/erts/emulator/nifs/common/wasm_nif.c
 new file mode 100644
-index 0000000000000000000000000000000000000000..1ddc7e33577a23a17fbb3230086ac9ae6a7c6505
+index 0000000000000000000000000000000000000000..360a7310ffb94e80e5cdfe92428fb4173b9b9b10
 --- /dev/null
 +++ b/erts/emulator/nifs/common/wasm_nif.c
-@@ -0,0 +1,743 @@
+@@ -0,0 +1,742 @@
 +/*
 + * %CopyrightBegin%
 + *
@@ -238,9 +250,9 @@ index 0000000000000000000000000000000000000000..1ddc7e33577a23a17fbb3230086ac9ae
 +static wasm_state_t *erts_wasm_state = NULL;
 +
 +#ifdef ERTS_EMSCRIPTEN
-+void sendVmMessage(const char *target_name, int target_name_len,
-+                   const char *payload_json, int payload_len,
-+                   const char *meta_json, int meta_len);
++int sendVmMessage(const char *target_name, int target_name_len,
++                  const char *payload_json, int payload_len,
++                  const char *meta_json, int meta_len);
 +#endif
 +
 +static void init_atoms(ErlNifEnv *env) {
@@ -382,24 +394,16 @@ index 0000000000000000000000000000000000000000..1ddc7e33577a23a17fbb3230086ac9ae
 +
 +static int listener_registered_name_is_current(ErlNifEnv *env,
 +                                               wasm_listener_t *listener) {
-+  ERL_NIF_TERM registered_name;
-+  ErlNifPid current_pid;
++  (void)env;
++  (void)listener;
 +
-+  if (listener->name_kind != WASM_LISTENER_NAME_REGISTERED) {
-+    return 1;
-+  }
-+
-+  if (!enif_make_existing_atom_len(env, (const char *)listener->name.data,
-+                                   listener->name.size, &registered_name,
-+                                   ERL_NIF_UTF8)) {
-+    return 0;
-+  }
-+
-+  if (!enif_whereis_pid(env, registered_name, &current_pid)) {
-+    return 0;
-+  }
-+
-+  return same_pid(&listener->pid, &current_pid);
++  /*
++   * `wasm:register_listener/1` creates an explicit bridge alias for the
++   * current pid. Atom names are labels for JS callers and should not be tied
++   * to `register/2` ownership, otherwise a listener registered as
++   * `wasm:register_listener(bridge)` is discarded before the first lookup.
++   */
++  return 1;
 +}
 +
 +static int listener_is_stale(ErlNifEnv *env, wasm_listener_t *listener) {
@@ -778,6 +782,7 @@ index 0000000000000000000000000000000000000000..1ddc7e33577a23a17fbb3230086ac9ae
 +
 +  js_bridge_on_from_beam_async(copy, (int)size);
 +}
++
 +#endif
 +
 +static ERL_NIF_TERM send_raw_nif(ErlNifEnv *env, int argc,
@@ -798,9 +803,9 @@ index 0000000000000000000000000000000000000000..1ddc7e33577a23a17fbb3230086ac9ae
 +
 +#ifdef ERTS_EMSCRIPTEN
 +EMSCRIPTEN_KEEPALIVE
-+void sendVmMessage(const char *target_name, int target_name_len,
-+                   const char *payload_json, int payload_len,
-+                   const char *meta_json, int meta_len) {
++int sendVmMessage(const char *target_name, int target_name_len,
++                  const char *payload_json, int payload_len,
++                  const char *meta_json, int meta_len) {
 +  ErlNifEnv *env;
 +  wasm_state_t *state;
 +  wasm_listener_t *listener;
@@ -812,17 +817,17 @@ index 0000000000000000000000000000000000000000..1ddc7e33577a23a17fbb3230086ac9ae
 +  if (target_name == NULL || target_name_len <= 0 || payload_len < 0 ||
 +      meta_len < 0 || (payload_json == NULL && payload_len > 0) ||
 +      (meta_json == NULL && meta_len > 0)) {
-+    return;
++    return 2;
 +  }
 +
 +  env = enif_alloc_env();
 +  if (env == NULL) {
-+    return;
++    return 2;
 +  }
 +
 +  if (erts_wasm_state_lock == NULL) {
 +    enif_free_env(env);
-+    return;
++    return 1;
 +  }
 +
 +  enif_mutex_lock(erts_wasm_state_lock);
@@ -830,7 +835,7 @@ index 0000000000000000000000000000000000000000..1ddc7e33577a23a17fbb3230086ac9ae
 +  if (state == NULL) {
 +    enif_mutex_unlock(erts_wasm_state_lock);
 +    enif_free_env(env);
-+    return;
++    return 1;
 +  }
 +
 +  listener = find_listener_by_pid_token_locked(
@@ -849,7 +854,7 @@ index 0000000000000000000000000000000000000000..1ddc7e33577a23a17fbb3230086ac9ae
 +
 +  if (listener == NULL) {
 +    enif_free_env(env);
-+    return;
++    return 1;
 +  }
 +
 +  if (!make_binary_copy(env, payload_json != NULL ? payload_json : "",
@@ -857,28 +862,34 @@ index 0000000000000000000000000000000000000000..1ddc7e33577a23a17fbb3230086ac9ae
 +      !make_binary_copy(env, meta_json != NULL ? meta_json : "",
 +                        (size_t)meta_len, &meta_term)) {
 +    enif_free_env(env);
-+    return;
++    return 2;
 +  }
 +
 +  message = enif_make_tuple3(env, am_wasm, payload_term, meta_term);
 +
-+  (void)enif_send(NULL, &pid, env, message);
++  if (!enif_send(NULL, &pid, env, message)) {
++    enif_free_env(env);
++    return 1;
++  }
++
 +  enif_free_env(env);
++  return 0;
 +}
 +#else
-+void sendVmMessage(const char *target_name, int target_name_len,
-+                   const char *payload_json, int payload_len,
-+                   const char *meta_json, int meta_len) {
++int sendVmMessage(const char *target_name, int target_name_len,
++                  const char *payload_json, int payload_len,
++                  const char *meta_json, int meta_len) {
 +  (void)target_name;
 +  (void)target_name_len;
 +  (void)payload_json;
 +  (void)payload_len;
 +  (void)meta_json;
 +  (void)meta_len;
++  return 2;
 +}
 +#endif
 diff --git a/erts/emulator/sys/unix/sys.c b/erts/emulator/sys/unix/sys.c
-index 4663b680c0a24684c6bcd171129420df24e753c5..fa26557945c1b4e0a2a570c6f329f5061dee6ae0 100644
+index 4663b680c0a24684c6bcd171129420df24e753c5..efd4ce6c49cc2d1a0276af562618308b81a43059 100644
 --- a/erts/emulator/sys/unix/sys.c
 +++ b/erts/emulator/sys/unix/sys.c
 @@ -82,6 +82,9 @@
@@ -891,7 +902,56 @@ index 4663b680c0a24684c6bcd171129420df24e753c5..fa26557945c1b4e0a2a570c6f329f506
  extern int  driver_interrupt(int, int);
  extern void do_break(void);
  
-@@ -1105,6 +1108,9 @@ static erts_tid_t sig_dispatcher_tid;
+@@ -102,7 +105,9 @@ static erts_atomic32_t have_prepared_crash_dump;
+ erts_atomic_t sys_misc_mem_sz;
+ 
+ static void smp_sig_notify(int signum);
++#ifndef ERTS_EMSCRIPTEN
+ static int sig_notify_fds[2] = {-1, -1};
++#endif
+ 
+ #ifdef ERTS_SYS_SUSPEND_SIGNAL
+ static int sig_suspend_fds[2] = {-1, -1};
+@@ -586,6 +591,7 @@ int erts_sys_prepare_crash_dump(int secs)
+     return prepare_crash_dump(secs);
+ }
+ 
++#ifndef ERTS_EMSCRIPTEN
+ static void signal_notify_requested(Eterm type) {
+     Process* p = NULL;
+     Eterm msg, *hp;
+@@ -622,6 +628,7 @@ break_requested(void)
+   /* Wake aux thread to get handle break */
+   erts_aux_thread_poke();
+ }
++#endif
+ 
+ static RETSIGTYPE request_break(int signum)
+ {
+@@ -720,6 +727,7 @@ signalterm_to_signum(Eterm signal)
+     }
+ }
+ 
++#ifndef ERTS_EMSCRIPTEN
+ static ERTS_INLINE Eterm
+ signum_to_signalterm(int signum)
+ {
+@@ -745,6 +753,7 @@ signum_to_signalterm(int signum)
+     default:      return am_error;
+     }
+ }
++#endif
+ 
+ static RETSIGTYPE generic_signal_handler(int signum)
+ {
+@@ -1100,11 +1109,16 @@ erl_debug(char* fmt, ...)
+ 
+ #endif /* DEBUG */
+ 
++#ifndef ERTS_EMSCRIPTEN
+ static erts_tid_t sig_dispatcher_tid;
++#endif
+ 
  static void
  smp_sig_notify(int signum)
  {
@@ -901,15 +961,26 @@ index 4663b680c0a24684c6bcd171129420df24e753c5..fa26557945c1b4e0a2a570c6f329f506
      int res;
      do {
  	/* write() is async-signal safe (according to posix) */
-@@ -1117,6 +1123,7 @@ smp_sig_notify(int signum)
+@@ -1117,8 +1131,10 @@ smp_sig_notify(int signum)
  	erts_silence_warn_unused_result(write(2, msg, sizeof(msg)));
  	abort();
      }
 +#endif
  }
  
++#ifndef ERTS_EMSCRIPTEN
  static void *
-@@ -1239,6 +1246,15 @@ erts_sys_main_thread(void)
+ signal_dispatcher_thread_func(void *unused)
+ {
+@@ -1211,6 +1227,7 @@ init_smp_sig_suspend(void) {
+   }
+ #endif
+ }
++#endif
+ 
+ #ifdef __DARWIN__
+ 
+@@ -1239,6 +1256,15 @@ erts_sys_main_thread(void)
  #endif
      smp_sig_notify(0); /* Notify initialized */
  
@@ -925,7 +996,7 @@ index 4663b680c0a24684c6bcd171129420df24e753c5..fa26557945c1b4e0a2a570c6f329f506
      /* Wait for a signal to arrive... */
  
  #ifdef __DARWIN__
-@@ -1293,8 +1309,10 @@ erl_sys_args(int* argc, char** argv)
+@@ -1293,8 +1319,10 @@ erl_sys_args(int* argc, char** argv)
  
      max_files = erts_check_io_max_files();
  
@@ -937,17 +1008,17 @@ index 4663b680c0a24684c6bcd171129420df24e753c5..fa26557945c1b4e0a2a570c6f329f506
      erts_sys_env_init();
  }
 diff --git a/erts/emulator/sys/unix/sys_drivers.c b/erts/emulator/sys/unix/sys_drivers.c
-index c06d6b66036a316dd6d5179dfcf8ee684ce161b6..10792a788a45c28162735db4198d9e6470313f70 100644
+index c06d6b66036a316dd6d5179dfcf8ee684ce161b6..7fb18a09bc90f80d892eca0102ccfc8d8c1dc066 100644
 --- a/erts/emulator/sys/unix/sys_drivers.c
 +++ b/erts/emulator/sys/unix/sys_drivers.c
-@@ -172,6 +172,7 @@ erl_sys_late_init(void)
+@@ -169,6 +169,7 @@ typedef struct driver_data {
+ void
+ erl_sys_late_init(void)
+ {
++#ifndef ERTS_EMSCRIPTEN
      SysDriverOpts opts = {0};
      Port *port;
  
-+#ifndef ERTS_EMSCRIPTEN
-     sys_signal(SIGPIPE, SIG_IGN); /* Ignore - we'll handle the write failure */
- 
-     opts.packet_bytes = 0;
 @@ -191,6 +192,7 @@ erl_sys_late_init(void)
          erts_open_driver(&forker_driver, make_internal_pid(0), "forker", &opts, NULL, NULL);
      erts_mtx_unlock(port->lock);

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -54,19 +54,17 @@ index 9ed8c5e398624b4ee4e752c0e32b2e87d22ea02d..924973cf2a2fed76f0a45e06a0d17e41
  	;;
  esac
 diff --git a/erts/emulator/Makefile.in b/erts/emulator/Makefile.in
-index 5d6c12c8a54493e3550082370288a7d0cc79aded..9b39ceff97b9b20dc26aa30b5605bd6345fa361f 100644
+index 5d6c12c8a54493e3550082370288a7d0cc79aded..170b833e8f5c20fab52426010083a9b6d09d2ccb 100644
 --- a/erts/emulator/Makefile.in
 +++ b/erts/emulator/Makefile.in
-@@ -1204,7 +1204,8 @@ OS_OBJS = \
- 
- DRV_OBJS = \
- 	$(OBJDIR)/inet_drv.o \
--	$(OBJDIR)/ram_file_drv.o
-+	$(OBJDIR)/ram_file_drv.o \
-+	$(OBJDIR)/js_bridge_drv.o
- endif
- 
- ifneq ($(STATIC_NIFS),no)
+@@ -1169,6 +1169,7 @@ NIF_OBJS = \
+ 	$(OBJDIR)/erl_tracer_nif.o \
+ 	$(OBJDIR)/prim_buffer_nif.o \
+ 	$(OBJDIR)/prim_file_nif.o \
++	$(OBJDIR)/wasm_nif.o \
+ 	$(OBJDIR)/zlib_nif.o \
+ 	$(OBJDIR)/zstd_nif.o \
+ 	$(ESOCK_NIF_OBJS)
 @@ -1291,7 +1292,7 @@ EMU_LD=$(CC)
  endif
  $(BINDIR)/$(FLAVOR_EXECUTABLE): $(INIT_OBJS) $(OBJS) $(DEPLIBS)
@@ -76,350 +74,6 @@ index 5d6c12c8a54493e3550082370288a7d0cc79aded..9b39ceff97b9b20dc26aa30b5605bd63
  	$(STATIC_NIF_LIBS) $(STATIC_DRIVER_LIBS) $(LIBS)
  
  endif
-diff --git a/erts/emulator/drivers/common/js_bridge_drv.c b/erts/emulator/drivers/common/js_bridge_drv.c
-new file mode 100644
-index 0000000000000000000000000000000000000000..09cb0c79f224c79ef1ed061b69f054920a3cfecc
---- /dev/null
-+++ b/erts/emulator/drivers/common/js_bridge_drv.c
-@@ -0,0 +1,338 @@
-+#ifdef HAVE_CONFIG_H
-+#  include "config.h"
-+#endif
-+
-+#include <stddef.h>
-+#include <stdio.h>
-+#include <string.h>
-+
-+#include "sys.h"
-+#include "erl_driver.h"
-+
-+#ifdef ERTS_EMSCRIPTEN
-+#  include <emscripten/emscripten.h>
-+#endif
-+
-+typedef struct {
-+    ErlDrvPort port;
-+} JsBridgeData;
-+
-+static ErlDrvPort js_bridge_port = (ErlDrvPort) 0;
-+
-+static ErlDrvData js_bridge_start(ErlDrvPort port, char *cmd);
-+static void js_bridge_stop(ErlDrvData handle);
-+static void js_bridge_outputv(ErlDrvData handle, ErlIOVec *ev);
-+
-+static void js_bridge_send_term(ErlDrvPort port,
-+                                const char *target_type,
-+                                ErlDrvBinary *target_bin,
-+                                ErlDrvBinary *payload_bin,
-+                                ErlDrvBinary *meta_bin) {
-+    ErlDrvTermData spec[32];
-+    int i = 0;
-+
-+    spec[i++] = ERL_DRV_ATOM;
-+    spec[i++] = driver_mk_atom("js_bridge_in");
-+
-+    spec[i++] = ERL_DRV_ATOM;
-+    spec[i++] = driver_mk_atom(target_type);
-+
-+    spec[i++] = ERL_DRV_BINARY;
-+    spec[i++] = (ErlDrvTermData) target_bin;
-+    spec[i++] = target_bin ? target_bin->orig_size : 0;
-+    spec[i++] = 0;
-+
-+    if (payload_bin != NULL) {
-+        spec[i++] = ERL_DRV_BINARY;
-+        spec[i++] = (ErlDrvTermData) payload_bin;
-+        spec[i++] = payload_bin->orig_size;
-+        spec[i++] = 0;
-+    } else {
-+        spec[i++] = ERL_DRV_ATOM;
-+        spec[i++] = driver_mk_atom("undefined");
-+    }
-+
-+    if (meta_bin != NULL) {
-+        spec[i++] = ERL_DRV_BINARY;
-+        spec[i++] = (ErlDrvTermData) meta_bin;
-+        spec[i++] = meta_bin->orig_size;
-+        spec[i++] = 0;
-+    } else {
-+        spec[i++] = ERL_DRV_ATOM;
-+        spec[i++] = driver_mk_atom("undefined");
-+    }
-+
-+    spec[i++] = ERL_DRV_TUPLE;
-+    spec[i++] = 5;
-+
-+    erl_drv_output_term(driver_mk_port(port), spec, i);
-+}
-+
-+#ifdef ERTS_EMSCRIPTEN
-+extern void js_bridge_on_from_beam(const char *data, int len);
-+extern void js_bridge_on_error(const char *data, int len);
-+
-+static void js_bridge_emit_error(const char *type, const char *detail) {
-+    char envelope[512];
-+    int written = snprintf(envelope,
-+                           sizeof(envelope),
-+                           "{\"type\":\"%s\",\"detail\":\"%s\"}",
-+                           type,
-+                           detail);
-+
-+    if (written <= 0) {
-+        return;
-+    }
-+    if (written >= (int) sizeof(envelope)) {
-+        written = (int) sizeof(envelope) - 1;
-+    }
-+    js_bridge_on_error(envelope, written);
-+}
-+
-+EM_JS(void, js_vm_message_parse, (const char *data, int len), {
-+    var msg = UTF8ToString(data, len);
-+
-+    function sendError(type, detail) {
-+      var envelope = JSON.stringify({
-+        type: type,
-+        detail: detail,
-+      });
-+      var ptr = Module.stringToNewUTF8(envelope);
-+      _js_vm_message_error(ptr, Module.lengthBytesUTF8(envelope));
-+      _free(ptr);
-+    }
-+
-+    var command;
-+    try {
-+      command = JSON.parse(msg);
-+    } catch (_error) {
-+      sendError('invalid_message', 'command is not valid JSON');
-+      return;
-+    }
-+
-+    if (command === null || typeof command !== 'object') {
-+      sendError('invalid_message', 'command must be a JSON object');
-+      return;
-+    }
-+
-+    if (command.type !== 'send') {
-+      sendError('invalid_message', 'command.type must be \"send\"');
-+      return;
-+    }
-+
-+    if (command.target === null || typeof command.target !== 'object') {
-+      sendError('invalid_message', 'command.target must be an object');
-+      return;
-+    }
-+
-+    var targetType;
-+    var targetValue;
-+    if (typeof command.target.name === 'string') {
-+      targetType = 'name';
-+      targetValue = command.target.name;
-+    } else if (typeof command.target.pid === 'string') {
-+      targetType = 'pid';
-+      targetValue = command.target.pid;
-+    } else {
-+      sendError('invalid_message', 'target must include name or pid');
-+      return;
-+    }
-+
-+    var targetTypePtr = Module.stringToNewUTF8(targetType);
-+    var targetValuePtr = Module.stringToNewUTF8(targetValue);
-+    var targetValueLen = Module.lengthBytesUTF8(targetValue);
-+
-+    var payloadPtr = 0;
-+    var payloadLen = 0;
-+    if (command.payload !== undefined) {
-+      var payload = JSON.stringify(command.payload);
-+      payloadPtr = Module.stringToNewUTF8(payload);
-+      payloadLen = Module.lengthBytesUTF8(payload);
-+    }
-+
-+    var metaPtr = 0;
-+    var metaLen = 0;
-+    if (command.meta !== undefined) {
-+      var meta = JSON.stringify(command.meta);
-+      metaPtr = Module.stringToNewUTF8(meta);
-+      metaLen = Module.lengthBytesUTF8(meta);
-+    }
-+
-+    _js_vm_message_dispatch(
-+      targetTypePtr,
-+      targetValuePtr,
-+      targetValueLen,
-+      payloadPtr,
-+      payloadLen,
-+      metaPtr,
-+      metaLen
-+    );
-+
-+    _free(targetTypePtr);
-+    _free(targetValuePtr);
-+    if (payloadPtr !== 0) {
-+      _free(payloadPtr);
-+    }
-+    if (metaPtr !== 0) {
-+      _free(metaPtr);
-+    }
-+});
-+
-+EMSCRIPTEN_KEEPALIVE
-+void js_vm_message_error(const char *envelope, int len) {
-+    if (envelope == NULL || len <= 0) {
-+        return;
-+    }
-+    js_bridge_on_error(envelope, len);
-+}
-+
-+EMSCRIPTEN_KEEPALIVE
-+void js_vm_message_dispatch(const char *target_type,
-+                            const char *target_value,
-+                            int target_value_len,
-+                            const char *payload_json,
-+                            int payload_len,
-+                            const char *meta_json,
-+                            int meta_len) {
-+    ErlDrvBinary *target_bin;
-+    ErlDrvBinary *payload_bin = NULL;
-+    ErlDrvBinary *meta_bin = NULL;
-+
-+    if (js_bridge_port == (ErlDrvPort) 0) {
-+        js_bridge_emit_error("bridge_not_ready", "bridge port is not open");
-+        return;
-+    }
-+
-+    if (target_type == NULL || target_value == NULL || target_value_len <= 0) {
-+        js_bridge_emit_error("invalid_message", "target is missing");
-+        return;
-+    }
-+
-+    target_bin = driver_alloc_binary(target_value_len);
-+    if (target_bin == NULL) {
-+        js_bridge_emit_error("bridge_error", "failed to allocate target buffer");
-+        return;
-+    }
-+    memcpy(target_bin->orig_bytes, target_value, target_value_len);
-+
-+    if (payload_json != NULL && payload_len > 0) {
-+        payload_bin = driver_alloc_binary(payload_len);
-+        if (payload_bin == NULL) {
-+            driver_free_binary(target_bin);
-+            js_bridge_emit_error("bridge_error", "failed to allocate payload buffer");
-+            return;
-+        }
-+        memcpy(payload_bin->orig_bytes, payload_json, payload_len);
-+    }
-+
-+    if (meta_json != NULL && meta_len > 0) {
-+        meta_bin = driver_alloc_binary(meta_len);
-+        if (meta_bin == NULL) {
-+            driver_free_binary(target_bin);
-+            if (payload_bin != NULL) {
-+                driver_free_binary(payload_bin);
-+            }
-+            js_bridge_emit_error("bridge_error", "failed to allocate meta buffer");
-+            return;
-+        }
-+        memcpy(meta_bin->orig_bytes, meta_json, meta_len);
-+    }
-+
-+    js_bridge_send_term(js_bridge_port, target_type, target_bin, payload_bin, meta_bin);
-+
-+    driver_free_binary(target_bin);
-+    if (payload_bin != NULL) {
-+        driver_free_binary(payload_bin);
-+    }
-+    if (meta_bin != NULL) {
-+        driver_free_binary(meta_bin);
-+    }
-+}
-+
-+EMSCRIPTEN_KEEPALIVE
-+void sendVmMessage(const char *data, int len) {
-+    if (data == NULL || len <= 0) {
-+        js_bridge_emit_error("invalid_message", "command must be a non-empty UTF-8 string");
-+        return;
-+    }
-+    js_vm_message_parse(data, len);
-+}
-+#else
-+void sendVmMessage(const char *data, int len) {
-+    (void) data;
-+    (void) len;
-+}
-+#endif
-+
-+static ErlDrvData js_bridge_start(ErlDrvPort port, char *cmd) {
-+    JsBridgeData *data;
-+    (void) cmd;
-+
-+    data = (JsBridgeData *) driver_alloc(sizeof(JsBridgeData));
-+    if (data == NULL) {
-+        return (ErlDrvData) NULL;
-+    }
-+
-+    data->port = port;
-+    js_bridge_port = port;
-+    return (ErlDrvData) data;
-+}
-+
-+static void js_bridge_stop(ErlDrvData handle) {
-+    JsBridgeData *data = (JsBridgeData *) handle;
-+    if (data != NULL) {
-+        if (js_bridge_port == data->port) {
-+            js_bridge_port = (ErlDrvPort) 0;
-+        }
-+        driver_free(data);
-+    }
-+}
-+
-+static void js_bridge_outputv(ErlDrvData handle, ErlIOVec *ev) {
-+    char *buffer;
-+    (void) handle;
-+
-+    if (ev == NULL || ev->size <= 0) {
-+        return;
-+    }
-+
-+    buffer = (char *) driver_alloc(ev->size + 1);
-+    if (buffer == NULL) {
-+        return;
-+    }
-+
-+    driver_vec_to_buf(ev, buffer, ev->size);
-+    buffer[ev->size] = '\0';
-+
-+#ifdef ERTS_EMSCRIPTEN
-+    js_bridge_on_from_beam(buffer, (int) ev->size);
-+#endif
-+
-+    driver_free(buffer);
-+}
-+
-+struct erl_drv_entry js_bridge_driver_entry = {
-+    NULL,
-+    js_bridge_start,
-+    js_bridge_stop,
-+    NULL,
-+    NULL,
-+    NULL,
-+    "js_bridge",
-+    NULL,
-+    NULL,
-+    NULL,
-+    NULL,
-+    js_bridge_outputv,
-+    NULL,
-+    NULL,
-+    NULL,
-+    NULL,
-+    ERL_DRV_EXTENDED_MARKER,
-+    ERL_DRV_EXTENDED_MAJOR_VERSION,
-+    ERL_DRV_EXTENDED_MINOR_VERSION,
-+    ERL_DRV_FLAG_USE_PORT_LOCKING,
-+    NULL,
-+    NULL,
-+    NULL
-+};
 diff --git a/erts/emulator/js_bridge/beam-bridge.pre.js b/erts/emulator/js_bridge/beam-bridge.pre.js
 new file mode 100644
 index 0000000000000000000000000000000000000000..2e85c729e92e9948fd15302a88ed12a4d3bfbe60
@@ -467,6 +121,622 @@ index 0000000000000000000000000000000000000000..0b7996e35e311aa67629a6e54df2820e
 +    }
 +  },
 +});
+diff --git a/erts/emulator/nifs/common/wasm_nif.c b/erts/emulator/nifs/common/wasm_nif.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..242afa26643ff51ba1565991ff6bdd7c6dd9e8e8
+--- /dev/null
++++ b/erts/emulator/nifs/common/wasm_nif.c
+@@ -0,0 +1,610 @@
++/*
++ * %CopyrightBegin%
++ *
++ * SPDX-License-Identifier: Apache-2.0
++ *
++ * Copyright Ericsson AB 2026. All Rights Reserved.
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ * %CopyrightEnd%
++ */
++
++#define STATIC_ERLANG_NIF 1
++
++#include "erl_nif.h"
++#include "config.h"
++#include "sys.h"
++
++#include <stddef.h>
++#include <stdio.h>
++#include <string.h>
++
++#ifdef ERTS_EMSCRIPTEN
++#  include <emscripten/emscripten.h>
++#endif
++
++typedef struct wasm_listener_s {
++    ErlNifBinary name;
++    ErlNifPid pid;
++    struct wasm_listener_s *next;
++} wasm_listener_t;
++
++typedef struct {
++    ErlNifMutex *lock;
++    wasm_listener_t *listeners;
++} wasm_state_t;
++
++static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info);
++static int upgrade(ErlNifEnv *env,
++                   void **priv_data,
++                   void **old_priv_data,
++                   ERL_NIF_TERM load_info);
++static void unload(ErlNifEnv *env, void *priv_data);
++
++static ERL_NIF_TERM register_listener_nif(ErlNifEnv *env,
++                                          int argc,
++                                          const ERL_NIF_TERM argv[]);
++static ERL_NIF_TERM unregister_listener_nif(ErlNifEnv *env,
++                                            int argc,
++                                            const ERL_NIF_TERM argv[]);
++static ERL_NIF_TERM send_raw_nif(ErlNifEnv *env,
++                                 int argc,
++                                 const ERL_NIF_TERM argv[]);
++
++static ErlNifFunc nif_funcs[] = {
++    {"register_listener_nif", 1, register_listener_nif},
++    {"unregister_listener_nif", 1, unregister_listener_nif},
++    {"send_raw", 1, send_raw_nif},
++};
++
++ERL_NIF_INIT(wasm, nif_funcs, load, NULL, upgrade, unload)
++
++static ERL_NIF_TERM am_ok;
++static ERL_NIF_TERM am_error;
++static ERL_NIF_TERM am_already_registered;
++static ERL_NIF_TERM am_not_found;
++static ERL_NIF_TERM am_not_owner;
++static ERL_NIF_TERM am_out_of_memory;
++static ERL_NIF_TERM am_unsupported;
++static ERL_NIF_TERM am_wasm;
++
++static wasm_state_t *erts_wasm_state = NULL;
++
++#ifdef ERTS_EMSCRIPTEN
++void wasm_bridge_emit_error(const char *envelope, int len);
++void wasm_bridge_dispatch(const char *target_name,
++                          int target_name_len,
++                          const char *payload_json,
++                          int payload_len,
++                          const char *meta_json,
++                          int meta_len);
++void sendVmMessage(const char *data, int len);
++#endif
++
++static wasm_state_t *create_wasm_state(void)
++{
++    wasm_state_t *state;
++
++    state = enif_alloc(sizeof(wasm_state_t));
++    if (state == NULL) {
++        return NULL;
++    }
++
++    state->lock = enif_mutex_create("wasm_nif_lock");
++    if (state->lock == NULL) {
++        enif_free(state);
++        return NULL;
++    }
++
++    state->listeners = NULL;
++
++    return state;
++}
++
++static wasm_state_t *ensure_wasm_state(void)
++{
++    wasm_state_t *state;
++
++    if (erts_wasm_state != NULL) {
++        return erts_wasm_state;
++    }
++
++    state = create_wasm_state();
++    if (state == NULL) {
++        return NULL;
++    }
++
++    if (erts_wasm_state == NULL) {
++        erts_wasm_state = state;
++        return state;
++    }
++
++    enif_mutex_destroy(state->lock);
++    enif_free(state);
++    return erts_wasm_state;
++}
++
++static int same_name(const unsigned char *lhs_data,
++                     size_t lhs_size,
++                     const unsigned char *rhs_data,
++                     size_t rhs_size)
++{
++    return lhs_size == rhs_size
++        && (lhs_size == 0 || memcmp(lhs_data, rhs_data, lhs_size) == 0);
++}
++
++static int same_pid(ErlNifEnv *env, const ErlNifPid *lhs, const ErlNifPid *rhs)
++{
++    return enif_is_identical(enif_make_pid(env, lhs), enif_make_pid(env, rhs));
++}
++
++static ERL_NIF_TERM make_error(ErlNifEnv *env, ERL_NIF_TERM reason)
++{
++    return enif_make_tuple2(env, am_error, reason);
++}
++
++static int copy_binary(ErlNifBinary *dst, const ErlNifBinary *src)
++{
++    if (!enif_alloc_binary(src->size, dst)) {
++        return 0;
++    }
++
++    if (src->size > 0) {
++        memcpy(dst->data, src->data, src->size);
++    }
++
++    return 1;
++}
++
++static void free_listener(wasm_listener_t *listener)
++{
++    enif_release_binary(&listener->name);
++    enif_free(listener);
++}
++
++static void remove_listener_locked(wasm_state_t *state,
++                                   wasm_listener_t *prev,
++                                   wasm_listener_t *listener)
++{
++    if (prev == NULL) {
++        state->listeners = listener->next;
++    } else {
++        prev->next = listener->next;
++    }
++
++    free_listener(listener);
++}
++
++static wasm_listener_t *find_listener_locked(ErlNifEnv *env,
++                                             wasm_state_t *state,
++                                             const unsigned char *name_data,
++                                             size_t name_size,
++                                             wasm_listener_t **prev_out)
++{
++    wasm_listener_t *prev = NULL;
++    wasm_listener_t *listener = state->listeners;
++
++    while (listener != NULL) {
++        wasm_listener_t *next = listener->next;
++
++        if (!enif_is_process_alive(env, &listener->pid)) {
++            remove_listener_locked(state, prev, listener);
++            listener = next;
++            continue;
++        }
++
++        if (same_name(listener->name.data,
++                      listener->name.size,
++                      name_data,
++                      name_size)) {
++            if (prev_out != NULL) {
++                *prev_out = prev;
++            }
++            return listener;
++        }
++
++        prev = listener;
++        listener = next;
++    }
++
++    if (prev_out != NULL) {
++        *prev_out = prev;
++    }
++
++    return NULL;
++}
++
++static ERL_NIF_TERM make_binary_copy(ErlNifEnv *env,
++                                     const char *data,
++                                     size_t size)
++{
++    unsigned char *dst;
++    ERL_NIF_TERM term;
++
++    dst = enif_make_new_binary(env, size, &term);
++    if (dst == NULL) {
++        return enif_make_badarg(env);
++    }
++
++    if (size > 0) {
++        memcpy(dst, data, size);
++    }
++
++    return term;
++}
++
++static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info)
++{
++    wasm_state_t *state;
++
++    (void) load_info;
++
++    state = ensure_wasm_state();
++    if (state == NULL) {
++        return -1;
++    }
++
++    am_ok = enif_make_atom(env, "ok");
++    am_error = enif_make_atom(env, "error");
++    am_already_registered = enif_make_atom(env, "already_registered");
++    am_not_found = enif_make_atom(env, "not_found");
++    am_not_owner = enif_make_atom(env, "not_owner");
++    am_out_of_memory = enif_make_atom(env, "out_of_memory");
++    am_unsupported = enif_make_atom(env, "unsupported");
++    am_wasm = enif_make_atom(env, "wasm");
++
++    *priv_data = state;
++
++    return 0;
++}
++
++static int upgrade(ErlNifEnv *env,
++                   void **priv_data,
++                   void **old_priv_data,
++                   ERL_NIF_TERM load_info)
++{
++    (void) old_priv_data;
++
++    if (*priv_data != NULL) {
++        return -1;
++    }
++
++    return load(env, priv_data, load_info);
++}
++
++static void unload(ErlNifEnv *env, void *priv_data)
++{
++    wasm_state_t *state = priv_data;
++    wasm_listener_t *listener;
++
++    (void) env;
++
++    if (state == NULL) {
++        return;
++    }
++
++    listener = state->listeners;
++    while (listener != NULL) {
++        wasm_listener_t *next = listener->next;
++        free_listener(listener);
++        listener = next;
++    }
++
++    enif_mutex_destroy(state->lock);
++
++    if (erts_wasm_state == state) {
++        erts_wasm_state = NULL;
++    }
++
++    enif_free(state);
++}
++
++static ERL_NIF_TERM register_listener_nif(ErlNifEnv *env,
++                                          int argc,
++                                          const ERL_NIF_TERM argv[])
++{
++    ErlNifBinary name;
++    ErlNifPid self;
++    wasm_listener_t *listener;
++    wasm_state_t *state = enif_priv_data(env);
++
++    if (argc != 1 || !enif_inspect_iolist_as_binary(env, argv[0], &name) || name.size == 0) {
++        return enif_make_badarg(env);
++    }
++
++    enif_self(env, &self);
++
++    enif_mutex_lock(state->lock);
++    listener = find_listener_locked(env, state, name.data, name.size, NULL);
++
++    if (listener != NULL) {
++        ERL_NIF_TERM result =
++            same_pid(env, &listener->pid, &self)
++                ? am_ok
++                : make_error(env, am_already_registered);
++
++        enif_mutex_unlock(state->lock);
++        return result;
++    }
++
++    listener = enif_alloc(sizeof(wasm_listener_t));
++    if (listener == NULL) {
++        enif_mutex_unlock(state->lock);
++        return make_error(env, am_out_of_memory);
++    }
++
++    if (!copy_binary(&listener->name, &name)) {
++        enif_free(listener);
++        enif_mutex_unlock(state->lock);
++        return make_error(env, am_out_of_memory);
++    }
++
++    listener->pid = self;
++    listener->next = state->listeners;
++    state->listeners = listener;
++
++    enif_mutex_unlock(state->lock);
++
++    return am_ok;
++}
++
++static ERL_NIF_TERM unregister_listener_nif(ErlNifEnv *env,
++                                            int argc,
++                                            const ERL_NIF_TERM argv[])
++{
++    ErlNifBinary name;
++    ErlNifPid self;
++    wasm_listener_t *listener;
++    wasm_listener_t *prev = NULL;
++    wasm_state_t *state = enif_priv_data(env);
++
++    if (argc != 1 || !enif_inspect_iolist_as_binary(env, argv[0], &name) || name.size == 0) {
++        return enif_make_badarg(env);
++    }
++
++    enif_self(env, &self);
++
++    enif_mutex_lock(state->lock);
++    listener = find_listener_locked(env, state, name.data, name.size, &prev);
++
++    if (listener == NULL) {
++        enif_mutex_unlock(state->lock);
++        return make_error(env, am_not_found);
++    }
++
++    if (!same_pid(env, &listener->pid, &self)) {
++        enif_mutex_unlock(state->lock);
++        return make_error(env, am_not_owner);
++    }
++
++    remove_listener_locked(state, prev, listener);
++    enif_mutex_unlock(state->lock);
++
++    return am_ok;
++}
++
++#ifdef ERTS_EMSCRIPTEN
++extern void js_bridge_on_from_beam(const char *data, int len);
++extern void js_bridge_on_error(const char *data, int len);
++
++static void wasm_emit_error(const char *type, const char *detail)
++{
++    char envelope[512];
++    int written = snprintf(envelope,
++                           sizeof(envelope),
++                           "{\"type\":\"%s\",\"detail\":\"%s\"}",
++                           type,
++                           detail);
++
++    if (written <= 0) {
++        return;
++    }
++    if (written >= (int) sizeof(envelope)) {
++        written = (int) sizeof(envelope) - 1;
++    }
++
++    js_bridge_on_error(envelope, written);
++}
++
++EMSCRIPTEN_KEEPALIVE
++void wasm_bridge_emit_error(const char *envelope, int len)
++{
++    if (envelope == NULL || len <= 0) {
++        return;
++    }
++
++    js_bridge_on_error(envelope, len);
++}
++
++EM_JS(void, js_vm_message_parse, (const char *data, int len), {
++    var message = UTF8ToString(data, len);
++
++    function sendError(type, detail) {
++      var envelope = JSON.stringify({
++        type: type,
++        detail: detail,
++      });
++      var ptr = Module.stringToNewUTF8(envelope);
++      _wasm_bridge_emit_error(ptr, Module.lengthBytesUTF8(envelope));
++      _free(ptr);
++    }
++
++    var command;
++    try {
++      command = JSON.parse(message);
++    } catch (_error) {
++      sendError("invalid_message", "command is not valid JSON");
++      return;
++    }
++
++    if (command === null || typeof command !== "object") {
++      sendError("invalid_message", "command must be a JSON object");
++      return;
++    }
++
++    if (command.type !== "send") {
++      sendError("invalid_message", "command.type must be \"send\"");
++      return;
++    }
++
++    if (command.target === null || typeof command.target !== "object") {
++      sendError("invalid_message", "command.target must be an object");
++      return;
++    }
++
++    if (typeof command.target.name !== "string" || command.target.name.length === 0) {
++      if (typeof command.target.pid === "string") {
++        sendError("unsupported_target", "pid targets are not supported yet");
++      } else {
++        sendError("invalid_message", "target.name must be a non-empty string");
++      }
++      return;
++    }
++
++    var payload;
++    try {
++      payload = JSON.stringify(command.payload === undefined ? null : command.payload);
++    } catch (_error) {
++      sendError("invalid_message", "payload is not serializable");
++      return;
++    }
++
++    var meta;
++    try {
++      meta = JSON.stringify(command.meta === undefined ? null : command.meta);
++    } catch (_error) {
++      sendError("invalid_message", "meta is not serializable");
++      return;
++    }
++
++    var namePtr = Module.stringToNewUTF8(command.target.name);
++    var payloadPtr = Module.stringToNewUTF8(payload);
++    var metaPtr = Module.stringToNewUTF8(meta);
++
++    _wasm_bridge_dispatch(
++      namePtr,
++      Module.lengthBytesUTF8(command.target.name),
++      payloadPtr,
++      Module.lengthBytesUTF8(payload),
++      metaPtr,
++      Module.lengthBytesUTF8(meta)
++    );
++
++    _free(namePtr);
++    _free(payloadPtr);
++    _free(metaPtr);
++});
++
++EMSCRIPTEN_KEEPALIVE
++void wasm_bridge_dispatch(const char *target_name,
++                          int target_name_len,
++                          const char *payload_json,
++                          int payload_len,
++                          const char *meta_json,
++                          int meta_len)
++{
++    ErlNifEnv *env;
++    wasm_listener_t *listener;
++    ErlNifPid pid;
++    ERL_NIF_TERM payload_term;
++    ERL_NIF_TERM meta_term;
++    ERL_NIF_TERM message;
++
++    if (ensure_wasm_state() == NULL) {
++        wasm_emit_error("bridge_error", "failed to initialize bridge state");
++        return;
++    }
++
++    if (target_name == NULL || target_name_len <= 0) {
++        wasm_emit_error("invalid_message", "target is missing");
++        return;
++    }
++
++    env = enif_alloc_env();
++    if (env == NULL) {
++        wasm_emit_error("bridge_error", "failed to allocate message environment");
++        return;
++    }
++
++    enif_mutex_lock(erts_wasm_state->lock);
++    listener = find_listener_locked(env,
++                                    erts_wasm_state,
++                                    (const unsigned char *) target_name,
++                                    (size_t) target_name_len,
++                                    NULL);
++
++    if (listener == NULL) {
++        enif_mutex_unlock(erts_wasm_state->lock);
++        enif_free_env(env);
++        wasm_emit_error("listener_not_found", "target listener is not registered");
++        return;
++    }
++
++    pid = listener->pid;
++    enif_mutex_unlock(erts_wasm_state->lock);
++
++    payload_term = make_binary_copy(env,
++                                    payload_json != NULL ? payload_json : "",
++                                    payload_len > 0 ? (size_t) payload_len : 0);
++    meta_term = make_binary_copy(env,
++                                 meta_json != NULL ? meta_json : "",
++                                 meta_len > 0 ? (size_t) meta_len : 0);
++    message = enif_make_tuple3(env, am_wasm, payload_term, meta_term);
++
++    if (!enif_send(NULL, &pid, env, message)) {
++        enif_free_env(env);
++        wasm_emit_error("bridge_error", "failed to deliver message to listener");
++        return;
++    }
++
++    enif_free_env(env);
++}
++#endif
++
++static ERL_NIF_TERM send_raw_nif(ErlNifEnv *env,
++                                 int argc,
++                                 const ERL_NIF_TERM argv[])
++{
++    ErlNifBinary message;
++
++    if (argc != 1 || !enif_inspect_iolist_as_binary(env, argv[0], &message)) {
++        return enif_make_badarg(env);
++    }
++
++#ifdef ERTS_EMSCRIPTEN
++    js_bridge_on_from_beam((const char *) message.data, (int) message.size);
++    return am_ok;
++#else
++    return make_error(env, am_unsupported);
++#endif
++}
++
++#ifdef ERTS_EMSCRIPTEN
++EMSCRIPTEN_KEEPALIVE
++void sendVmMessage(const char *data, int len)
++{
++    if (data == NULL || len <= 0) {
++        wasm_emit_error("invalid_message", "command must be a non-empty UTF-8 string");
++        return;
++    }
++
++    js_vm_message_parse(data, len);
++}
++#else
++void sendVmMessage(const char *data, int len)
++{
++    (void) data;
++    (void) len;
++}
++#endif
 diff --git a/erts/emulator/sys/unix/sys.c b/erts/emulator/sys/unix/sys.c
 index 4663b680c0a24684c6bcd171129420df24e753c5..fa26557945c1b4e0a2a570c6f329f5061dee6ae0 100644
 --- a/erts/emulator/sys/unix/sys.c
@@ -611,6 +881,104 @@ index 1f9e23e9976d9345a424002476acaeb8f767732b..bed8fa83f7f16c0d9beeb6c1fa0f8fc3
   ],
   [
    dnl "$with_odbc" != "no"
+diff --git a/lib/stdlib/src/Makefile b/lib/stdlib/src/Makefile
+index ddecd632450c741768c5463d52b1a83c56b6b971..81413860358d3ac8809ecb9362f204eeaa211a23 100644
+--- a/lib/stdlib/src/Makefile
++++ b/lib/stdlib/src/Makefile
+@@ -136,6 +136,7 @@ MODULES= \
+ 	unicode \
+ 	unicode_util \
+ 	uri_string \
++	wasm \
+ 	win32reg \
+ 	zip \
+ 	zstd
+diff --git a/lib/stdlib/src/stdlib.app.src b/lib/stdlib/src/stdlib.app.src
+index 7f42f8573765db26e571864972016e29c7ed5e01..c0ae85a462419b6d4ab1641c9f45f304c5444891 100644
+--- a/lib/stdlib/src/stdlib.app.src
++++ b/lib/stdlib/src/stdlib.app.src
+@@ -116,6 +116,7 @@
+ 	     unicode,
+              unicode_util,
+ 	     uri_string,
++	     wasm,
+ 	     win32reg,
+ 	     zip,
+              zstd]},
+diff --git a/lib/stdlib/src/wasm.erl b/lib/stdlib/src/wasm.erl
+new file mode 100644
+index 0000000000000000000000000000000000000000..e31c87e05a826cb89bf1315e322cb4c4feb33a98
+--- /dev/null
++++ b/lib/stdlib/src/wasm.erl
+@@ -0,0 +1,68 @@
++%%
++%% %CopyrightBegin%
++%%
++%% SPDX-License-Identifier: Apache-2.0
++%%
++%% Copyright Ericsson AB 2026. All Rights Reserved.
++%%
++%% Licensed under the Apache License, Version 2.0 (the "License");
++%% you may not use this file except in compliance with the License.
++%% You may obtain a copy of the License at
++%%
++%%     http://www.apache.org/licenses/LICENSE-2.0
++%%
++%% Unless required by applicable law or agreed to in writing, software
++%% distributed under the License is distributed on an "AS IS" BASIS,
++%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++%% See the License for the specific language governing permissions and
++%% limitations under the License.
++%%
++%% %CopyrightEnd%
++%%
++-module(wasm).
++-moduledoc false.
++
++-on_load(on_load/0).
++
++-export([register_listener/1, unregister_listener/1, send/1]).
++
++-nifs([register_listener_nif/1, unregister_listener_nif/1, send_raw/1]).
++
++-type listener_name() :: atom() | unicode:charlist() | unicode:unicode_binary().
++
++-export_type([listener_name/0]).
++
++-spec register_listener(listener_name()) -> ok | {error, already_registered}.
++register_listener(Name) ->
++    register_listener_nif(normalize_name(Name)).
++
++-spec unregister_listener(listener_name()) -> ok | {error, not_found | not_owner}.
++unregister_listener(Name) ->
++    unregister_listener_nif(normalize_name(Name)).
++
++-spec send(json:encode_value()) -> ok.
++send(Message) ->
++    Envelope = #{type => vm_message, data => Message},
++    ok = send_raw(iolist_to_binary(json:encode(Envelope))).
++
++-spec on_load() -> ok.
++on_load() ->
++    ok = erlang:load_nif("wasm", wasm).
++
++register_listener_nif(_Name) ->
++    erlang:nif_error(undef).
++
++unregister_listener_nif(_Name) ->
++    erlang:nif_error(undef).
++
++send_raw(_Message) ->
++    erlang:nif_error(undef).
++
++normalize_name(Name) when is_atom(Name) ->
++    atom_to_binary(Name, utf8);
++normalize_name(Name) when is_binary(Name) ->
++    Name;
++normalize_name(Name) when is_list(Name) ->
++    unicode:characters_to_binary(Name);
++normalize_name(Name) ->
++    erlang:error(badarg, [Name]).
 diff --git a/make/autoconf/otp.m4 b/make/autoconf/otp.m4
 index 2ca07d8d0e79eb5f1c6cdf2b303757b697697b92..839240d5dee15d710bd2d9f527b87ad8bafa90e1 100644
 --- a/make/autoconf/otp.m4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,8 +223,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.30
       playwright:
-        specifier: ^1.53.2
-        version: 1.59.1
+        specifier: ^1.60.0
+        version: 1.60.0
       react:
         specifier: ^19.1.0
         version: 19.2.6
@@ -233,7 +233,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       rehype-mermaid:
         specifier: ^3.0.0
-        version: 3.0.0(playwright@1.59.1)
+        version: 3.0.0(playwright@1.60.0)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -354,8 +354,8 @@ importers:
         specifier: ^9.30.1
         version: 9.39.4
       '@playwright/test':
-        specifier: ^1.56.1
-        version: 1.59.1
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
@@ -414,8 +414,8 @@ importers:
   otp/js:
     devDependencies:
       '@playwright/test':
-        specifier: ^1.58.2
-        version: 1.59.1
+        specifier: ^1.60.0
+        version: 1.60.0
       '@rollup/plugin-typescript':
         specifier: ^12.1.2
         version: 12.3.0(rollup@4.60.3)(tslib@2.8.1)(typescript@5.9.3)
@@ -458,8 +458,8 @@ importers:
         specifier: ^9.39.0
         version: 9.39.4
       '@playwright/test':
-        specifier: ^1.52.0
-        version: 1.59.1
+        specifier: ^1.60.0
+        version: 1.60.0
       '@rollup/plugin-typescript':
         specifier: ^12.1.2
         version: 12.3.0(rollup@4.60.3)(tslib@2.8.1)(typescript@5.8.3)
@@ -510,8 +510,8 @@ importers:
   popdoc/e2e:
     devDependencies:
       '@playwright/test':
-        specifier: 1.59.1
-        version: 1.59.1
+        specifier: 1.60.0
+        version: 1.60.0
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.0
@@ -1484,8 +1484,8 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3810,13 +3810,13 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5491,9 +5491,9 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.60.0
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
@@ -7924,13 +7924,13 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
-  mermaid-isomorphic@3.1.0(playwright@1.59.1):
+  mermaid-isomorphic@3.1.0(playwright@1.60.0):
     dependencies:
       '@fortawesome/fontawesome-free': 6.7.2
       katex: 0.16.45
       mermaid: 11.14.0
     optionalDependencies:
-      playwright: 1.59.1
+      playwright: 1.60.0
 
   mermaid@11.14.0:
     dependencies:
@@ -8411,11 +8411,11 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.59.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -8538,19 +8538,19 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
-  rehype-mermaid@3.0.0(playwright@1.59.1):
+  rehype-mermaid@3.0.0(playwright@1.60.0):
     dependencies:
       '@types/hast': 3.0.4
       hast-util-from-html-isomorphic: 2.0.0
       hast-util-to-text: 4.0.2
-      mermaid-isomorphic: 3.1.0(playwright@1.59.1)
+      mermaid-isomorphic: 3.1.0(playwright@1.60.0)
       mini-svg-data-uri: 1.4.4
       space-separated-tokens: 2.0.2
       unified: 11.0.5
       unist-util-visit-parents: 6.0.2
       vfile: 6.0.3
     optionalDependencies:
-      playwright: 1.59.1
+      playwright: 1.60.0
 
   rehype-parse@9.0.1:
     dependencies:

--- a/popcorn/js/package.json
+++ b/popcorn/js/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.0",
-    "@playwright/test": "^1.52.0",
+    "@playwright/test": "^1.60.0",
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/node": "catalog:",
     "esbuild": "^0.25.0",

--- a/popdoc/e2e/package.json
+++ b/popdoc/e2e/package.json
@@ -6,7 +6,7 @@
     "test:e2e": "playwright test --config playwright.config.ts"
   },
   "devDependencies": {
-    "@playwright/test": "1.59.1",
+    "@playwright/test": "1.60.0",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/scripts/build-beam.sh
+++ b/scripts/build-beam.sh
@@ -363,7 +363,9 @@ copy_artifacts() {
     done
 
     if [[ -f "${beam_dir}/bootstrap/bin/no_dot_erlang.boot" ]]; then
-        cp "${beam_dir}/bootstrap/bin/no_dot_erlang.boot" "${outdir}/bin/vm.boot"
+        escript "${PROJECT_ROOT}/scripts/ensure-wasm-boot.escript" \
+            "${beam_dir}/bootstrap/bin/no_dot_erlang.boot" \
+            "${outdir}/bin/vm.boot"
     fi
 
     success "Artifacts written to: ${outdir}"

--- a/scripts/ensure-wasm-boot.escript
+++ b/scripts/ensure-wasm-boot.escript
@@ -1,0 +1,46 @@
+#!/usr/bin/env escript
+%%! -noshell
+
+main([SourceBoot, TargetBoot]) ->
+    {ok, Binary} = file:read_file(SourceBoot),
+    {script, Version, Entries} = binary_to_term(Binary),
+    Patched = {script, Version, patch_entries(Entries)},
+    ok = file:write_file(TargetBoot, term_to_binary(Patched));
+main(_) ->
+    io:format(standard_error, "Usage: ensure-wasm-boot.escript SOURCE_BOOT TARGET_BOOT~n", []),
+    halt(1).
+
+patch_entries(Entries) ->
+    patch_stdlib_application(patch_stdlib_prim_load(Entries)).
+
+patch_stdlib_prim_load([{path, ["$ROOT/lib/stdlib/ebin"]} = Path, {primLoad, Modules} | Rest]) ->
+    [Path, {primLoad, add_module(wasm, Modules)} | Rest];
+patch_stdlib_prim_load([Entry | Rest]) ->
+    [Entry | patch_stdlib_prim_load(Rest)];
+patch_stdlib_prim_load([]) ->
+    [].
+
+patch_stdlib_application([
+    {apply, {application, load, [{application, stdlib, Properties}]}} | Rest
+]) ->
+    [
+        {apply, {application, load, [{application, stdlib, patch_modules_property(Properties)}]}}
+        | Rest
+    ];
+patch_stdlib_application([Entry | Rest]) ->
+    [Entry | patch_stdlib_application(Rest)];
+patch_stdlib_application([]) ->
+    [].
+
+patch_modules_property([{modules, Modules} | Rest]) ->
+    [{modules, add_module(wasm, Modules)} | Rest];
+patch_modules_property([Property | Rest]) ->
+    [Property | patch_modules_property(Rest)];
+patch_modules_property([]) ->
+    [].
+
+add_module(Module, Modules) ->
+    case lists:member(Module, Modules) of
+        true -> Modules;
+        false -> Modules ++ [Module]
+    end.

--- a/scripts/stdlib.sh
+++ b/scripts/stdlib.sh
@@ -71,13 +71,13 @@ select_otp_app_ebin_dir() {
     local bootstrap_ebin="${beam_dir}/bootstrap/lib/${app}/ebin"
     local lib_ebin="${beam_dir}/lib/${app}/ebin"
 
-    if [[ -f "${bootstrap_ebin}/${app}.app" ]]; then
-        echo "${bootstrap_ebin}"
+    if [[ -f "${lib_ebin}/${app}.app" ]]; then
+        echo "${lib_ebin}"
         return 0
     fi
 
-    if [[ -f "${lib_ebin}/${app}.app" ]]; then
-        echo "${lib_ebin}"
+    if [[ -f "${bootstrap_ebin}/${app}.app" ]]; then
+        echo "${bootstrap_ebin}"
         return 0
     fi
 


### PR DESCRIPTION
Implements communication layer (bridge) between JS and VM. Currently it has:

```ts
public async send(
    target: string,
    payload?: AnyValue,
    opts?: PopcornSendOpts,
): Promise<Result<null>>
```

in JS, which takes registered process name, any serializable payload, and has a way for specifying timeouts. It's async and returns either `{ok: true, data: null}` or `{ok: false, error}` (when `target` is invalid, isn't registered, bridge isn't working, etc).

In Elixir/Erlang we need to call `wasm:register_listener` and `receive` clause. To send events to JS, you can use `wasm:send` NIF call.

Example uses are nicely highlighted in `otp.spec.js`.

This PR also fixes some CI errors coming from new node versions: https://github.com/nodejs/node/issues/63487.

Follow-ups:
- drop .boot file patching (currently needed to load wasm module, it most likely can be autoloaded)
- drop `wasm:register_listener` and allow passing any registered process name (currently, there's also code supporting opaque handles to PIDs, in the future JS APIs will support passing VM-value handle to do that)
- add tracked values (i.e. handles in Elixir to JS values and handles to Elixir values in JS)