### PR TITLE
[LLV] Local LV Compare tests

### DIFF
--- a/.github/workflows/local_lv_compare_test.yml
+++ b/.github/workflows/local_lv_compare_test.yml
@@ -1,0 +1,116 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: local-lv-compare - Test
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "examples/local-lv-compare/**"
+      - "local-live-view/**"
+      - ".github/workflows/local_lv_compare_test.yml"
+      - ".github/actions/**"
+      - "pnpm-workspace.yaml"
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - ".npmrc"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CI: true
+  MIX_ENV: test
+
+jobs:
+  # The online half is a regular Phoenix LiveView app, tested on the BEAM
+  # with Phoenix.LiveViewTest (no AtomVM involved).
+  online:
+    name: Online (Phoenix LiveView, BEAM)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+
+    defaults:
+      run:
+        working-directory: examples/local-lv-compare
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-toolchain
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: examples/local-lv-compare/deps
+          key: ${{ runner.os }}-mix-local_lv_compare-${{ hashFiles('examples/local-lv-compare/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-local_lv_compare-
+
+      - name: Install Hex dependencies
+        run: mix deps.get
+
+      - name: Run tests
+        run: mix test
+
+  # The offline half is a LocalLiveView app that runs in the browser via AtomVM.
+  # We test it headless on the native (unix) AtomVM through Popcorn.Support.AtomVM.
+  offline-atomvm:
+    name: Offline (LocalLiveView, AtomVM)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        working-directory: examples/local-lv-compare/local
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-toolchain
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install JS dependencies
+        run: pnpm install
+        working-directory: .
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: examples/local-lv-compare/local/deps
+          key: ${{ runner.os }}-mix-local_lv_compare_local-${{ hashFiles('examples/local-lv-compare/local/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-local_lv_compare_local-
+
+      - name: Install Hex dependencies
+        run: mix deps.get
+
+      # Builds the native AtomVM binary the tests run on. Cached by the action
+      # across runs (keyed on the FissionVM commit). The test_helper points
+      # :atomvm_unix_runtime_path at this exact location.
+      - name: Build AtomVM
+        uses: ./.github/actions/build-atomvm
+        with:
+          working-directory: examples/local-lv-compare/local
+          build-mode: debug-unix
+          outdir: test/popcorn_runtime_source/artifacts/unix
+          cmake-opts: "SANITIZER=OFF"
+
+      - name: Run tests
+        run: mix test

--- a/examples/local-lv-compare/local/.gitignore
+++ b/examples/local-lv-compare/local/.gitignore
@@ -1,3 +1,3 @@
 # AtomVM test scaffolding
 /tmp/
-/popcorn_runtime_source/
+/test/popcorn_runtime_source/

--- a/examples/local-lv-compare/local/.gitignore
+++ b/examples/local-lv-compare/local/.gitignore
@@ -1,0 +1,3 @@
+# AtomVM test scaffolding
+/tmp/
+/popcorn_runtime_source/

--- a/examples/local-lv-compare/local/test/demo_modal_offline_atomvm_test.exs
+++ b/examples/local-lv-compare/local/test/demo_modal_offline_atomvm_test.exs
@@ -7,7 +7,7 @@ defmodule DemoModalOfflineAtomVMTest do
 
   Build the runtime once with:
 
-      MIX_TARGET=wasm mix popcorn.build_runtime --target unix
+      MIX_TARGET=wasm mix popcorn.build_runtime --target unix --out-dir test/popcorn_runtime_source
   """
   use ExUnit.Case
   alias Popcorn.Support.AtomVM

--- a/examples/local-lv-compare/local/test/demo_modal_offline_atomvm_test.exs
+++ b/examples/local-lv-compare/local/test/demo_modal_offline_atomvm_test.exs
@@ -1,0 +1,47 @@
+defmodule DemoModalOfflineAtomVMTest do
+  @moduledoc """
+  Runs the offline (LocalLiveView) modal on a real native AtomVM, the same runtime
+  that powers the example in the browser. We compile a quoted expression that mounts
+  the view, handles the close event and renders both states to HTML, run it on the
+  AtomVM binary, and assert on the HTML it produces.
+
+  Build the runtime once with:
+
+      MIX_TARGET=wasm mix popcorn.build_runtime --target unix
+  """
+  use ExUnit.Case
+  alias Popcorn.Support.AtomVM
+
+  @moduletag :tmp_dir
+  @moduletag timeout: :timer.minutes(3)
+
+  @modal ~s(class="modal")
+
+  test "DemoModalOffline mount/handle_event/render runs on AtomVM", %{tmp_dir: dir} do
+    bundle =
+      quote do
+        render = fn socket ->
+          socket.assigns
+          |> Map.put(:__changed__, nil)
+          |> DemoModalOffline.render()
+          |> Phoenix.HTML.Safe.to_iodata()
+          |> IO.iodata_to_binary()
+        end
+
+        {:ok, socket} = DemoModalOffline.mount(%{}, %{}, %Phoenix.LiveView.Socket{})
+        open_html = render.(socket)
+
+        {:noreply, closed} = DemoModalOffline.handle_event("close_modal", %{}, socket)
+        closed_html = render.(closed)
+
+        %{open: open_html, closed: closed_html}
+      end
+      |> AtomVM.compile_quoted()
+
+    assert %{open: open_html, closed: closed_html} = AtomVM.run(bundle, dir)
+
+    # Same behaviour we asserted on the BEAM, now produced by AtomVM:
+    assert open_html =~ @modal
+    refute closed_html =~ @modal
+  end
+end

--- a/examples/local-lv-compare/local/test/test_helper.exs
+++ b/examples/local-lv-compare/local/test/test_helper.exs
@@ -1,0 +1,11 @@
+# These tests run on a real (native, unix) AtomVM via Popcorn.Support.AtomVM.
+# Build the runtime once with: MIX_TARGET=wasm mix popcorn.build_runtime --target unix
+Application.put_env(:popcorn, :test_target, :unix)
+
+Application.put_env(
+  :popcorn,
+  :atomvm_unix_runtime_path,
+  Path.join([File.cwd!(), "popcorn_runtime_source/artifacts/unix", "AtomVM"])
+)
+
+ExUnit.start()

--- a/examples/local-lv-compare/local/test/test_helper.exs
+++ b/examples/local-lv-compare/local/test/test_helper.exs
@@ -1,11 +1,14 @@
 # These tests run on a real (native, unix) AtomVM via Popcorn.Support.AtomVM.
-# Build the runtime once with: MIX_TARGET=wasm mix popcorn.build_runtime --target unix
+# Build the runtime once (e.g. in CI before `mix test`) with:
+#
+#   MIX_TARGET=wasm mix popcorn.build_runtime --target unix --out-dir test/popcorn_runtime_source
+#
 Application.put_env(:popcorn, :test_target, :unix)
 
 Application.put_env(
   :popcorn,
   :atomvm_unix_runtime_path,
-  Path.join([File.cwd!(), "popcorn_runtime_source/artifacts/unix", "AtomVM"])
+  Path.join([File.cwd!(), "test/popcorn_runtime_source/artifacts/unix", "AtomVM"])
 )
 
 ExUnit.start()

--- a/examples/local-lv-compare/test/compare_live_views_web/controllers/page_controller_test.exs
+++ b/examples/local-lv-compare/test/compare_live_views_web/controllers/page_controller_test.exs
@@ -1,8 +1,0 @@
-defmodule CompareLiveViewsWeb.PageControllerTest do
-  use CompareLiveViewsWeb.ConnCase
-
-  test "GET /", %{conn: conn} do
-    conn = get(conn, ~p"/")
-    assert html_response(conn, 200) =~ "Peace of mind from prototype to production"
-  end
-end

--- a/examples/local-lv-compare/test/compare_live_views_web/live/demo_modal_online_test.exs
+++ b/examples/local-lv-compare/test/compare_live_views_web/live/demo_modal_online_test.exs
@@ -1,0 +1,30 @@
+defmodule CompareLiveViewsWeb.DemoModalOnlineTest do
+  use CompareLiveViewsWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  describe "DemoModalOnline (Phoenix LiveView)" do
+    test "hides the modal when the close button is clicked", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, CompareLiveViewsWeb.DemoModalOnline)
+
+      # The modal is open right after mount.
+      assert has_element?(view, ".modal")
+
+      view |> element(".close") |> render_click()
+
+      refute has_element?(view, ".modal")
+    end
+
+    test "shows the modal again when the show button is clicked", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, CompareLiveViewsWeb.DemoModalOnline)
+
+      # Close it first so we can observe it being re-opened.
+      view |> element(".close") |> render_click()
+      refute has_element?(view, ".modal")
+
+      view |> element(".show-modal-button") |> render_click()
+
+      assert has_element?(view, ".modal")
+    end
+  end
+end

--- a/popcorn/elixir/lib/mix/tasks/popcorn.build_runtime.ex
+++ b/popcorn/elixir/lib/mix/tasks/popcorn.build_runtime.ex
@@ -3,7 +3,8 @@ defmodule Mix.Tasks.Popcorn.BuildRuntime do
   @moduledoc """
   #{@shortdoc}
 
-  It outputs the artifacts in `project_dir/popcorn_runtime_source/artifacts/<target>`.
+  It outputs the artifacts in `<out-dir>/artifacts/<target>` (by default
+  `project_dir/popcorn_runtime_source/artifacts/<target>`).
   To use the built artifacts in Popcorn, configure it with
 
   ```
@@ -15,6 +16,8 @@ defmodule Mix.Tasks.Popcorn.BuildRuntime do
     - `git-ref` - branch, tag or commit (only works with the `git` option)
     - `path` - path to repo source (can be used instead of `git`)
     - `target` - `wasm` (default) or `unix`
+    - `out-dir` - directory for the build artifacts (default:
+    `popcorn_runtime_source`). Useful e.g. to keep a test-only runtime under `test/`.
     - `cmake-opts` - string with space-separated `KEY=VALUE` options that
     will be converted to `-DKEY=VALUE` cmake options
 
@@ -25,10 +28,10 @@ defmodule Mix.Tasks.Popcorn.BuildRuntime do
 
   @requirements "app.config"
 
-  @out_dir "popcorn_runtime_source"
+  @default_out_dir "popcorn_runtime_source"
 
   def run(args) do
-    options_defaults = %{path: nil, git: nil, git_ref: nil, cmake_opts: nil}
+    options_defaults = %{path: nil, git: nil, git_ref: nil, cmake_opts: nil, out_dir: nil}
     parser_config = [strict: [:target | Map.keys(options_defaults)] |> Keyword.from_keys(:string)]
     {options, _rest} = OptionParser.parse!(args, parser_config)
     options = Map.merge(options_defaults, Map.new(options))
@@ -38,14 +41,15 @@ defmodule Mix.Tasks.Popcorn.BuildRuntime do
     end
 
     target = options.target
+    out_dir = options.out_dir || @default_out_dir
 
     # Build script args
     script_args = build_script_args(options)
 
     # Add output directory
-    artifacts_dir = Path.join([@out_dir, "artifacts", target])
+    artifacts_dir = Path.join([out_dir, "artifacts", target])
     File.mkdir_p!(artifacts_dir)
-    File.write!(Path.join(@out_dir, ".gitignore"), "*\n")
+    File.write!(Path.join(out_dir, ".gitignore"), "*\n")
 
     script_args = ["--outdir", artifacts_dir | script_args]
 

--- a/popcorn/elixir/lib/popcorn/support/atom_vm.ex
+++ b/popcorn/elixir/lib/popcorn/support/atom_vm.ex
@@ -161,19 +161,19 @@ defmodule Popcorn.Support.AtomVM do
       apply(Playwright.Page, :evaluate, [
         page,
         """
-      async () => {
-        const instance = window.popcornInstances.get("#{instance_id}");
-        try {
-          const result = await instance.popcorn.call("#{args}", {process: "main"});
-          if (!result.ok) {
+        async () => {
+          const instance = window.popcornInstances.get("#{instance_id}");
+          try {
+            const result = await instance.popcorn.call("#{args}", {process: "main"});
+            if (!result.ok) {
+              return { error: true, logs: instance.logs.join("") };
+            }
+            return { data: result.data, logs: instance.logs.join("") };
+          } catch (e) {
             return { error: true, logs: instance.logs.join("") };
           }
-          return { data: result.data, logs: instance.logs.join("") };
-        } catch (e) {
-          return { error: true, logs: instance.logs.join("") };
         }
-      }
-      """
+        """
       ])
 
     logs = Map.get(result, :logs, "")

--- a/popcorn/elixir/lib/popcorn/support/atom_vm.ex
+++ b/popcorn/elixir/lib/popcorn/support/atom_vm.ex
@@ -152,10 +152,15 @@ defmodule Popcorn.Support.AtomVM do
 
     log_path = Path.join(run_dir, "logs.txt")
 
-    {page, instance_id} = Popcorn.Support.Browser.new_instance(bundle_path)
+    # `apply/3` keeps the test-only Browser/Playwright modules off the compile-time
+    # dependency graph so this module can ship in `lib/` without forcing those deps
+    # on consumers that only use the :unix target.
+    {page, instance_id} = apply(Popcorn.Support.Browser, :new_instance, [bundle_path])
 
     result =
-      Playwright.Page.evaluate(page, """
+      apply(Playwright.Page, :evaluate, [
+        page,
+        """
       async () => {
         const instance = window.popcornInstances.get("#{instance_id}");
         try {
@@ -168,7 +173,8 @@ defmodule Popcorn.Support.AtomVM do
           return { error: true, logs: instance.logs.join("") };
         }
       }
-      """)
+      """
+      ])
 
     logs = Map.get(result, :logs, "")
     File.write!(log_path, logs)
@@ -203,8 +209,19 @@ defmodule Popcorn.Support.AtomVM do
     Path.join(build_dir, "bundle.avm")
   end
 
+  @doc """
+  Path to the native AtomVM binary used by the :unix target.
+
+  Defaults to popcorn's own test fixture location; consumers building the runtime
+  via `mix popcorn.build_runtime --target unix` should point this at their
+  artifacts dir, e.g. in `test_helper.exs`:
+
+      Application.put_env(:popcorn, :atomvm_unix_runtime_path,
+        Path.join([File.cwd!(), "popcorn_runtime_source/artifacts/unix", "AtomVM"]))
+  """
   def unix_runtime_path() do
-    Path.join([File.cwd!(), "test/fixtures/unix", "AtomVM"])
+    Application.get_env(:popcorn, :atomvm_unix_runtime_path) ||
+      Path.join([File.cwd!(), "test/fixtures/unix", "AtomVM"])
   end
 
   @doc """
@@ -255,7 +272,16 @@ defmodule Popcorn.Support.AtomVM do
 
     source_path = Path.join(build_dir, "code.ex")
     File.write!(source_path, Macro.to_string(ast))
-    {_output, 0} = System.shell("elixirc #{source_path} -o #{build_dir}")
+
+    # Expose the project's dep closure so struct literals / macros from deps
+    # (e.g. %Phoenix.LiveView.Socket{}) resolve while compiling the wrapper module.
+    pa_flags =
+      [Mix.Project.build_path(), "lib/*/ebin"]
+      |> Path.join()
+      |> Path.wildcard()
+      |> Enum.map_join(" ", &"-pa #{&1}")
+
+    {_output, 0} = System.shell("elixirc #{pa_flags} #{source_path} -o #{build_dir}")
 
     files = build_dir |> Path.join("*.{ex,beam}") |> Path.wildcard()
     paths = Enum.map(files, copy_artifacts_to_dir)


### PR DESCRIPTION
Adds tests for both halves of the example: the online side (Phoenix LiveView) is covered by BEAM tests via `Phoenix.LiveViewTest.live_isolated`, while the offline side (LocalLiveView) runs on a **real, native AtomVM** through `Popcorn.Support.AtomVM`. Along the way it promotes `Popcorn.Support.AtomVM` from `test/support` into popcorn's `lib/` (mirroring `Phoenix.LiveViewTest`) so examples can use it as a library test helper. It also adds an `--out-dir` option to `mix popcorn.build_runtime`, letting us keep the test-only AtomVM runtime under `test/` instead of as an artifact in the project root. Finally it adds the `local_lv_compare_test.yml` workflow with two jobs (online on the BEAM, offline building and running a unix AtomVM). The offline part requires a one-time `mix popcorn.build_runtime --target unix --out-dir test/popcorn_runtime_source` before `mix test` (this step is present in CI).