### PR TITLE
otp: tracked values in wasm

### DIFF
--- a/otp/js/e2e/helpers.ts
+++ b/otp/js/e2e/helpers.ts
@@ -25,6 +25,7 @@ declare global {
 type InitOptions = PopcornOpts;
 type BootResult = Result<null>;
 type EventWaiter = (event: PopcornEvent) => void;
+type OtpFactory = () => Promise<OtpHandle>;
 type Otp = {
   events: PopcornEvent[];
   boot(options: InitOptions): Promise<BootResult>;
@@ -48,10 +49,20 @@ export const test = base.extend<Fixtures>({
     await page.waitForFunction(() => window.Popcorn !== undefined);
     await use(page);
   },
-  otp: async ({ page }, use) => {
-    const otp = await OtpHandle.create(page);
+  createOtp: async ({ page }, use) => {
+    const handles = new Set<OtpHandle>();
+    const createOtp = async () => {
+      const otp = await OtpHandle.create(page);
+      handles.add(otp);
+      return otp;
+    };
+
+    await use(createOtp);
+    await Promise.all(Array.from(handles, (otp) => otp.dispose()));
+  },
+  otp: async ({ createOtp }, use) => {
+    const otp = await createOtp();
     await use(otp);
-    await otp.dispose();
   },
 });
 
@@ -226,6 +237,7 @@ function createOtp(): Otp {
 }
 
 type Fixtures = {
+  createOtp: OtpFactory;
   otp: OtpHandle;
 };
 

--- a/otp/js/e2e/helpers.ts
+++ b/otp/js/e2e/helpers.ts
@@ -19,17 +19,215 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Window {
     Popcorn: typeof Popcorn;
-    __recordOtpEvent: (event: PopcornEvent) => Promise<void>;
   }
 }
 
 type InitOptions = PopcornOpts;
 type BootResult = Result<null>;
 type EventWaiter = (event: PopcornEvent) => void;
+type Otp = {
+  events: PopcornEvent[];
+  boot(options: InitOptions): Promise<BootResult>;
+  send(
+    target: string | BeamTarget,
+    payload?: unknown,
+    opts?: PopcornSendOpts,
+  ): Promise<BootResult>;
+  waitForEvent(name: string): Promise<PopcornEvent>;
+  deinit(): void;
+};
 
 export type Result<T> =
-  | { ok: true; data: T }
-  | { ok: false; error: SerializedError };
+  { ok: true; data: T } | { ok: false; error: SerializedError };
+
+export { assert, expect };
+
+export const test = base.extend<Fixtures>({
+  page: async ({ page }, use) => {
+    await page.goto("/");
+    await page.waitForFunction(() => window.Popcorn !== undefined);
+    await use(page);
+  },
+  otp: async ({ page }, use) => {
+    const otp = await OtpHandle.create(page);
+    await use(otp);
+    await otp.dispose();
+  },
+});
+
+export class OtpHandle {
+  public readonly events = new Set<PopcornEvent>();
+  private otpHandle: JSHandle<Otp> | null;
+
+  private constructor(
+    private readonly page: Page,
+    otp: JSHandle<Otp>,
+  ) {
+    this.otpHandle = otp;
+  }
+
+  public static async create(page: Page): Promise<OtpHandle> {
+    const otp = await page.evaluateHandle(createOtp);
+    return new OtpHandle(page, otp);
+  }
+
+  public async boot(options: InitOptions): Promise<BootResult> {
+    const result = await this.otp.evaluate(
+      (otp, initOptions) => otp.boot(initOptions),
+      options,
+    );
+    await this.syncEvents();
+    return result;
+  }
+
+  public async send(
+    target: string | BeamTarget,
+    payload?: unknown,
+    opts?: PopcornSendOpts,
+  ): Promise<BootResult> {
+    const result = await this.otp.evaluate(
+      (otp, args) => otp.send(args.target, args.payload, args.opts),
+      { target, payload, opts },
+    );
+    await this.syncEvents();
+    return result;
+  }
+
+  public async waitForEvent(name: string): Promise<PopcornEvent> {
+    const event = await this.otp.evaluate(
+      (otp, eventName) => otp.waitForEvent(eventName),
+      name,
+    );
+    await this.syncEvents();
+    return event;
+  }
+
+  public async waitForStderr(text: string): Promise<ConsoleMessage> {
+    return await this.page.waitForEvent("console", (message) => {
+      return (
+        message.type() === "error" &&
+        message.text().includes("[Popcorn]") &&
+        message.text().includes(text)
+      );
+    });
+  }
+
+  public async dispose(): Promise<void> {
+    const otp = this.otpHandle;
+    this.otpHandle = null;
+
+    if (otp === null) return;
+    await otp.evaluate((browserOtp) => browserOtp.deinit());
+    await otp.dispose();
+  }
+
+  private get otp(): JSHandle<Otp> {
+    assert(this.otpHandle !== null, "OTP has been disposed");
+    return this.otpHandle;
+  }
+
+  private async syncEvents(): Promise<void> {
+    const events = await this.otp.evaluate((otp) => otp.events);
+    this.events.clear();
+    for (const event of events) {
+      this.events.add(event);
+    }
+  }
+}
+
+function createOtp(): Otp {
+  function hasKey(event: PopcornEvent, key: string) {
+    return (
+      typeof event === "object" && event !== null && Object.hasOwn(event, key)
+    );
+  }
+
+  function check(condition: boolean, message: string): asserts condition {
+    if (!condition) throw new Error(message);
+  }
+
+  class Otp {
+    public readonly events: PopcornEvent[] = [];
+
+    private popcornHandle: Popcorn | null = null;
+    private readonly eventWaiters = new Map<string, Array<EventWaiter>>();
+
+    public async boot(options: InitOptions): Promise<BootResult> {
+      check(this.popcornHandle === null, "OTP is already booted");
+
+      this.popcornHandle = new window.Popcorn(options);
+      this.popcornHandle.onEvent((event) => {
+        this.recordEvent(event);
+      });
+
+      const boot = await this.popcornHandle.boot();
+      if (boot.ok) return { ok: true, data: null };
+
+      const result: BootResult = {
+        ok: false,
+        error: boot.error.serialize(),
+      };
+      this.deinit();
+      return result;
+    }
+
+    public async send(
+      target: string | BeamTarget,
+      payload?: unknown,
+      opts?: PopcornSendOpts,
+    ): Promise<BootResult> {
+      const result = await this.popcorn.send(target, payload, opts);
+      if (result.ok) return { ok: true, data: null };
+      return { ok: false, error: result.error.serialize() };
+    }
+
+    public async waitForEvent(name: string): Promise<PopcornEvent> {
+      const event = this.findEvent(name);
+      if (event !== null) return event;
+
+      return await new Promise<PopcornEvent>((resolve) => {
+        const waiters = this.eventWaiters.get(name) ?? [];
+        waiters.push(resolve);
+        this.eventWaiters.set(name, waiters);
+      });
+    }
+
+    public deinit(): void {
+      const popcorn = this.popcornHandle;
+      this.popcornHandle = null;
+      popcorn?.deinit();
+    }
+
+    private get popcorn() {
+      const popcorn = this.popcornHandle;
+      check(popcorn !== null, "Popcorn has not been booted");
+      return popcorn;
+    }
+
+    private recordEvent(event: PopcornEvent): void {
+      this.events.push(event);
+
+      for (const [name, waiters] of this.eventWaiters) {
+        if (hasKey(event, name)) {
+          this.eventWaiters.delete(name);
+          for (const resolve of waiters) {
+            resolve(event);
+          }
+        }
+      }
+    }
+
+    private findEvent(name: string): PopcornEvent | null {
+      return this.events.find((event) => hasKey(event, name)) ?? null;
+    }
+  }
+
+  return new Otp();
+}
+
+type Fixtures = {
+  otp: OtpHandle;
+};
 
 export function trimLeft(text: string): string {
   const leadingBlanks = /^(?:[ \t]*\n)+/;
@@ -50,161 +248,3 @@ export function trimLeft(text: string): string {
   const trimmedLines = lines.map((line) => line.slice(indentN));
   return trimmedLines.join("\n");
 }
-
-export class Otp {
-  public readonly events = new Set<PopcornEvent>();
-
-  private popcorn: JSHandle<Popcorn> | null = null;
-  private readonly eventWaiters = new Map<string, Array<EventWaiter>>();
-
-  public constructor(private readonly page: Page) {}
-
-  public async installEventBridge(): Promise<void> {
-    await this.page.exposeBinding("__recordOtpEvent", (_source, event) => {
-      this.recordEvent(event as PopcornEvent);
-    });
-  }
-
-  public async boot(options: InitOptions): Promise<BootResult> {
-    if (this.popcorn !== null) {
-      throw new Error("OTP is already booted");
-    }
-
-    this.popcorn = await this.page.evaluateHandle(
-      (initOptions: InitOptions): Popcorn => new window.Popcorn(initOptions),
-      options,
-    );
-    await this.popcorn.evaluate((popcorn) => {
-      popcorn.onEvent((event) => {
-        window.__recordOtpEvent(event);
-      });
-    });
-
-    const result = await this.popcorn.evaluate(
-      async (popcorn): Promise<BootResult> => {
-        const boot = await popcorn.boot();
-        if (boot.ok) return { ok: true, data: null };
-        return { ok: false, error: boot.error.serialize() };
-      },
-    );
-
-    if (!result.ok) {
-      await this.dispose();
-    }
-
-    return result;
-  }
-
-  public async send(
-    target: string | BeamTarget,
-    payload?: unknown,
-    opts?: PopcornSendOpts,
-  ): Promise<BootResult> {
-    const popcorn = this.requirePopcorn();
-
-    return await popcorn.evaluate(
-      async (instance, args) => {
-        const result = await instance.send(
-          args.target,
-          args.payload,
-          args.opts,
-        );
-
-        if (result.ok) return { ok: true, data: null };
-        return { ok: false, error: result.error.serialize() };
-      },
-      { target, payload, opts },
-    );
-  }
-
-  public async waitForEvent(name: string): Promise<PopcornEvent> {
-    const event = this.findEvent(name);
-    if (event !== null) {
-      return event;
-    }
-
-    return await new Promise<PopcornEvent>((resolve) => {
-      const waiters = this.eventWaiters.get(name) ?? [];
-      waiters.push(resolve);
-      this.eventWaiters.set(name, waiters);
-    });
-  }
-
-  public async waitForStderr(text: string): Promise<ConsoleMessage> {
-    return await this.page.waitForEvent("console", (message) => {
-      return (
-        message.type() === "error" &&
-        message.text().includes("[Popcorn]") &&
-        message.text().includes(text)
-      );
-    });
-  }
-
-  public async dispose(): Promise<void> {
-    const popcorn = this.popcorn;
-    this.popcorn = null;
-    if (popcorn !== null) {
-      await this.page.evaluate((instance) => instance.deinit(), popcorn);
-      await popcorn.dispose();
-    }
-  }
-
-  private requirePopcorn(): JSHandle<Popcorn> {
-    if (this.popcorn === null) {
-      throw new Error("Popcorn has not been booted");
-    }
-
-    return this.popcorn;
-  }
-
-  private recordEvent(event: PopcornEvent): void {
-    this.events.add(event);
-
-    for (const [name, waiters] of this.eventWaiters) {
-      if (
-        typeof event === "object" &&
-        event !== null &&
-        Object.hasOwn(event, name)
-      ) {
-        this.eventWaiters.delete(name);
-        for (const resolve of waiters) {
-          resolve(event);
-        }
-      }
-    }
-  }
-
-  private findEvent(name: string): PopcornEvent | null {
-    for (const event of this.events) {
-      if (
-        typeof event === "object" &&
-        event !== null &&
-        Object.hasOwn(event, name)
-      ) {
-        return event;
-      }
-    }
-
-    return null;
-  }
-}
-
-type Fixtures = {
-  otp: Otp;
-};
-
-export { assert, expect };
-
-export const test = base.extend<Fixtures>({
-  page: async ({ page }, use) => {
-    await page.goto("/");
-    await page.waitForFunction(() => window.Popcorn !== undefined);
-    await use(page);
-  },
-  otp: async ({ page }, use) => {
-    const otp = new Otp(page);
-    await otp.installEventBridge();
-    await use(otp);
-    await otp.dispose();
-  },
-});

--- a/otp/js/e2e/helpers.ts
+++ b/otp/js/e2e/helpers.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import {
   expect,
   test as base,
@@ -12,6 +13,7 @@ import type {
   PopcornEvent,
   PopcornSendOpts,
   BeamTarget,
+  OtpErrorPayload,
   SerializedError,
 } from "@swmansion/popcorn-otp";
 
@@ -25,8 +27,9 @@ declare global {
 type InitOptions = PopcornOpts;
 type BootResult = Result<null>;
 type EventWaiter = (event: PopcornEvent) => void;
-type OtpFactory = () => Promise<OtpHandle>;
+type OtpFactory = (id?: string) => Promise<OtpHandle>;
 type Otp = {
+  id: string;
   events: PopcornEvent[];
   boot(options: InitOptions): Promise<BootResult>;
   send(
@@ -51,8 +54,8 @@ export const test = base.extend<Fixtures>({
   },
   createOtp: async ({ page }, use) => {
     const handles = new Set<OtpHandle>();
-    const createOtp = async () => {
-      const otp = await OtpHandle.create(page);
+    const createOtp = async (id = randomOtpId()) => {
+      const otp = await OtpHandle.create(page, id);
       handles.add(otp);
       return otp;
     };
@@ -72,14 +75,15 @@ export class OtpHandle {
 
   private constructor(
     private readonly page: Page,
+    public readonly id: string,
     otp: JSHandle<Otp>,
   ) {
     this.otpHandle = otp;
   }
 
-  public static async create(page: Page): Promise<OtpHandle> {
-    const otp = await page.evaluateHandle(createOtp);
-    return new OtpHandle(page, otp);
+  public static async create(page: Page, id: string): Promise<OtpHandle> {
+    const otp = await page.evaluateHandle(createOtp, id);
+    return new OtpHandle(page, id, otp);
   }
 
   public async boot(options: InitOptions): Promise<BootResult> {
@@ -117,7 +121,7 @@ export class OtpHandle {
     return await this.page.waitForEvent("console", (message) => {
       return (
         message.type() === "error" &&
-        message.text().includes("[Popcorn]") &&
+        message.text().includes(`[Popcorn-${this.id}]`) &&
         message.text().includes(text)
       );
     });
@@ -146,7 +150,21 @@ export class OtpHandle {
   }
 }
 
-function createOtp(): Otp {
+function createOtp(id: string): Otp {
+  function logOtpError(logPrefix: string, payload: OtpErrorPayload): void {
+    switch (payload.kind) {
+      case "abort":
+        console.error(`${logPrefix} abort:`, payload.data);
+        return;
+      case "error":
+        console.error(`${logPrefix} error:`, payload.data);
+        return;
+      case "exit":
+        console.info(`${logPrefix} exit:`, payload.data);
+        return;
+    }
+  }
+
   function hasKey(event: PopcornEvent, key: string) {
     return (
       typeof event === "object" && event !== null && Object.hasOwn(event, key)
@@ -158,6 +176,7 @@ function createOtp(): Otp {
   }
 
   class Otp {
+    public readonly id = id;
     public readonly events: PopcornEvent[] = [];
 
     private popcornHandle: Popcorn | null = null;
@@ -166,7 +185,7 @@ function createOtp(): Otp {
     public async boot(options: InitOptions): Promise<BootResult> {
       check(this.popcornHandle === null, "OTP is already booted");
 
-      this.popcornHandle = new window.Popcorn(options);
+      this.popcornHandle = new window.Popcorn(this.withLogHandlers(options));
       this.popcornHandle.onEvent((event) => {
         this.recordEvent(event);
       });
@@ -215,6 +234,19 @@ function createOtp(): Otp {
       return popcorn;
     }
 
+    private get logPrefix(): string {
+      return `[Popcorn-${this.id}]`;
+    }
+
+    private withLogHandlers(options: InitOptions): InitOptions {
+      return {
+        ...options,
+        onStdout: (text) => console.log(`${this.logPrefix} stdout:`, text),
+        onStderr: (text) => console.error(`${this.logPrefix} stderr:`, text),
+        onError: (event) => logOtpError(this.logPrefix, event),
+      };
+    }
+
     private recordEvent(event: PopcornEvent): void {
       this.events.push(event);
 
@@ -240,6 +272,10 @@ type Fixtures = {
   createOtp: OtpFactory;
   otp: OtpHandle;
 };
+
+function randomOtpId(): string {
+  return `otp-${randomUUID().slice(0, 8)}`;
+}
 
 export function trimLeft(text: string): string {
   const leadingBlanks = /^(?:[ \t]*\n)+/;

--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -139,7 +139,7 @@ test("event hooks preserved after a reboot", async ({ page }) => {
   expect(result.afterReboot).toBeGreaterThan(0);
 });
 
-test("failing boot fails fast (no timeout)", async ({ page }) => {
+test("failing boot fails immediately", async ({ page }) => {
   const result = await page.evaluate(async () => {
     const popcorn = new window.Popcorn({
       beam: { assetsUrl: "/otp-assets" },
@@ -212,7 +212,7 @@ test("handles events in both directions", async ({ otp }) => {
   });
 });
 
-test("run_js returns the snippet result to the caller", async ({ otp }) => {
+test("run_js -> send", async ({ otp }) => {
   const RUN_JS_BOOT_EVAL = trimLeft(`
     V = wasm:run_js(<<"(args) => 1 + 2">>, #{}),
     ok = wasm:send(#{run_js_result => V}).
@@ -224,7 +224,7 @@ test("run_js returns the snippet result to the caller", async ({ otp }) => {
   expect(otp.events).toContainEqual({ run_js_result: 3 });
 });
 
-test("run_js passes args and awaits an async snippet", async ({ otp }) => {
+test("async run_js", async ({ otp }) => {
   const RUN_JS_BOOT_EVAL = trimLeft(`
     V = wasm:run_js(<<"async ({a, b}) => a + b">>, #{a => 2, b => 5}),
     ok = wasm:send(#{run_js_async => V}).
@@ -236,7 +236,7 @@ test("run_js passes args and awaits an async snippet", async ({ otp }) => {
   expect(otp.events).toContainEqual({ run_js_async: 7 });
 });
 
-test("run_js accepts a custom timeout", async ({ otp }) => {
+test("run_js timeout", async ({ otp }) => {
   const RUN_JS_BOOT_EVAL = trimLeft(`
     R = try
       wasm:run_js(<<"() => new Promise(() => {})">>, #{}, [{timeout, 0}])
@@ -252,7 +252,7 @@ test("run_js accepts a custom timeout", async ({ otp }) => {
   expect(otp.events).toContainEqual({ run_js_timeout: "timeout" });
 });
 
-test("a throwing run_js snippet raises in the caller", async ({ otp }) => {
+test("throwing run_js raises in VM", async ({ otp }) => {
   const RUN_JS_BOOT_EVAL = trimLeft(`
     R = try
       wasm:run_js(<<"() => { throw new Error('boom') }">>, #{})
@@ -268,7 +268,111 @@ test("a throwing run_js snippet raises in the caller", async ({ otp }) => {
   expect(otp.events).toContainEqual({ run_js_error: "Error: boom" });
 });
 
-test("popcorn.send() reports unregistered process", async ({ otp }) => {
+test("tracked values keep identity", async ({ otp }) => {
+  const RUN_JS_BOOT_EVAL = trimLeft(`
+    H = wasm:run_js(<<"() => new TrackedValue({n: 1})">>, #{}),
+    V = wasm:run_js(<<"({h}) => { h.n = h.n + 1; return h.n; }">>, #{h => H}),
+    ok = wasm:send(#{roundtrip => V}).
+  `);
+  const boot = await otp.boot(evalOpts(RUN_JS_BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("roundtrip");
+  expect(otp.events).toContainEqual({ roundtrip: 2 });
+});
+
+test("nested tracked values", async ({ otp }) => {
+  const RUN_JS_BOOT_EVAL = trimLeft(`
+    H = wasm:run_js(<<"() => new TrackedValue({n: 5})">>, #{}),
+    V = wasm:run_js(
+      <<"(a) => a.list[0].n + a.wrap.h.n">>,
+      #{list => [H], wrap => #{h => H}}
+    ),
+    ok = wasm:send(#{nested => V}).
+  `);
+  const boot = await otp.boot(evalOpts(RUN_JS_BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("nested");
+  expect(otp.events).toContainEqual({ nested: 10 });
+});
+
+test("isolated tracked values", async ({ createOtp }) => {
+  const evalFor = (id: string) =>
+    trimLeft(`
+      H = wasm:run_js(<<"() => new TrackedValue({id: '${id}'})">>, #{}),
+      ok = wasm:send(H).
+    `);
+
+  const [a, b] = await Promise.all([createOtp(), createOtp()]);
+  const [aBoot, bBoot] = await Promise.all([
+    a.boot(evalOpts(evalFor("A"))),
+    b.boot(evalOpts(evalFor("B"))),
+  ]);
+  assert(aBoot.ok);
+  assert(bBoot.ok);
+
+  const aId = await a.waitForEvent("id");
+  const bId = await b.waitForEvent("id");
+
+  expect(aId).toEqual({ id: "A" });
+  expect(bId).toEqual({ id: "B" });
+});
+
+test("tracked values isolated cleanup", async ({ createOtp, page }) => {
+  const [closedOtp, liveOtp] = await Promise.all([createOtp(), createOtp()]);
+  let cleanupCalls = 0;
+  await page.exposeFunction("popcornCleanup", () => {
+    cleanupCalls += 1;
+  });
+  await page.evaluate(() => {
+    const scope = globalThis as unknown as {
+      popcorn: { cleanup: () => void };
+      popcornCleanup: () => void;
+    };
+    scope.popcorn = { cleanup: () => scope.popcornCleanup() };
+  });
+  const cleanupTrackedEval = trimLeft(`
+    spawn(fun() ->
+      H = wasm:run_js(
+        <<"() => new TrackedValue(0, () => globalThis.popcorn.cleanup())">>,
+        #{}
+      ),
+      ok = wasm:send(#{deinit_ready => true}),
+      receive stop -> H end
+    end).
+  `);
+  const liveEval = trimLeft(`
+    register(controller, self()),
+    HB = wasm:run_js(<<"() => new TrackedValue({v: 42})">>, #{}),
+    ok = wasm:send(#{live_ready => true}),
+    receive
+      {wasm, _, _} ->
+        ok = wasm:send(HB)
+    end.
+  `);
+
+  const [closedBoot, liveBoot] = await Promise.all([
+    closedOtp.boot(evalOpts(cleanupTrackedEval)),
+    liveOtp.boot(evalOpts(liveEval)),
+  ]);
+  assert(closedBoot.ok);
+  assert(liveBoot.ok);
+
+  await closedOtp.waitForEvent("deinit_ready");
+  await liveOtp.waitForEvent("live_ready");
+  await closedOtp.dispose();
+  await expect.poll(() => cleanupCalls).toBe(1);
+
+  const send = await liveOtp.send("controller", { ping: true });
+  assert(send.ok);
+  const liveEvent = await liveOtp.waitForEvent("v");
+
+  expect(liveEvent).toEqual({ v: 42 });
+  expect(cleanupCalls).toBe(1);
+});
+
+test("send() to unregistered process", async ({ otp }) => {
   const READY_BOOT_EVAL = "ok = wasm:send(#{ready => true}).";
   const boot = await otp.boot(evalOpts(READY_BOOT_EVAL));
   assert(boot.ok);
@@ -284,7 +388,7 @@ test("popcorn.send() reports unregistered process", async ({ otp }) => {
   });
 });
 
-test("reports timeouts on send", async ({ otp }) => {
+test("send() timeout", async ({ otp }) => {
   const boot = await otp.boot({
     beam: { assetsUrl: "/otp-assets" },
     timeoutsMs: { send: 0 },

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -63,6 +63,8 @@ export async function boot({
     },
     onError: (text) =>
       emit({ type: "otp:error", payload: { kind: "error", data: text } }),
+    onTrackedValueDelete: (key) =>
+      emit({ type: "otp:tracked-value-delete", payload: key }),
     arguments: buildArgs({
       searchPaths: searchPaths ?? [],
       extra: extraArgs ?? [],

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -102,6 +102,7 @@ export function readWorkerEvent(value: unknown): VmToMainEvent | null {
     case "otp:error":
     case "otp:message":
     case "otp:run_js":
+    case "otp:tracked-value-delete":
     case "popcorn:boot-end":
     case "popcorn:boot-fail":
     case "popcorn:send-end":

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -25,6 +25,8 @@ export type PopcornOpts = {
     boot?: number;
     send?: number;
   };
+  onStdout?: (text: string) => void;
+  onStderr?: (text: string) => void;
   onError?: (event: OtpErrorPayload) => void;
   workerUrl?: string | URL;
 };
@@ -85,7 +87,7 @@ export class Popcorn {
       case "popcorn:boot-fail":
         return;
       case "otp:message":
-        this.emit(data.payload);
+        this.emit(this.reviveTrackedValues(data.payload));
         return;
       case "otp:run_js":
         this.runJs(data.payload);
@@ -94,10 +96,10 @@ export class Popcorn {
         this.deleteTrackedValue(data.payload);
         return;
       case "otp:stdout":
-        console.log(`${LOG_PREFIX} stdout:`, data.payload);
+        this.handleStdout(data.payload);
         return;
       case "otp:stderr":
-        console.error(`${LOG_PREFIX} stderr:`, data.payload);
+        this.handleStderr(data.payload);
         return;
       case "otp:error":
         this.handleOtpError(data.payload);
@@ -302,7 +304,7 @@ export class Popcorn {
     try {
       const fn = this.jsWithCurrentEnv(request.code);
       assertRunJsFn(fn);
-      const args = this.reviveArgs(request.args);
+      const args = this.reviveTrackedValues(request.args);
       const result = await fn(args);
       payload = { ok: true, value: this.serializeResult(result) ?? null };
     } catch (error) {
@@ -326,8 +328,7 @@ export class Popcorn {
     return make(this.TrackedValue);
   }
 
-  // Replaces `{popcorn_ref: key}` in args, walking recursively
-  private reviveArgs(value: unknown): unknown {
+  private reviveTrackedValues(value: unknown): unknown {
     const key = trackedRefKey(value);
     if (key !== null) {
       const entry = this.trackedValues.get(key);
@@ -335,20 +336,19 @@ export class Popcorn {
       return entry.value;
     }
     if (Array.isArray(value)) {
-      return value.map((item) => this.reviveArgs(item));
+      return value.map((item) => this.reviveTrackedValues(item));
     }
     const obj = objectWithKeys(value, []);
     if (obj !== null) {
       const revived: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(obj)) {
-        revived[k] = this.reviveArgs(v);
+        revived[k] = this.reviveTrackedValues(v);
       }
       return revived;
     }
     return value;
   }
 
-  // Replaces `{popcorn_ref: key}` in args, walking recursively
   private serializeResult(value: unknown): unknown {
     if (value instanceof this.TrackedValue) {
       this.trackedKeySeq += 1;
@@ -401,6 +401,16 @@ export class Popcorn {
   private nextRequestId(): string {
     this.requestSeq += 1;
     return `send:${this.requestSeq}`;
+  }
+
+  private handleStdout(text: string): void {
+    const onStdout = this.opts.onStdout ?? defaultOnStdout;
+    onStdout(text);
+  }
+
+  private handleStderr(text: string): void {
+    const onStderr = this.opts.onStderr ?? defaultOnStderr;
+    onStderr(text);
   }
 
   private handleOtpError(payload: OtpErrorPayload): void {
@@ -459,6 +469,14 @@ function canEval(): boolean {
   } catch {
     return false;
   }
+}
+
+function defaultOnStdout(text: string): void {
+  console.log(`${LOG_PREFIX} stdout:`, text);
+}
+
+function defaultOnStderr(text: string): void {
+  console.error(`${LOG_PREFIX} stderr:`, text);
 }
 
 function defaultOnError(payload: OtpErrorPayload): void {

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -13,7 +13,11 @@ import type {
   OtpErrorPayload,
   RunJsRequest,
 } from "./types";
-import { check, unreachable } from "./utils";
+import { check, objectWithKeys, unreachable } from "./utils";
+
+type TrackedEntry = { value: unknown; cleanup?: () => void };
+
+const TRACKED_REF_KEY = "popcorn_ref";
 
 export type PopcornOpts = {
   beam: Pick<BeamBootOptions, "assetsUrl" | "searchPaths" | "extraArgs">;
@@ -63,6 +67,15 @@ export class Popcorn {
   private settleBoot: ((result: Result<Popcorn>) => void) | null = null;
   private readonly eventHandlers = new Set<(event: PopcornEvent) => void>();
   private readonly pendingSends = new Map<string, PendingSend>();
+  private readonly trackedValues = new Map<number, TrackedEntry>();
+  private trackedKeySeq = 0;
+
+  private readonly TrackedValue = class {
+    public constructor(
+      public readonly value: unknown,
+      public readonly cleanup?: () => void,
+    ) {}
+  };
   private readonly onWorkerMessage = (event: MessageEvent<unknown>) => {
     const data = readWorkerEvent(event.data);
     check(data !== null);
@@ -76,6 +89,9 @@ export class Popcorn {
         return;
       case "otp:run_js":
         this.runJs(data.payload);
+        return;
+      case "otp:tracked-value-delete":
+        this.deleteTrackedValue(data.payload);
         return;
       case "otp:stdout":
         console.log(`${LOG_PREFIX} stdout:`, data.payload);
@@ -260,9 +276,19 @@ export class Popcorn {
       resolve({ ok: false, error });
     }
     this.pendingSends.clear();
+    this.clearTrackedValues();
     this.vmWorker.removeEventListener("message", this.onWorkerMessage);
     this.vmWorker.terminate();
     // we keep onEvent() callbacks across reboots
+  }
+
+  private clearTrackedValues(): void {
+    for (const entry of this.trackedValues.values()) {
+      try {
+        entry.cleanup?.();
+      } catch {}
+    }
+    this.trackedValues.clear();
   }
 
   private emit(event: PopcornEvent): void {
@@ -274,10 +300,11 @@ export class Popcorn {
   private async runJs(request: RunJsRequest): Promise<void> {
     let payload: AnyValue;
     try {
-      const fn = indirectEval(request.code);
+      const fn = this.jsWithCurrentEnv(request.code);
       assertRunJsFn(fn);
-      const result = await fn(request.args);
-      payload = { ok: true, value: result ?? null };
+      const args = this.reviveArgs(request.args);
+      const result = await fn(args);
+      payload = { ok: true, value: this.serializeResult(result) ?? null };
     } catch (error) {
       check(error instanceof Error);
       payload = { ok: false, error: error.toString() };
@@ -289,6 +316,71 @@ export class Popcorn {
       type: "popcorn:run-js-reply",
       payload: { message: command.data },
     });
+  }
+
+  private jsWithCurrentEnv(code: string): unknown {
+    const make = new Function(
+      "TrackedValue",
+      `"use strict"; return (${code});`,
+    );
+    return make(this.TrackedValue);
+  }
+
+  // Replaces `{popcorn_ref: key}` in args, walking recursively
+  private reviveArgs(value: unknown): unknown {
+    const key = trackedRefKey(value);
+    if (key !== null) {
+      const entry = this.trackedValues.get(key);
+      check(entry !== undefined);
+      return entry.value;
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => this.reviveArgs(item));
+    }
+    const obj = objectWithKeys(value, []);
+    if (obj !== null) {
+      const revived: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(obj)) {
+        revived[k] = this.reviveArgs(v);
+      }
+      return revived;
+    }
+    return value;
+  }
+
+  // Replaces `{popcorn_ref: key}` in args, walking recursively
+  private serializeResult(value: unknown): unknown {
+    if (value instanceof this.TrackedValue) {
+      this.trackedKeySeq += 1;
+      const key = this.trackedKeySeq;
+      this.trackedValues.set(key, {
+        value: value.value,
+        cleanup: value.cleanup,
+      });
+      return { [TRACKED_REF_KEY]: key };
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => this.serializeResult(item));
+    }
+    const obj = objectWithKeys(value, []);
+    if (obj !== null) {
+      const serialized: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(obj)) {
+        serialized[k] = this.serializeResult(v);
+      }
+      return serialized;
+    }
+    return value;
+  }
+
+  private deleteTrackedValue(key: number): void {
+    const entry = this.trackedValues.get(key);
+    check(entry !== undefined);
+    try {
+      entry.cleanup?.();
+    } finally {
+      this.trackedValues.delete(key);
+    }
   }
 
   private completeSend(payload: SendCompletionPayload): void {
@@ -342,6 +434,17 @@ function exitReason(payload: OtpErrorPayload): VmExitReason {
     default:
       return unreachable();
   }
+}
+
+function trackedRefKey(value: unknown): number | null {
+  const marker = objectWithKeys(value, [TRACKED_REF_KEY]);
+  const hasOnlyMarker = marker !== null && Object.keys(marker).length === 1;
+  if (!hasOnlyMarker) {
+    return null;
+  }
+  const key = marker[TRACKED_REF_KEY];
+  check(typeof key === "number");
+  return key;
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#direct_and_indirect_eval

--- a/otp/js/src/types.ts
+++ b/otp/js/src/types.ts
@@ -23,7 +23,8 @@ export type BeamEvent =
   | { type: "otp:stderr"; payload: string }
   | { type: "otp:error"; payload: OtpErrorPayload }
   | { type: "otp:message"; payload: AnyValue }
-  | { type: "otp:run_js"; payload: RunJsRequest };
+  | { type: "otp:run_js"; payload: RunJsRequest }
+  | { type: "otp:tracked-value-delete"; payload: number };
 
 export type RunJsRequest = {
   code: string;
@@ -66,6 +67,7 @@ export type EmscriptenModule = {
   _free: (ptr: number) => void;
   onBeamMessage?: (text: string) => void | Promise<void>;
   onError?: (text: string) => void | Promise<void>;
+  onTrackedValueDelete?: (key: number) => void;
   addRunDependency: (id: string) => void;
   removeRunDependency: (id: string) => void;
 };

--- a/otp/js/src/utils.ts
+++ b/otp/js/src/utils.ts
@@ -63,8 +63,8 @@ export function objectWithKeys<K extends string>(
   value: unknown,
   keys: K[],
 ): null | Record<K, unknown> {
-  const isObject = value !== null && typeof value === "object";
-  if (!isObject) return null;
+  if (value === null || typeof value !== "object") return null;
+  if (value.constructor !== Object) return null;
   const hasAllKeys = keys.every((k) => Object.hasOwn(value, k));
   if (!hasAllKeys) return null;
   return value as Record<K, unknown>;

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -183,10 +183,10 @@ index 0000000000000000000000000000000000000000..0b446eedf17294c0c47c2b872bf2fb44
 +});
 diff --git a/erts/emulator/nifs/common/wasm_nif.c b/erts/emulator/nifs/common/wasm_nif.c
 new file mode 100644
-index 0000000000000000000000000000000000000000..2b786c77d12f0716646938b60fdcbc4b91408d52
+index 0000000000000000000000000000000000000000..59f98e78d8c00ce54afc7525937acf2e640b20a5
 --- /dev/null
 +++ b/erts/emulator/nifs/common/wasm_nif.c
-@@ -0,0 +1,580 @@
+@@ -0,0 +1,655 @@
 +/*
 + * %CopyrightBegin%
 + *
@@ -252,6 +252,10 @@ index 0000000000000000000000000000000000000000..2b786c77d12f0716646938b60fdcbc4b
 +  wasm_listener_t *listeners;
 +};
 +
++typedef struct wasm_tracked_value_s {
++  int key;
++} wasm_tracked_value_t;
++
 +static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info);
 +static int upgrade(ErlNifEnv *env, void **priv_data, void **old_priv_data,
 +                   ERL_NIF_TERM load_info);
@@ -259,13 +263,20 @@ index 0000000000000000000000000000000000000000..2b786c77d12f0716646938b60fdcbc4b
 +
 +static ERL_NIF_TERM send_raw_nif(ErlNifEnv *env, int argc,
 +                                 const ERL_NIF_TERM argv[]);
++static ERL_NIF_TERM materialize_ref_nif(ErlNifEnv *env, int argc,
++                                        const ERL_NIF_TERM argv[]);
++static ERL_NIF_TERM ref_key_nif(ErlNifEnv *env, int argc,
++                                const ERL_NIF_TERM argv[]);
 +
 +static void wasm_listener_dtor(ErlNifEnv *env, void *obj);
 +static void wasm_listener_down(ErlNifEnv *env, void *obj, ErlNifPid *pid,
 +                               ErlNifMonitor *mon);
++static void wasm_tracked_value_dtor(ErlNifEnv *env, void *obj);
 +
 +static ErlNifFunc nif_funcs[] = {
 +    {"send_raw", 1, send_raw_nif},
++    {"materialize_ref", 1, materialize_ref_nif},
++    {"ref_key", 1, ref_key_nif},
 +};
 +
 +ERL_NIF_INIT(wasm, nif_funcs, load, NULL, upgrade, unload)
@@ -278,6 +289,7 @@ index 0000000000000000000000000000000000000000..2b786c77d12f0716646938b60fdcbc4b
 +static ERL_NIF_TERM am_wasm;
 +
 +static ErlNifResourceType *wasm_listener_type = NULL;
++static ErlNifResourceType *wasm_tracked_value_type = NULL;
 +/*
 + * The bridge keeps a single active state at a time. Serializing lookups,
 + * callbacks, and unload through one process-wide lock is slower than the
@@ -308,6 +320,15 @@ index 0000000000000000000000000000000000000000..2b786c77d12f0716646938b60fdcbc4b
 +  wasm_listener_type =
 +      enif_open_resource_type_x(env, "wasm_listener", &init, flags, NULL);
 +  return wasm_listener_type != NULL;
++}
++
++static bool load_tracked_value_resource_type(ErlNifEnv *env,
++                                             ErlNifResourceFlags flags) {
++  ErlNifResourceTypeInit init = {wasm_tracked_value_dtor, NULL, NULL};
++
++  wasm_tracked_value_type =
++      enif_open_resource_type_x(env, "wasm_tracked_value", &init, flags, NULL);
++  return wasm_tracked_value_type != NULL;
 +}
 +
 +static int ensure_wasm_state_lock(void) {
@@ -526,6 +547,11 @@ index 0000000000000000000000000000000000000000..2b786c77d12f0716646938b60fdcbc4b
 +    return -1;
 +  }
 +
++  if (!load_tracked_value_resource_type(env, ERL_NIF_RT_CREATE)) {
++    destroy_wasm_state(state);
++    return -1;
++  }
++
 +  init_atoms(env);
 +
 +  enif_mutex_lock(erts_wasm_state_lock);
@@ -555,6 +581,10 @@ index 0000000000000000000000000000000000000000..2b786c77d12f0716646938b60fdcbc4b
 +  state = *old_priv_data;
 +
 +  if (!load_listener_resource_type(env, ERL_NIF_RT_TAKEOVER)) {
++    return -1;
++  }
++
++  if (!load_tracked_value_resource_type(env, ERL_NIF_RT_TAKEOVER)) {
 +    return -1;
 +  }
 +
@@ -615,6 +645,7 @@ index 0000000000000000000000000000000000000000..2b786c77d12f0716646938b60fdcbc4b
 +
 +#ifdef ERTS_EMSCRIPTEN
 +extern void js_bridge_on_from_beam_async(char *data, int len);
++extern void js_bridge_on_tracked_value_delete(int key);
 +
 +static void schedule_js_message(const unsigned char *data, size_t size) {
 +  char *copy;
@@ -652,6 +683,50 @@ index 0000000000000000000000000000000000000000..2b786c77d12f0716646938b60fdcbc4b
 +#else
 +  return make_error(env, am_unsupported);
 +#endif
++}
++
++static void wasm_tracked_value_dtor(ErlNifEnv *env, void *obj) {
++  wasm_tracked_value_t *tracked = obj;
++
++  (void)env;
++
++#ifdef ERTS_EMSCRIPTEN
++  js_bridge_on_tracked_value_delete(tracked->key);
++#else
++  (void)tracked;
++#endif
++}
++
++static ERL_NIF_TERM materialize_ref_nif(ErlNifEnv *env, int argc,
++                                        const ERL_NIF_TERM argv[]) {
++  int key;
++  wasm_tracked_value_t *tracked;
++  ERL_NIF_TERM term;
++
++  if (argc != 1 || !enif_get_int(env, argv[0], &key)) {
++    return enif_make_badarg(env);
++  }
++
++  tracked = enif_alloc_resource(wasm_tracked_value_type,
++                                sizeof(wasm_tracked_value_t));
++  tracked->key = key;
++
++  term = enif_make_resource(env, tracked);
++  enif_release_resource(tracked);
++
++  return term;
++}
++
++static ERL_NIF_TERM ref_key_nif(ErlNifEnv *env, int argc,
++                                const ERL_NIF_TERM argv[]) {
++  wasm_tracked_value_t *tracked;
++
++  if (argc != 1 || !enif_get_resource(env, argv[0], wasm_tracked_value_type,
++                                      (void **)&tracked)) {
++    return enif_make_badarg(env);
++  }
++
++  return enif_make_int(env, tracked->key);
 +}
 +
 +#ifdef ERTS_EMSCRIPTEN
@@ -946,10 +1021,10 @@ index 3b672dc41a554cf7d5440ccfd94e85bd44b61d35..4e5efb04e7eb04556ff14dc3ba8e0d83
  	    ]},
 diff --git a/erts/preloaded/src/wasm.erl b/erts/preloaded/src/wasm.erl
 new file mode 100644
-index 0000000000000000000000000000000000000000..778a49d4b207159cd495116d0d548226777f43af
+index 0000000000000000000000000000000000000000..2941e22e231bc3ea65868e61b03a661c845144af
 --- /dev/null
 +++ b/erts/preloaded/src/wasm.erl
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,89 @@
 +%%
 +%% %CopyrightBegin%
 +%%
@@ -978,7 +1053,7 @@ index 0000000000000000000000000000000000000000..778a49d4b207159cd495116d0d548226
 +%% -on_load attribute (a preloaded module with one aborts the VM at boot).
 +-export([on_load/0, send/1, run_js/2, run_js/3]).
 +
-+-nifs([send_raw/1]).
++-nifs([send_raw/1, materialize_ref/1, ref_key/1]).
 +
 +-define(RUN_JS_TIMEOUT, 5000).
 +
@@ -997,7 +1072,7 @@ index 0000000000000000000000000000000000000000..778a49d4b207159cd495116d0d548226
 +    Token = erlang:unique_integer(),
 +    ReplyTo = base64:encode(term_to_binary({self(), Token})),
 +    Envelope = #{type => run_js, code => Code, args => Args, reply_to => ReplyTo},
-+    ok = send_raw(iolist_to_binary(json:encode(Envelope))),
++    ok = send_raw(iolist_to_binary(json:encode(Envelope, fun encode_arg/2))),
 +    receive
 +        {wasm, {Token, PayloadJson}, _MetaJson} ->
 +            handle_run_js_reply(PayloadJson)
@@ -1007,16 +1082,37 @@ index 0000000000000000000000000000000000000000..778a49d4b207159cd495116d0d548226
 +
 +handle_run_js_reply(PayloadJson) ->
 +    case json:decode(PayloadJson) of
-+        #{<<"ok">> := true, <<"value">> := Value} -> Value;
++        #{<<"ok">> := true, <<"value">> := Value} -> revive_refs(Value);
 +        #{<<"ok">> := true} -> null;
 +        #{<<"ok">> := false, <<"error">> := Reason} -> error({run_js, Reason})
 +    end.
++
++encode_arg({wasm_tracked_value, Resource}, Encoder) ->
++    json:encode_value(#{popcorn_ref => ref_key(Resource)}, Encoder);
++encode_arg(Other, Encoder) ->
++    json:encode_value(Other, Encoder).
++
++revive_refs(#{<<"popcorn_ref">> := Key} = Marker)
++  when is_integer(Key), map_size(Marker) =:= 1 ->
++    {wasm_tracked_value, materialize_ref(Key)};
++revive_refs(Map) when is_map(Map) ->
++    maps:map(fun(_K, V) -> revive_refs(V) end, Map);
++revive_refs(List) when is_list(List) ->
++    [revive_refs(V) || V <- List];
++revive_refs(Other) ->
++    Other.
 +
 +-spec on_load() -> ok.
 +on_load() ->
 +    ok = erlang:load_nif("wasm", wasm).
 +
 +send_raw(_Message) ->
++    erlang:nif_error(undef).
++
++materialize_ref(_Key) ->
++    erlang:nif_error(undef).
++
++ref_key(_Resource) ->
 +    erlang:nif_error(undef).
 diff --git a/lib/asn1/src/asn1rtt_ber.erl b/lib/asn1/src/asn1rtt_ber.erl
 index 03fd099cc4786442362bd48f4764b9c31e667de7..3c385df0a66fb48cff3a1699318f1b3a3568c09b 100644

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -1029,7 +1029,7 @@ index 3b672dc41a554cf7d5440ccfd94e85bd44b61d35..4e5efb04e7eb04556ff14dc3ba8e0d83
  	    ]},
 diff --git a/erts/preloaded/src/wasm.erl b/erts/preloaded/src/wasm.erl
 new file mode 100644
-index 0000000000000000000000000000000000000000..2941e22e231bc3ea65868e61b03a661c845144af
+index 0000000000000000000000000000000000000000..9b79d3cfd08e70efc765a74ef07de90836f6854d
 --- /dev/null
 +++ b/erts/preloaded/src/wasm.erl
 @@ -0,0 +1,89 @@
@@ -1068,7 +1068,7 @@ index 0000000000000000000000000000000000000000..2941e22e231bc3ea65868e61b03a661c
 +-spec send(json:encode_value()) -> ok.
 +send(Message) ->
 +    Envelope = #{type => vm_message, data => Message},
-+    ok = send_raw(iolist_to_binary(json:encode(Envelope))).
++    ok = send_raw(iolist_to_binary(json:encode(Envelope, fun encode_arg/2))).
 +
 +-spec run_js(binary(), map()) -> json:decode_value().
 +run_js(Code, Args) when is_binary(Code), is_map(Args) ->

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -151,10 +151,10 @@ index 0000000000000000000000000000000000000000..2e85c729e92e9948fd15302a88ed12a4
 +};
 diff --git a/erts/emulator/js_bridge/js_bridge.js b/erts/emulator/js_bridge/js_bridge.js
 new file mode 100644
-index 0000000000000000000000000000000000000000..0b446eedf17294c0c47c2b872bf2fb44a032ff67
+index 0000000000000000000000000000000000000000..ed09e8dd4ff11df4fe5e8b9adcb4dc7036722f5c
 --- /dev/null
 +++ b/erts/emulator/js_bridge/js_bridge.js
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,34 @@
 +mergeInto(LibraryManager.library, {
 +  js_bridge_on_from_beam_async__proxy: 'async',
 +  js_bridge_on_from_beam_async__sig: 'vii',
@@ -169,6 +169,14 @@ index 0000000000000000000000000000000000000000..0b446eedf17294c0c47c2b872bf2fb44
 +
 +    if (typeof Module['onBeamMessage'] === 'function') {
 +      Module['onBeamMessage'](envelope);
++    }
++  },
++
++  js_bridge_on_tracked_value_delete__proxy: 'async',
++  js_bridge_on_tracked_value_delete__sig: 'vi',
++  js_bridge_on_tracked_value_delete: function(key) {
++    if (typeof Module['onTrackedValueDelete'] === 'function') {
++      Module['onTrackedValueDelete'](key);
 +    }
 +  },
 +


### PR DESCRIPTION
- adds TrackedValues() which are opaque handles to JS values stored in main context. They can take optional cleanup function that runs after handle is dropped for VM. Typical examples of usage are unregistering handlers. TrackedValues are serializated as objects with ids when passed between contexts and materialized in main context.
- adds `onStdout(text)`, `onStderr(text)`, `onError(event)` options when creating the instance.
- refactors the tests to allow for multiple otp instances.

Followups:
- new callbacks should be able to be replaced after init
