### PR TITLE
[LLV] Thermostat example tests

### DIFF
--- a/.github/workflows/local_lv_thermostat_test.yml
+++ b/.github/workflows/local_lv_thermostat_test.yml
@@ -1,0 +1,116 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: local-lv-thermostat - Test
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "examples/local-lv-thermostat/**"
+      - "local-live-view/**"
+      - ".github/workflows/local_lv_thermostat_test.yml"
+      - ".github/actions/**"
+      - "pnpm-workspace.yaml"
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - ".npmrc"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CI: true
+  MIX_ENV: test
+
+jobs:
+  # The online half is a regular Phoenix app that serves the page hosting the
+  # LocalLiveView mount points, tested on the BEAM (no AtomVM involved).
+  online:
+    name: Online (Phoenix, BEAM)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+
+    defaults:
+      run:
+        working-directory: examples/local-lv-thermostat
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-toolchain
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: examples/local-lv-thermostat/deps
+          key: ${{ runner.os }}-mix-local_lv_thermostat-${{ hashFiles('examples/local-lv-thermostat/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-local_lv_thermostat-
+
+      - name: Install Hex dependencies
+        run: mix deps.get
+
+      - name: Run tests
+        run: mix test
+
+  # The offline half is a LocalLiveView app that runs in the browser via AtomVM.
+  # We test it headless on the native (unix) AtomVM through Popcorn.Support.AtomVM.
+  offline-atomvm:
+    name: Offline (LocalLiveView, AtomVM)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        working-directory: examples/local-lv-thermostat/local
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-toolchain
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install JS dependencies
+        run: pnpm install
+        working-directory: .
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: examples/local-lv-thermostat/local/deps
+          key: ${{ runner.os }}-mix-local_lv_thermostat_local-${{ hashFiles('examples/local-lv-thermostat/local/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-local_lv_thermostat_local-
+
+      - name: Install Hex dependencies
+        run: mix deps.get
+
+      # Builds the native AtomVM binary the tests run on. Cached by the action
+      # across runs (keyed on the FissionVM commit). The test_helper points
+      # :atomvm_unix_runtime_path at this exact location.
+      - name: Build AtomVM
+        uses: ./.github/actions/build-atomvm
+        with:
+          working-directory: examples/local-lv-thermostat/local
+          build-mode: debug-unix
+          outdir: test/popcorn_runtime_source/artifacts/unix
+          cmake-opts: "SANITIZER=OFF"
+
+      - name: Run tests
+        run: mix test

--- a/examples/local-lv-thermostat/local/.gitignore
+++ b/examples/local-lv-thermostat/local/.gitignore
@@ -1,0 +1,3 @@
+# AtomVM test scaffolding
+/tmp/
+/test/popcorn_runtime_source/

--- a/examples/local-lv-thermostat/local/test/test_helper.exs
+++ b/examples/local-lv-thermostat/local/test/test_helper.exs
@@ -1,0 +1,14 @@
+# These tests run on a real (native, unix) AtomVM via Popcorn.Support.AtomVM.
+# Build the runtime once (e.g. in CI before `mix test`) with:
+#
+#   MIX_TARGET=wasm mix popcorn.build_runtime --target unix --out-dir test/popcorn_runtime_source
+#
+Application.put_env(:popcorn, :test_target, :unix)
+
+Application.put_env(
+  :popcorn,
+  :atomvm_unix_runtime_path,
+  Path.join([File.cwd!(), "test/popcorn_runtime_source/artifacts/unix", "AtomVM"])
+)
+
+ExUnit.start()

--- a/examples/local-lv-thermostat/local/test/thermostat_live_atomvm_test.exs
+++ b/examples/local-lv-thermostat/local/test/thermostat_live_atomvm_test.exs
@@ -1,0 +1,51 @@
+defmodule ThermostatLiveAtomVMTest do
+  @moduledoc """
+  Runs the offline (LocalLiveView) thermostat on a real native AtomVM, the same runtime
+  that powers the example in the browser. We compile a quoted expression that mounts
+  the view, handles the increment/decrement events and renders each state to HTML, run
+  it on the AtomVM binary, and assert on the HTML it produces.
+
+  Build the runtime once with:
+
+      MIX_TARGET=wasm mix popcorn.build_runtime --target unix --out-dir test/popcorn_runtime_source
+  """
+  use ExUnit.Case
+  alias Popcorn.Support.AtomVM
+
+  @moduletag :tmp_dir
+  @moduletag timeout: :timer.minutes(3)
+
+  test "ThermostatLive mount/handle_event/render runs on AtomVM", %{tmp_dir: dir} do
+    bundle =
+      quote do
+        render = fn socket ->
+          socket.assigns
+          |> Map.put(:__changed__, nil)
+          |> ThermostatLive.render()
+          |> Phoenix.HTML.Safe.to_iodata()
+          |> IO.iodata_to_binary()
+        end
+
+        {:ok, socket} = ThermostatLive.mount(%{}, %{}, %Phoenix.LiveView.Socket{})
+        initial_html = render.(socket)
+
+        {:noreply, hotter} = ThermostatLive.handle_event("inc_temperature", %{}, socket)
+        hotter_html = render.(hotter)
+
+        {:noreply, colder} = ThermostatLive.handle_event("dec_temperature", %{}, socket)
+        colder_html = render.(colder)
+
+        %{initial: initial_html, hotter: hotter_html, colder: colder_html}
+      end
+      |> AtomVM.compile_quoted()
+
+    assert %{initial: initial_html, hotter: hotter_html, colder: colder_html} =
+             AtomVM.run(bundle, dir)
+
+    # Same behaviour the view exhibits in the browser, now produced by AtomVM:
+    assert initial_html =~ "Current temperature: 25°C"
+    assert initial_html =~ "Country: Poland"
+    assert hotter_html =~ "Current temperature: 26°C"
+    assert colder_html =~ "Current temperature: 24°C"
+  end
+end

--- a/examples/local-lv-thermostat/test/local_thermostat_web/controllers/page_controller_test.exs
+++ b/examples/local-lv-thermostat/test/local_thermostat_web/controllers/page_controller_test.exs
@@ -1,8 +1,12 @@
 defmodule LocalThermostatWeb.PageControllerTest do
   use LocalThermostatWeb.ConnCase
 
-  test "GET /", %{conn: conn} do
+  test "GET / renders the LocalLiveView mount points", %{conn: conn} do
     conn = get(conn, ~p"/")
-    assert html_response(conn, 200) =~ "Peace of mind from prototype to production"
+    html = html_response(conn, 200)
+
+    # The server renders mount points; the views themselves boot in the browser via AtomVM.
+    assert html =~ ~s(data-pop-view="ThermostatLive")
+    assert html =~ ~s(data-pop-view="ClockLive")
   end
 end


### PR DESCRIPTION
Tests for the `local-lv-thermostat` example: an offline suite running `ThermostatLive` (mount/inc/dec temperature) on the native AtomVM, plus a CI workflow with online (BEAM) and offline-atomvm jobs — the online `page_controller_test` was also fixed to assert on the actual rendered LocalLiveView mount points.