### PR TITLE
otp: allow running js from VM

### DIFF
--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -211,6 +211,45 @@ test("handles events in both directions", async ({ otp }) => {
   });
 });
 
+test("run_js evaluates code on the main thread", async ({ otp, page }) => {
+  // run_js is fire-and-forget: it emits no onEvent and returns nothing, so we
+  // poll the side effect the eval'd code leaves on the main-thread window.
+  const RUN_JS_BOOT_EVAL = 'wasm:run_js(<<"window.popcorn = {js: true}">>).';
+  const boot = await otp.boot({
+    beam: { assetsUrl: "/otp-assets", extraArgs: ["-eval", RUN_JS_BOOT_EVAL] },
+  });
+  assert(boot.ok);
+
+  await page.waitForFunction("window.popcorn?.js === true");
+});
+
+test("run_js runs an async snippet", async ({ otp, page }) => {
+  const RUN_JS_BOOT_EVAL =
+    'wasm:run_js(<<"(async () => { window.popcorn = {async: true}; })()">>).';
+  const boot = await otp.boot({
+    beam: { assetsUrl: "/otp-assets", extraArgs: ["-eval", RUN_JS_BOOT_EVAL] },
+  });
+  assert(boot.ok);
+
+  await page.waitForFunction("window.popcorn?.async === true");
+});
+
+test("a throwing run_js snippet doesn't stop later ones from running", async ({
+  otp,
+  page,
+}) => {
+  // The first eval throws; the second must still run and leave its side effect.
+  const RUN_JS_BOOT_EVAL =
+    "wasm:run_js(<<\"throw new Error('boom')\">>), " +
+    'wasm:run_js(<<"window.popcorn = {throwing: true}">>).';
+  const boot = await otp.boot({
+    beam: { assetsUrl: "/otp-assets", extraArgs: ["-eval", RUN_JS_BOOT_EVAL] },
+  });
+  assert(boot.ok);
+
+  await page.waitForFunction("window.popcorn?.throwing === true");
+});
+
 test("popcorn.send() reports unregistered process", async ({ otp }) => {
   const READY_BOOT_EVAL = "ok = wasm:send(#{ready => true}).";
   const boot = await otp.boot({

--- a/otp/js/src/errors.ts
+++ b/otp/js/src/errors.ts
@@ -17,6 +17,7 @@ export type PopcornErrors = {
   "beam:missing-tarball": { name: string; all: string[] };
   "internal:check": { detail?: string };
   "internal:unreachable": EmptyData;
+  "runtime:eval-unavailable": EmptyData;
 };
 
 export type SerializedError<T extends Tag = Tag> = {
@@ -110,6 +111,8 @@ function message(error: SerializedError): string {
         : `Check failed: ${error.data.detail}`;
     case "internal:unreachable":
       return "Entered unreachable code";
+    case "runtime:eval-unavailable":
+      return "JS eval is unavailable; run_js requires a Content-Security-Policy that allows 'unsafe-eval'";
     default:
       unreachable();
   }
@@ -151,6 +154,7 @@ function parse(value: unknown): SerializedError {
       check(isInternalCheckData(value.data));
       return { t: value.t, data: value.data };
     case "internal:unreachable":
+    case "runtime:eval-unavailable":
       check(isEmptyData(value.data));
       return { t: value.t, data: value.data };
     default:

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -56,6 +56,10 @@ type BridgeEnvelope =
   | {
       type: "vm_error";
       data: string;
+    }
+  | {
+      type: "run_js";
+      code: string;
     };
 
 export function readMainEvent(value: unknown): MainToVmEvent | null {
@@ -84,6 +88,7 @@ export function readWorkerEvent(value: unknown): VmToMainEvent | null {
     case "otp:stderr":
     case "otp:error":
     case "otp:message":
+    case "otp:run_js":
     case "popcorn:boot-end":
     case "popcorn:boot-fail":
     case "popcorn:send-end":
@@ -119,7 +124,9 @@ export function serializeSendPayload(
 
 export function deserializeBridgeMessage(
   text: string,
-): Extract<BeamEvent, { type: "otp:message" | "otp:error" }> | null {
+):
+  | Extract<BeamEvent, { type: "otp:message" | "otp:error" | "otp:run_js" }>
+  | null {
   try {
     const parsed = JSON.parse(text) as unknown;
     if (!isBridgeEnvelope(parsed)) return null;
@@ -135,6 +142,8 @@ export function deserializeBridgeMessage(
             data: parsed.data,
           },
         };
+      case "run_js":
+        return { type: "otp:run_js", payload: { code: parsed.code } };
       default:
         return null;
     }
@@ -157,7 +166,9 @@ function isBridgeEnvelope(value: unknown): value is BridgeEnvelope {
   const data = objectWithKeys(value, ["type"]);
   return (
     data !== null &&
-    (data.type === "vm_message" || data.type === "vm_error")
+    (data.type === "vm_message" ||
+      data.type === "vm_error" ||
+      data.type === "run_js")
   );
 }
 

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -63,6 +63,9 @@ export class Popcorn {
       case "otp:message":
         this.emit(data.payload);
         return;
+      case "otp:run_js":
+        this.runJs(data.payload.code);
+        return;
       case "otp:stdout":
         console.log(`${LOG_PREFIX} stdout:`, data.payload);
         return;
@@ -94,6 +97,10 @@ export class Popcorn {
   }
 
   public static async init(opts: PopcornOpts): Promise<Result<Popcorn>> {
+    if (!canEval()) {
+      return { ok: false, error: err("runtime:eval-unavailable", {}) };
+    }
+
     const popcorn = new Popcorn(opts);
     const result = await popcorn.boot();
 
@@ -253,6 +260,11 @@ export class Popcorn {
     }
   }
 
+  private runJs(code: string): void {
+    // Main thread; supports sync or async code, errors are thrown.
+    indirectEval(code);
+  }
+
   private completeSend(payload: SendCompletionPayload): void {
     const resolve = this.pendingSends.get(payload.id) ?? null;
 
@@ -303,6 +315,20 @@ function exitReason(payload: OtpErrorPayload): VmExitReason {
       return { reason: "exit", data: payload.data };
     default:
       return unreachable();
+  }
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#direct_and_indirect_eval
+function indirectEval(code: string): unknown {
+  return (0, eval)(code);
+}
+
+function canEval(): boolean {
+  try {
+    indirectEval("0");
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/otp/js/src/types.ts
+++ b/otp/js/src/types.ts
@@ -22,7 +22,8 @@ export type BeamEvent =
   | { type: "otp:stdout"; payload: string }
   | { type: "otp:stderr"; payload: string }
   | { type: "otp:error"; payload: OtpErrorPayload }
-  | { type: "otp:message"; payload: AnyValue };
+  | { type: "otp:message"; payload: AnyValue }
+  | { type: "otp:run_js"; payload: { code: string } };
 
 export type OtpErrorPayload =
   | { kind: "abort"; data: string }

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -894,10 +894,10 @@ index 3b672dc41a554cf7d5440ccfd94e85bd44b61d35..4e5efb04e7eb04556ff14dc3ba8e0d83
  	    ]},
 diff --git a/erts/preloaded/src/wasm.erl b/erts/preloaded/src/wasm.erl
 new file mode 100644
-index 0000000000000000000000000000000000000000..519f96444ebe4f3c581944daab93abe5add71736
+index 0000000000000000000000000000000000000000..cdc153b8b2a72525f044c8586c6893b399095f08
 --- /dev/null
 +++ b/erts/preloaded/src/wasm.erl
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,46 @@
 +%%
 +%% %CopyrightBegin%
 +%%
@@ -924,13 +924,18 @@ index 0000000000000000000000000000000000000000..519f96444ebe4f3c581944daab93abe5
 +
 +%% on_load/0 is called explicitly from erl_init:start/2; do NOT use the
 +%% -on_load attribute (a preloaded module with one aborts the VM at boot).
-+-export([on_load/0, send/1]).
++-export([on_load/0, send/1, run_js/1]).
 +
 +-nifs([send_raw/1]).
 +
 +-spec send(json:encode_value()) -> ok.
 +send(Message) ->
 +    Envelope = #{type => vm_message, data => Message},
++    ok = send_raw(iolist_to_binary(json:encode(Envelope))).
++
++-spec run_js(binary()) -> ok.
++run_js(Code) when is_binary(Code) ->
++    Envelope = #{type => run_js, code => Code},
 +    ok = send_raw(iolist_to_binary(json:encode(Envelope))).
 +
 +-spec on_load() -> ok.


### PR DESCRIPTION
Currently, this uses `eval` which has some security implications. The plan is to avoid it and preprocess user code that uses `run_js` and extract scripts statically.