### PR TITLE
[LLV] Add live_local router macro 

### DIFF
--- a/examples/local-lv-checkout/lib/local_lv_checkout_web/components/layouts.ex
+++ b/examples/local-lv-checkout/lib/local_lv_checkout_web/components/layouts.ex
@@ -122,6 +122,28 @@ defmodule LocalLvCheckoutWeb.Layouts do
   end
 
   @doc """
+  Plain layout with nav header for local routes.
+
+  Used for routes like /plain that need a simple container layout.
+  """
+  def plain(assigns) do
+    ~H"""
+    <div style="min-height: 100vh; background-color: #f3f4f6; padding: 48px 16px;">
+      <div style="max-width: 42rem; margin: 0 auto;">
+        <div style="background-color: white; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
+          <div style="padding: 16px 24px; border-bottom: 1px solid #e5e7eb;">
+            <p style="font-size: 12px; font-weight: 600; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.05em; margin: 0;">
+              Nav Test LLV — no LiveView host
+            </p>
+          </div>
+          {@inner_content}
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
   Provides dark vs light theme toggle based on themes defined in app.css.
 
   See <head> in root.html.heex which applies the theme before page load.

--- a/examples/local-lv-checkout/lib/local_lv_checkout_web/live/checkout_live.ex
+++ b/examples/local-lv-checkout/lib/local_lv_checkout_web/live/checkout_live.ex
@@ -2,11 +2,12 @@ defmodule LocalLvCheckoutWeb.CheckoutLive do
   use LocalLvCheckoutWeb, :live_view
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket,
-      llv_id: "checkout-#{socket.id}",
-      nav_llv_id: "nav-#{socket.id}",
-      current_step: 1
-    )}
+    {:ok,
+     assign(socket,
+       llv_id: "checkout-#{socket.id}",
+       nav_llv_id: "nav-#{socket.id}",
+       current_step: 1
+     )}
   end
 
   def handle_params(%{"step" => step}, _uri, socket) do
@@ -32,14 +33,16 @@ defmodule LocalLvCheckoutWeb.CheckoutLive do
               </div>
               <p style="font-size: 14px; margin-top: 8px; color: #6b7280;">Shipping</p>
             </div>
-            <div style={"height: 4px; flex: 1; margin: 0 16px; background-color: #{if @current_step > 1, do: "#3b82f6", else: "#d1d5db"};"}></div>
+            <div style={"height: 4px; flex: 1; margin: 0 16px; background-color: #{if @current_step > 1, do: "#3b82f6", else: "#d1d5db"};"}>
+            </div>
             <div style="display: flex; flex-direction: column; align-items: center; flex: 1;">
               <div style={"width: 40px; height: 40px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-weight: bold; transition: all 0.3s; background-color: #{if @current_step >= 2, do: "#3b82f6", else: "#d1d5db"}; color: #{if @current_step >= 2, do: "white", else: "#4b5563"};"}>
                 2
               </div>
               <p style="font-size: 14px; margin-top: 8px; color: #6b7280;">Payment</p>
             </div>
-            <div style={"height: 4px; flex: 1; margin: 0 16px; background-color: #{if @current_step > 2, do: "#3b82f6", else: "#d1d5db"};"}></div>
+            <div style={"height: 4px; flex: 1; margin: 0 16px; background-color: #{if @current_step > 2, do: "#3b82f6", else: "#d1d5db"};"}>
+            </div>
             <div style="display: flex; flex-direction: column; align-items: center; flex: 1;">
               <div style={"width: 40px; height: 40px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-weight: bold; transition: all 0.3s; background-color: #{if @current_step >= 3, do: "#3b82f6", else: "#d1d5db"}; color: #{if @current_step >= 3, do: "white", else: "#4b5563"};"}>
                 3
@@ -47,9 +50,7 @@ defmodule LocalLvCheckoutWeb.CheckoutLive do
               <p style="font-size: 14px; margin-top: 8px; color: #6b7280;">Confirm</p>
             </div>
           </div>
-          <.link patch={~p"/?step=#{@current_step + 1}"}>Next</.link>
         </div>
-
 
         <!-- Local Live View -->
         <div style="background-color: white; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">

--- a/examples/local-lv-checkout/lib/local_lv_checkout_web/router.ex
+++ b/examples/local-lv-checkout/lib/local_lv_checkout_web/router.ex
@@ -1,6 +1,8 @@
 defmodule LocalLvCheckoutWeb.Router do
   use LocalLvCheckoutWeb, :router
 
+  import LocalLiveView.Router
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -14,11 +16,21 @@ defmodule LocalLvCheckoutWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :put_plain_layout do
+    plug :put_layout, html: {LocalLvCheckoutWeb.Layouts, :plain}
+  end
+
   scope "/", LocalLvCheckoutWeb do
     pipe_through :browser
 
     live "/", CheckoutLive
-    get "/plain", PageController, :home
+  end
+
+  scope "/", LocalLvCheckoutWeb do
+    pipe_through :browser
+    pipe_through :put_plain_layout
+
+    live_local "/plain", NavTestLive
   end
 
   # Other scopes may use custom stacks.

--- a/examples/local-lv-checkout/local/lib/checkout_live.ex
+++ b/examples/local-lv-checkout/local/lib/checkout_live.ex
@@ -2,16 +2,17 @@ defmodule CheckoutLive do
   use LocalLiveView
 
   def mount(params, _session, socket) do
-    {:ok, assign(socket,
-      current_step: 1,
-      form_data: %{
-        "email" => "",
-        "name" => "",
-        "card_number" => "",
-        "expiry" => ""
-      },
-      errors: []
-    )}
+    {:ok,
+     assign(socket,
+       current_step: 1,
+       form_data: %{
+         "email" => "",
+         "name" => "",
+         "card_number" => "",
+         "expiry" => ""
+       },
+       errors: []
+     )}
   end
 
   def handle_params(%{"step" => step_str}, _uri, socket) do
@@ -33,7 +34,7 @@ defmodule CheckoutLive do
           <.step_2_payment form_data={@form_data} errors={@errors} />
         <% 3 -> %>
           <.step_3_confirmation form_data={@form_data} />
-        <% 4 -> %>
+        <% _ -> %>
           <.step_4_success />
       <% end %>
 
@@ -116,15 +117,29 @@ defmodule CheckoutLive do
 
   defp validate_step(1, form_data) do
     errors = []
-    errors = if String.trim(form_data["email"]) == "", do: ["Email is required" | errors], else: errors
-    errors = if String.trim(form_data["name"]) == "", do: ["Name is required" | errors], else: errors
+
+    errors =
+      if String.trim(form_data["email"]) == "", do: ["Email is required" | errors], else: errors
+
+    errors =
+      if String.trim(form_data["name"]) == "", do: ["Name is required" | errors], else: errors
+
     Enum.reverse(errors)
   end
 
   defp validate_step(2, form_data) do
     errors = []
-    errors = if String.trim(form_data["card_number"]) == "", do: ["Card number is required" | errors], else: errors
-    errors = if String.trim(form_data["expiry"]) == "", do: ["Expiry date is required" | errors], else: errors
+
+    errors =
+      if String.trim(form_data["card_number"]) == "",
+        do: ["Card number is required" | errors],
+        else: errors
+
+    errors =
+      if String.trim(form_data["expiry"]) == "",
+        do: ["Expiry date is required" | errors],
+        else: errors
+
     Enum.reverse(errors)
   end
 
@@ -134,7 +149,9 @@ defmodule CheckoutLive do
   defp step_1_shipping(assigns) do
     ~H"""
     <div>
-      <h2 style="font-size: 24px; font-weight: bold; margin-bottom: 24px; color: #1f2937;">Shipping Information</h2>
+      <h2 style="font-size: 24px; font-weight: bold; margin-bottom: 24px; color: #1f2937;">
+        Shipping Information
+      </h2>
       <form style="display: flex; flex-direction: column; gap: 16px;">
         <div>
           <label style="display: block; font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Email</label>
@@ -162,7 +179,9 @@ defmodule CheckoutLive do
 
         <%= if @errors != [] do %>
           <div style="background-color: #fef2f2; border: 1px solid #fecaca; border-radius: 4px; padding: 16px;">
-            <p style="color: #991b1b; font-weight: 600; margin-bottom: 8px; margin-top: 0;">Please fix the following:</p>
+            <p style="color: #991b1b; font-weight: 600; margin-bottom: 8px; margin-top: 0;">
+              Please fix the following:
+            </p>
             <ul style="list-style: disc; margin-left: 20px; color: #b91c1c; margin-top: 0; margin-bottom: 0;">
               <%= for error <- @errors do %>
                 <li>{error}</li>
@@ -178,7 +197,9 @@ defmodule CheckoutLive do
   defp step_2_payment(assigns) do
     ~H"""
     <div>
-      <h2 style="font-size: 24px; font-weight: bold; margin-bottom: 24px; color: #1f2937;">Payment Information</h2>
+      <h2 style="font-size: 24px; font-weight: bold; margin-bottom: 24px; color: #1f2937;">
+        Payment Information
+      </h2>
       <form style="display: flex; flex-direction: column; gap: 16px;">
         <div>
           <label style="display: block; font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Card Number</label>
@@ -208,7 +229,9 @@ defmodule CheckoutLive do
 
         <%= if @errors != [] do %>
           <div style="background-color: #fef2f2; border: 1px solid #fecaca; border-radius: 4px; padding: 16px;">
-            <p style="color: #991b1b; font-weight: 600; margin-bottom: 8px; margin-top: 0;">Please fix the following:</p>
+            <p style="color: #991b1b; font-weight: 600; margin-bottom: 8px; margin-top: 0;">
+              Please fix the following:
+            </p>
             <ul style="list-style: disc; margin-left: 20px; color: #b91c1c; margin-top: 0; margin-bottom: 0;">
               <%= for error <- @errors do %>
                 <li>{error}</li>
@@ -224,7 +247,9 @@ defmodule CheckoutLive do
   defp step_3_confirmation(assigns) do
     ~H"""
     <div>
-      <h2 style="font-size: 24px; font-weight: bold; margin-bottom: 24px; color: #1f2937;">Order Summary</h2>
+      <h2 style="font-size: 24px; font-weight: bold; margin-bottom: 24px; color: #1f2937;">
+        Order Summary
+      </h2>
       <div style="background-color: #f3f4f6; border-radius: 4px; padding: 24px; display: flex; flex-direction: column; gap: 12px;">
         <div style="display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid #d1d5db;">
           <span style="font-weight: 500;">Email:</span>
@@ -241,7 +266,9 @@ defmodule CheckoutLive do
       </div>
 
       <div style="margin-top: 24px; padding: 16px; background-color: #eff6ff; border: 1px solid #bfdbfe; border-radius: 4px;">
-        <p style="color: #1e40af; margin: 0;">✓ All information looks correct. Click "Complete Order" to finish.</p>
+        <p style="color: #1e40af; margin: 0;">
+          ✓ All information looks correct. Click "Complete Order" to finish.
+        </p>
       </div>
     </div>
     """
@@ -253,10 +280,11 @@ defmodule CheckoutLive do
       <div style="width: 64px; height: 64px; background-color: #dcfce7; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin: 0 auto 16px;">
         <span style="font-size: 32px;">✓</span>
       </div>
-      <h2 style="font-size: 24px; font-weight: bold; color: #15803d; margin-bottom: 8px;">Order Complete!</h2>
+      <h2 style="font-size: 24px; font-weight: bold; color: #15803d; margin-bottom: 8px;">
+        Order Complete!
+      </h2>
       <p style="color: #6b7280; font-size: 14px;">Your order has been placed successfully.</p>
     </div>
     """
   end
-
 end

--- a/examples/local-lv-checkout/local/lib/nav_test_live.ex
+++ b/examples/local-lv-checkout/local/lib/nav_test_live.ex
@@ -5,7 +5,8 @@ defmodule NavTestLive do
     {:ok, assign(socket, page: "products", count: 0)}
   end
 
-  def handle_params(%{"page" => page}, _uri, socket) when page in ["products", "orders", "profile"] do
+  def handle_params(%{"page" => page}, _uri, socket)
+      when page in ["products", "orders", "profile"] do
     {:noreply, assign(socket, page: page)}
   end
 
@@ -30,7 +31,9 @@ defmodule NavTestLive do
         <% "products" -> %>
           <div>
             <h3 style="font-weight: 600; color: #111827; margin-bottom: 12px;">Products</h3>
-            <p style="color: #6b7280; font-size: 14px;">Counter (persists across tab navigation): <%= @count %></p>
+            <p style="color: #6b7280; font-size: 14px;">
+              Counter (persists across tab navigation): {@count}
+            </p>
             <button
               phx-click="inc"
               style="margin-top: 8px; padding: 6px 14px; background-color: #3b82f6; color: white; border-radius: 4px; border: none; cursor: pointer; font-size: 14px;"
@@ -55,6 +58,7 @@ defmodule NavTestLive do
 
   defp tab_link(assigns) do
     assigns = assign(assigns, :active, assigns.page == assigns.target)
+
     ~H"""
     <.link
       patch={"/plain/?page=#{@target}"}

--- a/examples/local-lv-checkout/test/local_lv_checkout_web/controllers/error_html_test.exs
+++ b/examples/local-lv-checkout/test/local_lv_checkout_web/controllers/error_html_test.exs
@@ -9,6 +9,7 @@ defmodule LocalLvCheckoutWeb.ErrorHTMLTest do
   end
 
   test "renders 500.html" do
-    assert render_to_string(LocalLvCheckoutWeb.ErrorHTML, "500", "html", []) == "Internal Server Error"
+    assert render_to_string(LocalLvCheckoutWeb.ErrorHTML, "500", "html", []) ==
+             "Internal Server Error"
   end
 end

--- a/examples/local-lv-checkout/test/local_lv_checkout_web/controllers/error_json_test.exs
+++ b/examples/local-lv-checkout/test/local_lv_checkout_web/controllers/error_json_test.exs
@@ -2,7 +2,9 @@ defmodule LocalLvCheckoutWeb.ErrorJSONTest do
   use LocalLvCheckoutWeb.ConnCase, async: true
 
   test "renders 404" do
-    assert LocalLvCheckoutWeb.ErrorJSON.render("404.json", %{}) == %{errors: %{detail: "Not Found"}}
+    assert LocalLvCheckoutWeb.ErrorJSON.render("404.json", %{}) == %{
+             errors: %{detail: "Not Found"}
+           }
   end
 
   test "renders 500" do

--- a/local-live-view/lib/mix/tasks/llv.build.ex
+++ b/local-live-view/lib/mix/tasks/llv.build.ex
@@ -39,6 +39,7 @@ defmodule Mix.Tasks.Llv.Build do
 
     Mix.shell().info("[llv] Copying runtime files to #{dst_dir}/")
     File.mkdir_p!(dst_dir)
+    File.mkdir_p!(Path.join(dst_dir, "wasm"))
 
     for file <- @runtime_files do
       File.cp!(Path.join(src_dir, file), Path.join(dst_dir, file))

--- a/local-live-view/lib/mix/tasks/llv.install.ex
+++ b/local-live-view/lib/mix/tasks/llv.install.ex
@@ -39,6 +39,7 @@ defmodule Mix.Tasks.Llv.Install do
     igniter
     |> inject_endpoint()
     |> inject_web_module()
+    |> inject_router_import()
     |> inject_root_layout()
     |> inject_app_js()
     |> inject_esbuild_format()
@@ -178,6 +179,56 @@ defmodule Mix.Tasks.Llv.Install do
           |> Sourceror.Zipper.node()
           |> Macro.to_string()
           |> String.ends_with?(suffix)
+        end)
+      end)
+
+    case result do
+      {:ok, z} -> {:ok, z}
+      :error -> nil
+    end
+  end
+
+  # --- Router import ---
+
+  defp inject_router_import(igniter) do
+    router = Igniter.Libs.Phoenix.web_module_name(igniter, "Router")
+
+    case Igniter.Project.Module.find_and_update_module(igniter, router, &update_router/1) do
+      {:ok, igniter} ->
+        igniter
+
+      {:error, igniter} ->
+        Igniter.add_warning(
+          igniter,
+          "Could not find module #{inspect(router)}. Add manually: import LocalLiveView.Router"
+        )
+    end
+  end
+
+  defp update_router(zipper) do
+    if module_source_contains?(zipper, "LocalLiveView.Router") do
+      {:ok, zipper}
+    else
+      anchor =
+        find_import_by_suffix(zipper, "Phoenix.LiveView.Router") ||
+          find_use_router(zipper)
+
+      case anchor do
+        {:ok, anchor_zipper} ->
+          {:ok, Igniter.Code.Common.add_code(anchor_zipper, "import LocalLiveView.Router")}
+
+        nil ->
+          {:warning,
+           "Could not find Phoenix.LiveView.Router import in router. Add manually: import LocalLiveView.Router"}
+      end
+    end
+  end
+
+  defp find_use_router(zipper) do
+    result =
+      Igniter.Code.Function.move_to_function_call(zipper, :use, [1, 2], fn call ->
+        Igniter.Code.Function.argument_matches_predicate?(call, 1, fn arg ->
+          arg |> Sourceror.Zipper.node() |> Macro.to_string() == ":router"
         end)
       end)
 

--- a/local-live-view/lib/server/controller.ex
+++ b/local-live-view/lib/server/controller.ex
@@ -1,0 +1,15 @@
+defmodule LocalLiveView.Controller do
+  @moduledoc """
+  Controller for rendering LocalLiveView mounts via router macros.
+
+  This controller is used internally by the `live_local/2` router macro.
+  It intercepts the action name (which is the view module name as an atom)
+  and passes it to the template renderer.
+  """
+
+  use Phoenix.Controller, formats: [html: "ControllerHTML"]
+
+  def index(conn, _params) do
+    render(conn, :index, view: conn.private.llv_view)
+  end
+end

--- a/local-live-view/lib/server/controller_html.ex
+++ b/local-live-view/lib/server/controller_html.ex
@@ -1,0 +1,18 @@
+defmodule LocalLiveView.ControllerHTML do
+  @moduledoc """
+  HTML rendering module for LocalLiveView controller.
+
+  This module is used internally by LocalLiveView.Controller to render
+  the LocalLiveView mount point.
+  """
+
+  use Phoenix.Component
+
+  import LocalLiveView.Component
+
+  def index(assigns) do
+    ~H"""
+    <.local_live_view view={@view} />
+    """
+  end
+end

--- a/local-live-view/lib/server/router.ex
+++ b/local-live-view/lib/server/router.ex
@@ -1,0 +1,37 @@
+defmodule LocalLiveView.Router do
+  @moduledoc """
+  Phoenix router macro for mounting a LocalLiveView at a route.
+
+  Import this module in your Phoenix router:
+
+      defmodule MyAppWeb.Router do
+        use MyAppWeb, :router
+        import LocalLiveView.Router
+
+        scope "/" do
+          pipe_through :browser
+          live_local "/plain", HelloLocal
+        end
+      end
+  """
+
+  defmacro live_local(path, view_module) do
+    view_string =
+      case view_module do
+        {:__aliases__, _, parts} -> parts |> List.last() |> to_string()
+        name when is_binary(name) -> name
+        name when is_atom(name) -> to_string(name)
+      end
+
+    quote do
+      scope "/", alias: false do
+        Phoenix.Router.get(
+          unquote(path),
+          LocalLiveView.Controller,
+          :index,
+          private: %{llv_view: unquote(view_string)}
+        )
+      end
+    end
+  end
+end

--- a/local-live-view/test/mix/tasks/llv_install_e2e_test.exs
+++ b/local-live-view/test/mix/tasks/llv_install_e2e_test.exs
@@ -4,8 +4,8 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
 
   Spins up a fresh Phoenix project via `mix phx.new` in a temp dir,
   injects local_live_view as a path dep, runs `mix llv.install` + `mix setup`,
-  adds a `live_local "/hello_local"` route, starts `mix phx.server`, and uses Playwright
-  to assert that the bundled HelloLocal component renders "Hello from WASM!" in the browser.
+  starts `mix phx.server`, and uses Playwright to assert that the bundled
+  HelloLocal component renders "Hello from WASM!" in the browser.
 
   Slow (~1-2 min) — covers what unit tests can't: real `mix llv.build`,
   real esbuild + popcorn.cook + AtomVM bootstrap, real DOM render.
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
 
   test "HelloLocal renders inside the Phoenix page via live_local route", %{browser: browser} do
     page = Playwright.Browser.new_page(browser)
-    Playwright.Page.goto(page, "#{@url}/hello_local")
+    Playwright.Page.goto(page, "#{@url}/hello_wasm")
 
     wait_for(
       fn ->
@@ -67,6 +67,8 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
 
     Playwright.Page.close(page)
   end
+
+  # --- Project setup helpers ---
 
   defp setup_phoenix_project(llv_path) do
     tmp_root = System.tmp_dir!() |> Path.join("llv_e2e_#{System.unique_integer([:positive])}")
@@ -90,7 +92,6 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
     mix_path = Path.join(app_dir, "mix.exs")
     content = File.read!(mix_path)
 
-    # Insert the local_live_view dep at the top of the `defp deps do [ ... ]` list.
     new =
       String.replace(
         content,
@@ -102,15 +103,6 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
     File.write!(mix_path, new)
   end
 
-  # Mix doesn't materialize path deps under deps/, but Phoenix's esbuild resolves
-  # `import "local_live_view"` via NODE_PATH=deps. Symlink it in so the bundle resolves
-  # exactly like a real hex/git install (deps/local_live_view/priv/static/local_live_view.js).
-  defp link_llv_into_deps(app_dir, llv_path) do
-    link = Path.join([app_dir, "deps", "local_live_view"])
-    File.rm_rf!(link)
-    File.ln_s!(llv_path, link)
-  end
-
   defp patch_router(app_dir) do
     path = Path.join(app_dir, "lib/test_app_web/router.ex")
     content = File.read!(path)
@@ -119,22 +111,13 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
       String.replace(
         content,
         "get \"/\", PageController, :home",
-        "get \"/\", PageController, :home\n\n    live_local \"/hello_local\", \"HelloLocal\""
+        "get \"/\", PageController, :home\n\n    live_local \"/hello_wasm\", \"HelloLocal\""
       )
 
     File.write!(path, content)
   end
 
-  defp kill_port(port) do
-    System.shell("lsof -ti :#{port} | xargs -r kill -9 2>/dev/null", into: "")
-  end
-
-  defp kill_phoenix_subprocesses do
-    # Watchers don't bind the port — match by command name.
-    kill_port(@port)
-    System.shell("pkill -f 'esbuild.*test_app' 2>/dev/null", into: "")
-    System.shell("pkill -f 'tailwind.*test_app' 2>/dev/null", into: "")
-  end
+  # --- Server helpers ---
 
   defp start_phoenix_server(project_dir) do
     Task.start_link(fn ->
@@ -146,6 +129,18 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
       )
     end)
   end
+
+  defp kill_port(port) do
+    System.shell("lsof -ti :#{port} | xargs -r kill -9 2>/dev/null", into: "")
+  end
+
+  defp kill_phoenix_subprocesses do
+    kill_port(@port)
+    System.shell("pkill -f 'esbuild.*test_app' 2>/dev/null", into: "")
+    System.shell("pkill -f 'tailwind.*test_app' 2>/dev/null", into: "")
+  end
+
+  # --- Utilities ---
 
   defp run!(cmd, args, opts) do
     {_, 0} = System.cmd(cmd, args, [{:into, IO.stream(:stdio, :line)} | opts])

--- a/local-live-view/test/mix/tasks/llv_install_e2e_test.exs
+++ b/local-live-view/test/mix/tasks/llv_install_e2e_test.exs
@@ -4,8 +4,8 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
 
   Spins up a fresh Phoenix project via `mix phx.new` in a temp dir,
   injects local_live_view as a path dep, runs `mix llv.install` + `mix setup`,
-  starts `mix phx.server`, and uses Playwright to assert that the generated
-  HelloLocalLive route renders "Hello from WASM!" in the browser.
+  adds a `live_local "/hello_local"` route, starts `mix phx.server`, and uses Playwright
+  to assert that the bundled HelloLocal component renders "Hello from WASM!" in the browser.
 
   Slow (~1-2 min) — covers what unit tests can't: real `mix llv.build`,
   real esbuild + popcorn.cook + AtomVM bootstrap, real DOM render.
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
     [browser: browser]
   end
 
-  test "HelloLocal renders on the generated /hello_local route", %{browser: browser} do
+  test "HelloLocal renders inside the Phoenix page via live_local route", %{browser: browser} do
     page = Playwright.Browser.new_page(browser)
     Playwright.Page.goto(page, "#{@url}/hello_local")
 
@@ -80,6 +80,7 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
     add_llv_path_dep(app_dir, llv_path)
     run!("mix", ["deps.get"], cd: app_dir)
     run!("mix", ["llv.install", "--yes"], cd: app_dir)
+    patch_router(app_dir)
     run!("mix", ["setup"], cd: app_dir)
 
     app_dir
@@ -99,6 +100,29 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
       )
 
     File.write!(mix_path, new)
+  end
+
+  # Mix doesn't materialize path deps under deps/, but Phoenix's esbuild resolves
+  # `import "local_live_view"` via NODE_PATH=deps. Symlink it in so the bundle resolves
+  # exactly like a real hex/git install (deps/local_live_view/priv/static/local_live_view.js).
+  defp link_llv_into_deps(app_dir, llv_path) do
+    link = Path.join([app_dir, "deps", "local_live_view"])
+    File.rm_rf!(link)
+    File.ln_s!(llv_path, link)
+  end
+
+  defp patch_router(app_dir) do
+    path = Path.join(app_dir, "lib/test_app_web/router.ex")
+    content = File.read!(path)
+
+    content =
+      String.replace(
+        content,
+        "get \"/\", PageController, :home",
+        "get \"/\", PageController, :home\n\n    live_local \"/hello_local\", \"HelloLocal\""
+      )
+
+    File.write!(path, content)
   end
 
   defp kill_port(port) do


### PR DESCRIPTION
Introduces LocalLiveView.Router with a live_local/2 macro that allows mounting LocalLiveView components at routes via simple syntax `live_local "/plain", HelloLocal`