### PR TITLE
otp: boot from manifest

### DIFF
--- a/.github/actions/build-otp-wasm/action.yml
+++ b/.github/actions/build-otp-wasm/action.yml
@@ -24,15 +24,36 @@ runs:
       run: |
         set -euo pipefail
 
-        mapfile -t patch_files < <(find otp/patches -type f -print | sort)
+        hash_files() {
+          sort | xargs sha256sum | sha256sum | cut -d' ' -f1
+        }
 
-        if [[ "${#patch_files[@]}" -eq 0 ]]; then
-          patch_hash="no-patches"
-        else
-          patch_hash="$(sha256sum "${patch_files[@]}" | sha256sum | cut -d' ' -f1)"
-        fi
+        {
+          printf 'key=otp-wasm-${{ runner.os }}-${{ inputs.otp-tag }}-${{ inputs.build-mode }}-${{ inputs.with-crypto }}-%s\n' "$(
+            {
+              find otp/patches -type f -print
+              printf '%s\n' \
+                .github/actions/build-otp-wasm/action.yml \
+                .github/actions/setup-toolchain/action.yml \
+                scripts/_common.sh \
+                scripts/build-beam.sh \
+                scripts/build-openssl.sh \
+                scripts/patch-beam.sh \
+                scripts/stdlib.sh
+            } | hash_files
+          )"
 
-        echo "key=otp-wasm-${{ runner.os }}-${{ inputs.otp-tag }}-${{ inputs.build-mode }}-${{ inputs.with-crypto }}-${patch_hash}" >> "$GITHUB_OUTPUT"
+          printf 'openssl_key=openssl-wasm-${{ runner.os }}-3.0.15-${{ inputs.build-mode }}-%s\n' "$(
+            {
+              printf '%s\n' \
+                .github/actions/build-otp-wasm/action.yml \
+                .github/actions/setup-toolchain/action.yml \
+                scripts/_common.sh \
+                scripts/build-beam.sh \
+                scripts/build-openssl.sh
+            } | hash_files
+          )"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Cache built OTP output
       id: otp-build-cache
@@ -83,7 +104,7 @@ runs:
         path: |
           otp/sources/openssl-3.0.15-${{ inputs.build-mode }}
           otp/sources/openssl-3.0.15-${{ inputs.build-mode }}-installed
-        key: openssl-wasm-${{ runner.os }}-3.0.15-${{ inputs.build-mode }}
+        key: ${{ steps.otp-build-cache-key.outputs.openssl_key }}
 
     - name: Diagnose environment size
       if: steps.otp-build-cache.outputs.cache-hit != 'true'

--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -2,19 +2,24 @@ import { assert, expect, test, trimLeft } from "./helpers";
 
 function evalOpts(code: string) {
   return {
-    beam: { assetsUrl: "/otp-assets", extraArgs: ["-eval", code] },
+    beam: {
+      manifestUrl: "/otp-assets/manifest.json",
+      extraArgs: ["-eval", code],
+    },
   };
 }
 
 test("boots", async ({ otp }) => {
-  const result = await otp.boot({ beam: { assetsUrl: "/otp-assets" } });
+  const result = await otp.boot({
+    beam: { manifestUrl: "/otp-assets/manifest.json" },
+  });
 
   expect(result).toEqual({ ok: true, data: null });
 });
 
 test("reports timeouts on init", async ({ otp }) => {
   const result = await otp.boot({
-    beam: { assetsUrl: "/otp-assets" },
+    beam: { manifestUrl: "/otp-assets/manifest.json" },
     timeoutsMs: { boot: 0 },
   });
 
@@ -24,16 +29,16 @@ test("reports timeouts on init", async ({ otp }) => {
   });
 });
 
-test("handles missing boot script", async ({ otp }) => {
+test("handles missing manifest", async ({ otp }) => {
   const result = await otp.boot({
-    beam: { assetsUrl: "/otp-assets/missing" },
+    beam: { manifestUrl: "/otp-assets/missing/manifest.json" },
   });
 
   expect(result).toEqual({
     ok: false,
     error: {
-      t: "beam:missing-boot-script",
-      data: { url: "/otp-assets/missing/bin/vm.boot" },
+      t: "beam:missing-manifest",
+      data: { url: "/otp-assets/missing/manifest.json" },
     },
   });
 });
@@ -42,7 +47,7 @@ test("failures on boot aren't sent to onEvent()", async ({ page }) => {
   const result = await page.evaluate(async () => {
     const errors: unknown[] = [];
     const popcorn = new window.Popcorn({
-      beam: { assetsUrl: "/otp-assets/missing" },
+      beam: { manifestUrl: "/otp-assets/missing/manifest.json" },
       onError: (event) => errors.push(event),
     });
 
@@ -59,15 +64,17 @@ test("failures on boot aren't sent to onEvent()", async ({ page }) => {
   expect(result.boot).toEqual({
     ok: false,
     error: {
-      t: "beam:missing-boot-script",
-      data: { url: "/otp-assets/missing/bin/vm.boot" },
+      t: "beam:missing-manifest",
+      data: { url: "/otp-assets/missing/manifest.json" },
     },
   });
 });
 
 test("can reboot after deinit", async ({ page }) => {
   const result = await page.evaluate(async () => {
-    const popcorn = new window.Popcorn({ beam: { assetsUrl: "/otp-assets" } });
+    const popcorn = new window.Popcorn({
+      beam: { manifestUrl: "/otp-assets/manifest.json" },
+    });
     type BootResult = Awaited<ReturnType<typeof popcorn.boot>>;
 
     const first = await popcorn.boot();
@@ -92,7 +99,7 @@ test("event hooks preserved after a reboot", async ({ page }) => {
     const READY_BOOT_EVAL = "ok = wasm:send(#{ready => true}).";
     const opts = {
       beam: {
-        assetsUrl: "/otp-assets",
+        manifestUrl: "/otp-assets/manifest.json",
         extraArgs: ["-eval", READY_BOOT_EVAL],
       },
     };
@@ -142,7 +149,7 @@ test("event hooks preserved after a reboot", async ({ page }) => {
 test("failing boot fails immediately", async ({ page }) => {
   const result = await page.evaluate(async () => {
     const popcorn = new window.Popcorn({
-      beam: { assetsUrl: "/otp-assets" },
+      beam: { manifestUrl: "/otp-assets/manifest.json" },
       workerUrl: "/fault-worker.mjs",
       timeoutsMs: { boot: 30_000 },
     });
@@ -390,7 +397,7 @@ test("send() to unregistered process", async ({ otp }) => {
 
 test("send() timeout", async ({ otp }) => {
   const boot = await otp.boot({
-    beam: { assetsUrl: "/otp-assets" },
+    beam: { manifestUrl: "/otp-assets/manifest.json" },
     timeoutsMs: { send: 0 },
   });
   assert(boot.ok);

--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -219,6 +219,19 @@ test("handles events in both directions", async ({ otp }) => {
   });
 });
 
+test("loads manifest apps before eval", async ({ otp }) => {
+  const boot = await otp.boot(
+    evalOpts(`
+      {ok, _} = application:ensure_all_started(elixir),
+      ok = wasm:send(#{manifest_app => true}).
+    `),
+  );
+  assert(boot.ok);
+
+  await otp.waitForEvent("manifest_app");
+  expect(otp.events).toContainEqual({ manifest_app: true });
+});
+
 test("run_js -> send", async ({ otp }) => {
   const RUN_JS_BOOT_EVAL = trimLeft(`
     V = wasm:run_js(<<"(args) => 1 + 2">>, #{}),

--- a/otp/js/e2e/setup/vite.config.ts
+++ b/otp/js/e2e/setup/vite.config.ts
@@ -16,6 +16,11 @@ const CORS_HEADERS = {
 };
 
 type Res = ServerResponse<IncomingMessage>;
+type CoreTarballEntry = { tar: string; sha256: string };
+type CoreTarballsJson = { version: string } & Record<
+  string,
+  string | CoreTarballEntry
+>;
 
 function otpAssetsPlugin(): Plugin {
   const serveAsset = async (
@@ -30,6 +35,20 @@ function otpAssetsPlugin(): Plugin {
     }
 
     const relativePath = requestUrl.slice("/otp-assets/".length);
+    if (relativePath === "manifest.json") {
+      try {
+        const content = await readFile(resolve(assetsDir, "lib/tarballs.json"));
+        setHeaders(res);
+        res.setHeader("Content-Type", "application/json");
+        res.end(synthesizeManifest(content.toString("utf8")));
+      } catch {
+        res.statusCode = 404;
+        setHeaders(res);
+        res.end("Not found");
+      }
+      return;
+    }
+
     const filePath = resolve(assetsDir, relativePath);
     const assetRelativePath = relative(assetsDir, filePath);
     if (assetRelativePath.startsWith("..") || isAbsolute(assetRelativePath)) {
@@ -60,6 +79,27 @@ function otpAssetsPlugin(): Plugin {
       server.middlewares.use(serveAsset);
     },
   };
+}
+
+function synthesizeManifest(tarballsJson: string): string {
+  const tarballs = JSON.parse(tarballsJson) as CoreTarballsJson;
+  const apps: Record<string, { tar: string; version: string }> = {};
+
+  for (const [name, entry] of Object.entries(tarballs)) {
+    if (name === "version") continue;
+    const tarball = entry as CoreTarballEntry;
+    apps[name] = {
+      tar: tarball.tar.replace(/^\/lib\//, "lib/"),
+      version: tarballs.version,
+    };
+  }
+
+  return JSON.stringify({
+    entrypoint: null,
+    apps,
+    notes: [],
+    vm: { boot: "bin/vm.boot", version: tarballs.version },
+  });
 }
 
 function setHeaders(res: Res) {

--- a/otp/js/e2e/setup/vite.config.ts
+++ b/otp/js/e2e/setup/vite.config.ts
@@ -16,11 +16,6 @@ const CORS_HEADERS = {
 };
 
 type Res = ServerResponse<IncomingMessage>;
-type CoreTarballEntry = { tar: string; sha256: string };
-type CoreTarballsJson = { version: string } & Record<
-  string,
-  string | CoreTarballEntry
->;
 
 function otpAssetsPlugin(): Plugin {
   const serveAsset = async (
@@ -35,20 +30,6 @@ function otpAssetsPlugin(): Plugin {
     }
 
     const relativePath = requestUrl.slice("/otp-assets/".length);
-    if (relativePath === "manifest.json") {
-      try {
-        const content = await readFile(resolve(assetsDir, "lib/tarballs.json"));
-        setHeaders(res);
-        res.setHeader("Content-Type", "application/json");
-        res.end(synthesizeManifest(content.toString("utf8")));
-      } catch {
-        res.statusCode = 404;
-        setHeaders(res);
-        res.end("Not found");
-      }
-      return;
-    }
-
     const filePath = resolve(assetsDir, relativePath);
     const assetRelativePath = relative(assetsDir, filePath);
     if (assetRelativePath.startsWith("..") || isAbsolute(assetRelativePath)) {
@@ -79,27 +60,6 @@ function otpAssetsPlugin(): Plugin {
       server.middlewares.use(serveAsset);
     },
   };
-}
-
-function synthesizeManifest(tarballsJson: string): string {
-  const tarballs = JSON.parse(tarballsJson) as CoreTarballsJson;
-  const apps: Record<string, { tar: string; version: string }> = {};
-
-  for (const [name, entry] of Object.entries(tarballs)) {
-    if (name === "version") continue;
-    const tarball = entry as CoreTarballEntry;
-    apps[name] = {
-      tar: tarball.tar.replace(/^\/lib\//, "lib/"),
-      version: tarballs.version,
-    };
-  }
-
-  return JSON.stringify({
-    entrypoint: null,
-    apps,
-    notes: [],
-    vm: { boot: "bin/vm.boot", version: tarballs.version },
-  });
 }
 
 function setHeaders(res: Res) {

--- a/otp/js/package.json
+++ b/otp/js/package.json
@@ -20,19 +20,32 @@
       "types": "./dist/beam.d.ts",
       "import": "./dist/beam.mjs"
     },
+    "./esbuild": {
+      "types": "./dist/plugins/esbuild.d.ts",
+      "import": "./dist/plugins/esbuild.mjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
     "setup": "./scripts/setup-assets.sh",
     "build": "pnpm run setup && rollup -c && ./scripts/setup-assets.sh dist",
-    "lint": "tsc --noEmit",
+    "lint": "tsc --noEmit && tsc -p plugins/tsconfig.json --noEmit",
     "lint:e2e": "tsc -p e2e/tsconfig.json",
     "e2e": "env -u FORCE_COLOR -u NO_COLOR playwright test --config e2e/playwright.config.ts"
+  },
+  "peerDependencies": {
+    "esbuild": ">=0.17.0"
+  },
+  "peerDependenciesMeta": {
+    "esbuild": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/node": "catalog:",
+    "esbuild": "^0.25.0",
     "rollup": "^4.55.1",
     "tslib": "^2.8.1",
     "typescript": "catalog:"

--- a/otp/js/plugins/esbuild.ts
+++ b/otp/js/plugins/esbuild.ts
@@ -1,0 +1,46 @@
+import { cp, mkdir, rm } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import type { Plugin } from "esbuild";
+import { popcorn as prepare, type Options } from "./shared";
+
+export function popcorn(options: Options): Plugin {
+  let outputDir: string | undefined;
+
+  return {
+    name: "popcorn-otp",
+
+    setup(build) {
+      build.onStart(() => {
+        const opts = build.initialOptions;
+        const outdir =
+          opts.outdir ?? (opts.outfile === undefined ? undefined : dirname(opts.outfile));
+
+        assert(opts.format === "esm", "Popcorn OTP works only with esm builds.");
+        assert(outdir !== undefined, "outdir is not specified, cannot copy files");
+
+        outputDir = resolve(outdir);
+      });
+
+      build.onEnd(async (result) => {
+        if (result.errors.length > 0) return;
+
+        assert(outputDir !== undefined, "outdir was not resolved");
+        const outDir = outputDir;
+        const prepared = await prepare(options);
+
+        try {
+          await mkdir(outDir, { recursive: true });
+          await cp(prepared.dir, outDir, { recursive: true });
+        } finally {
+          await rm(prepared.dir, { recursive: true, force: true });
+        }
+      });
+    },
+  };
+}
+
+function assert(ok: boolean, message: string): asserts ok {
+  if (!ok) {
+    throw new Error(`[popcorn-otp] ${message}`);
+  }
+}

--- a/otp/js/plugins/shared.ts
+++ b/otp/js/plugins/shared.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert";
+import { execFile } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, readdir, rm } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const otpAssetsDirName = "otp-assets";
+const manifestUrl = `/${otpAssetsDirName}/manifest.json`;
+
+export type Options = {
+  rootDir: string;
+  app: string | null;
+};
+
+export type Prepared = {
+  dir: string;
+  manifestUrl: string;
+  notes: unknown[];
+};
+
+type Report = {
+  ok: boolean;
+  notes?: unknown[];
+  error?: unknown;
+};
+
+export async function popcorn(opts: Options): Promise<Prepared> {
+  const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const distAssetsDir = join(distDir, "assets");
+  const preparedDir = await mkdtemp(join(tmpdir(), "popcorn-otp-"));
+  const distPath = (name: string) => join(distDir, name);
+  const distAssetsPath = (name: string) => join(distAssetsDir, name);
+  const preparedPath = (name: string) => join(preparedDir, name);
+  const otpAssetsPath = (name: string) =>
+    preparedPath(join(otpAssetsDirName, name));
+  const providedAppsManifestPath = distAssetsPath("manifest.json");
+
+  try {
+    await Promise.all([
+      copy(distPath("worker.mjs"), preparedPath("worker.mjs")),
+      copy(distAssetsPath("beam.mjs"), preparedPath("assets/beam.mjs")),
+      copy(
+        distAssetsPath("beam.emu.mjs"),
+        preparedPath("assets/beam.emu.mjs"),
+      ),
+      copy(distAssetsPath("beam.wasm"), preparedPath("assets/beam.wasm")),
+      copy(distAssetsPath("bin/vm.boot"), otpAssetsPath("bin/vm.boot")),
+      copy(
+        distAssetsPath("lib/tarballs.json"),
+        otpAssetsPath("lib/tarballs.json"),
+      ),
+      copyCoreTarballs(distAssetsPath("lib"), otpAssetsPath("lib")),
+    ]);
+
+    const report = await packTarballs({
+      rootDir: resolve(opts.rootDir),
+      outDir: otpAssetsPath(""),
+      providedAppsManifestPath,
+      app: opts.app,
+    });
+
+    assert(
+      report.ok,
+      `[popcorn-otp] tarballs.exs failed: ${JSON.stringify(report.error)}`,
+    );
+
+    return {
+      dir: preparedDir,
+      manifestUrl,
+      notes: report.notes ?? [],
+    };
+  } catch (error) {
+    await rm(preparedDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function copyCoreTarballs(
+  sourceLibDir: string,
+  targetLibDir: string,
+): Promise<void> {
+  const names = await readdir(sourceLibDir);
+
+  await Promise.all(
+    names
+      .filter((name) => name.endsWith(".tar.gz"))
+      .map((name) => copy(join(sourceLibDir, name), join(targetLibDir, name))),
+  );
+}
+
+async function packTarballs({
+  rootDir,
+  outDir,
+  providedAppsManifestPath,
+  app,
+}: {
+  rootDir: string;
+  outDir: string;
+  providedAppsManifestPath: string;
+  app: string | null;
+}): Promise<Report> {
+  const scriptPath = join(dirname(fileURLToPath(import.meta.url)), "tarballs.exs");
+  const args = [
+    scriptPath,
+    "--root-dir",
+    rootDir,
+    "--out-dir",
+    outDir,
+    "--provided-apps-manifest-path",
+    providedAppsManifestPath,
+  ];
+
+  if (app !== null) {
+    args.push("--entrypoint-app", app);
+  }
+
+  const { stdout } = await execFileAsync("elixir", args);
+  return JSON.parse(stdout) as Report;
+}
+
+async function copy(source: string, target: string): Promise<void> {
+  await mkdir(dirname(target), { recursive: true });
+  await copyFile(source, target);
+}

--- a/otp/js/plugins/tarballs.exs
+++ b/otp/js/plugins/tarballs.exs
@@ -31,8 +31,6 @@ defmodule Tarballs do
         %{ok: false, error: error}
         |> Jason.encode!()
         |> IO.puts()
-
-        System.halt(1)
     end
   end
 
@@ -103,7 +101,7 @@ defmodule Tarballs do
 
   defp fetch_provided_apps(manifest_path) do
     with {:ok, json} <- File.read(manifest_path),
-         {:ok, %{"version" => version} = data} <- Jason.decode(json),
+         {:ok, %{"apps" => data, "vm" => %{"version" => version}}} <- Jason.decode(json),
          {:ok, apps} <- normalize_provided_apps(data) do
       {:ok, %{version: version, apps: apps, names: apps |> Map.keys() |> MapSet.new()}}
     else
@@ -113,20 +111,15 @@ defmodule Tarballs do
 
   defp normalize_provided_apps(data) do
     data
-    |> Map.delete("version")
     |> Enum.reduce_while({:ok, %{}}, fn
       {app, %{"tar" => tar, "version" => version} = entry}, {:ok, apps}
       when is_binary(tar) and is_binary(version) ->
-        entry = Map.put(entry, "tar", normalize_tar_path(tar))
         {:cont, {:ok, Map.put(apps, app, entry)}}
 
       _entry, _acc ->
         {:halt, :error}
     end)
   end
-
-  defp normalize_tar_path("/lib/" <> path), do: "lib/" <> path
-  defp normalize_tar_path(tar_path), do: tar_path
 
   defp fetch_apps_to_pack(user_apps, _provided_apps, nil) do
     {:ok, user_apps |> Map.keys() |> Enum.sort()}

--- a/otp/js/plugins/tarballs.exs
+++ b/otp/js/plugins/tarballs.exs
@@ -1,0 +1,274 @@
+redirect_to_stderr = fn f ->
+  stdout = Process.group_leader()
+  Process.group_leader(self(), Process.whereis(:standard_error))
+  f.()
+  Process.group_leader(self(), stdout)
+end
+
+redirect_to_stderr.(fn ->
+  Mix.install([{:jason, "~> 1.4"}])
+end)
+
+defmodule Tarballs do
+  @options [
+    root_dir: :string,
+    entrypoint_app: :string,
+    out_dir: :string,
+    provided_apps_manifest_path: :string
+  ]
+
+  @required_options [:root_dir, :out_dir, :provided_apps_manifest_path]
+  @static_nif_apps MapSet.new(["wasm"])
+
+  def main(argv) do
+    case run(argv) do
+      {:ok, report} ->
+        report
+        |> Jason.encode!()
+        |> IO.puts()
+
+      {:error, error} ->
+        %{ok: false, error: error}
+        |> Jason.encode!()
+        |> IO.puts()
+
+        System.halt(1)
+    end
+  end
+
+  defp run(argv) do
+    with {:ok, args} <- parse_argv(argv),
+         {:ok, provided_apps} <- fetch_provided_apps(args.provided_apps_manifest_path),
+         {:ok, user_apps} <- fetch_user_apps(args.root_dir),
+         {:ok, apps} <- fetch_apps_to_pack(user_apps, provided_apps.names, args.entrypoint_app) do
+      vm_version = provided_apps.version
+
+      File.mkdir_p!(args.out_dir)
+
+      packed_apps =
+        apps
+        |> Task.async_stream(fn app ->
+          info = Map.fetch!(user_apps, app)
+          version = Keyword.get(info.props, :vsn, ~c"") |> to_string()
+          tar_path = create_tarball(args.out_dir, app, info.ebin_dir)
+
+          {app, %{tar: tar_path, version: version}}
+        end)
+        |> Map.new(fn {:ok, app} -> app end)
+
+      dynamic_nifs =
+        apps
+        |> Task.async_stream(fn app ->
+          info = Map.fetch!(user_apps, app)
+          dynamic_nifs(app, info.ebin_dir)
+        end)
+        |> Enum.flat_map(fn {:ok, notes} -> notes end)
+
+      notes = dynamic_nifs ++ otp_version(vm_version)
+      manifest_path = Path.join(args.out_dir, "manifest.json")
+      manifest_apps = Map.merge(packed_apps, provided_apps.apps)
+
+      manifest = %{
+        entrypoint: args.entrypoint_app,
+        apps: manifest_apps,
+        notes: notes,
+        vm: %{boot: "bin/vm.boot", version: vm_version}
+      }
+
+      File.write!(manifest_path, Jason.encode!(manifest))
+
+      {:ok,
+       %{
+         ok: true,
+         entrypoint: args.entrypoint_app,
+         manifestPath: Path.expand(manifest_path),
+         apps: manifest_apps,
+         notes: notes
+       }}
+    end
+  end
+
+  defp fetch_user_apps(root_dir) do
+    build_lib_dir = Path.join([root_dir, "_build", "dev", "lib"])
+    app_matcher = Path.join(build_lib_dir, "*/ebin/*.app")
+    all_app_paths = Path.wildcard(app_matcher)
+
+    {:ok,
+     Map.new(all_app_paths, fn app_path ->
+       {:ok, [{:application, name, props}]} = :file.consult(app_path)
+
+       {to_string(name), %{props: props, ebin_dir: Path.dirname(app_path)}}
+     end)}
+  end
+
+  defp fetch_provided_apps(manifest_path) do
+    with {:ok, json} <- File.read(manifest_path),
+         {:ok, %{"version" => version} = data} <- Jason.decode(json),
+         {:ok, apps} <- normalize_provided_apps(data) do
+      {:ok, %{version: version, apps: apps, names: apps |> Map.keys() |> MapSet.new()}}
+    else
+      _ -> err(:bad_provided_app_manifest, manifest_path)
+    end
+  end
+
+  defp normalize_provided_apps(data) do
+    data
+    |> Map.delete("version")
+    |> Enum.reduce_while({:ok, %{}}, fn
+      {app, %{"tar" => tar, "version" => version} = entry}, {:ok, apps}
+      when is_binary(tar) and is_binary(version) ->
+        entry = Map.put(entry, "tar", normalize_tar_path(tar))
+        {:cont, {:ok, Map.put(apps, app, entry)}}
+
+      _entry, _acc ->
+        {:halt, :error}
+    end)
+  end
+
+  defp normalize_tar_path("/lib/" <> path), do: "lib/" <> path
+  defp normalize_tar_path(tar_path), do: tar_path
+
+  defp fetch_apps_to_pack(user_apps, _provided_apps, nil) do
+    {:ok, user_apps |> Map.keys() |> Enum.sort()}
+  end
+
+  defp fetch_apps_to_pack(user_apps, provided_apps, entrypoint_app) do
+    if Map.has_key?(user_apps, entrypoint_app) do
+      case fetch_needed_apps(user_apps, provided_apps, entrypoint_app, MapSet.new()) do
+        {:ok, apps} -> {:ok, apps |> MapSet.to_list() |> Enum.sort()}
+        {:error, _} = error -> error
+      end
+    else
+      err(:missing_entrypoint, entrypoint_app)
+    end
+  end
+
+  defp fetch_needed_apps(user_apps, provided_apps, app, required) do
+    cond do
+      MapSet.member?(required, app) ->
+        {:ok, required}
+
+      MapSet.member?(provided_apps, app) ->
+        {:ok, required}
+
+      true ->
+        info = Map.fetch!(user_apps, app)
+        required = MapSet.put(required, app)
+
+        info.props
+        |> get_required_apps()
+        |> Enum.reduce_while({:ok, required}, fn
+          dep, {:ok, acc} ->
+            available = MapSet.member?(provided_apps, dep) or Map.has_key?(user_apps, dep)
+
+            if available do
+              case fetch_needed_apps(user_apps, provided_apps, dep, acc) do
+                {:ok, acc} -> {:cont, {:ok, acc}}
+                {:error, _} = error -> {:halt, error}
+              end
+            else
+              {:halt, err(:missing_dep, {app, dep})}
+            end
+        end)
+    end
+  end
+
+  defp create_tarball(outdir, app, ebin_dir) do
+    tar = "lib/#{app}.tar.gz"
+    tar_path = Path.join(outdir, tar)
+    tar_path_c = to_charlist(tar_path)
+    arc_name = ~c"lib/#{app}/ebin"
+    ebin_dir_c = to_charlist(ebin_dir)
+
+    File.mkdir_p!(Path.dirname(tar_path))
+    :ok = :erl_tar.create(tar_path_c, [{arc_name, ebin_dir_c}], [:compressed])
+
+    tar
+  end
+
+  defp dynamic_nifs(app, ebin_dir) do
+    if MapSet.member?(@static_nif_apps, app) do
+      []
+    else
+      beams =
+        Path.join(ebin_dir, "*.beam")
+        |> Path.wildcard()
+        |> Enum.filter(&imports_load_nif?/1)
+        |> Enum.map(&Path.basename/1)
+
+      case beams do
+        [] -> []
+        _ -> [%{code: "dynamic_nif", app: app, beams: beams}]
+      end
+    end
+  end
+
+  defp imports_load_nif?(beam_path) do
+    case :beam_lib.chunks(to_charlist(beam_path), [:imports]) do
+      {:ok, {_mod, [imports: imports]}} -> {:erlang, :load_nif, 2} in imports
+      _ -> false
+    end
+  end
+
+  defp otp_version(vm_version) do
+    if otp_major(System.otp_release()) != otp_major(vm_version) do
+      [%{code: "otp_mismatch", local: System.otp_release(), vm: vm_version}]
+    else
+      []
+    end
+  end
+
+  defp otp_major(version) do
+    version |> to_string() |> String.split(".") |> hd() |> String.to_integer()
+  end
+
+  defp get_required_apps(props) do
+    prop = &Keyword.get/3
+    optional = prop.(props, :optional_applications, []) |> MapSet.new()
+    applications = prop.(props, :applications, []) |> MapSet.new()
+    included = prop.(props, :included_applications, []) |> MapSet.new()
+
+    MapSet.union(applications, included)
+    |> MapSet.difference(optional)
+    |> Enum.map(&to_string/1)
+  end
+
+  defp parse_argv(argv) do
+    {opts, _rest, invalid} = OptionParser.parse(argv, strict: @options)
+
+    missing_opts = Enum.reject(@required_options, &Keyword.has_key?(opts, &1))
+
+    case {invalid, missing_opts} do
+      {[], []} ->
+        {:ok, opts |> Map.new() |> Map.put_new(:entrypoint_app, nil)}
+
+      _ ->
+        err(:bad_args, {invalid, missing_opts})
+    end
+  end
+
+  defp err(:bad_args, {invalid, missing_opts}) do
+    invalid =
+      Enum.map(invalid, fn {option, value} ->
+        %{option: option, value: value}
+      end)
+
+    missing = Enum.map(missing_opts, &to_string/1)
+
+    {:error, %{code: "bad_args", invalid: invalid, missing: missing}}
+  end
+
+  defp err(:missing_entrypoint, app) do
+    {:error, %{code: "missing_entrypoint", app: app}}
+  end
+
+  defp err(:bad_provided_app_manifest, path) do
+    {:error, %{code: "bad_provided_app_manifest", path: path}}
+  end
+
+  defp err(:missing_dep, {app, dep}) do
+    {:error, %{code: "missing_dep", app: app, dep: dep}}
+  end
+end
+
+Tarballs.main(System.argv())

--- a/otp/js/plugins/tsconfig.json
+++ b/otp/js/plugins/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declarationDir": "../dist/plugins"
+  },
+  "include": ["./**/*.ts"]
+}

--- a/otp/js/rollup.config.mjs
+++ b/otp/js/rollup.config.mjs
@@ -1,4 +1,20 @@
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
 import typescript from "@rollup/plugin-typescript";
+
+function copyFiles(targets) {
+  return {
+    name: "copy-files",
+    async buildEnd() {
+      await Promise.all(
+        targets.map(async ({ src, dest }) => {
+          await mkdir(dirname(dest), { recursive: true });
+          await copyFile(src, dest);
+        }),
+      );
+    },
+  };
+}
 
 export default [
   // Main library
@@ -18,6 +34,36 @@ export default [
     external: (id) => id.startsWith("node:"),
     plugins: [
       typescript({ tsconfig: "./tsconfig.json", outputToFilesystem: true }),
+    ],
+  },
+  {
+    input: {
+      esbuild: "plugins/esbuild.ts",
+    },
+    output: {
+      dir: "dist/plugins",
+      format: "esm",
+      entryFileNames: "[name].mjs",
+    },
+    external: [
+      "node:assert",
+      "node:child_process",
+      "node:fs/promises",
+      "node:os",
+      "node:path",
+      "node:url",
+      "node:util",
+      "esbuild",
+    ],
+    cache: false,
+    plugins: [
+      typescript({
+        tsconfig: "./plugins/tsconfig.json",
+        outputToFilesystem: true,
+      }),
+      copyFiles([
+        { src: "plugins/tarballs.exs", dest: "dist/plugins/tarballs.exs" },
+      ]),
     ],
   },
 ];

--- a/otp/js/scripts/setup-assets.sh
+++ b/otp/js/scripts/setup-assets.sh
@@ -65,7 +65,10 @@ for (const filename of ["beam.mjs", "beam.emu.mjs"]) {
     writeFileSync(path, patchedSource);
   }
 }
+
 EOF
+
+  cp "${ASSETS_DIR}/lib/tarballs.json" "${ASSETS_DIR}/manifest.json"
 }
 
 copy_dist_assets() {
@@ -74,6 +77,7 @@ copy_dist_assets() {
   cp "${ASSETS_DIR}/beam.mjs" "${DIST_ASSETS_DIR}/beam.mjs"
   cp "${ASSETS_DIR}/beam.emu.mjs" "${DIST_ASSETS_DIR}/beam.emu.mjs"
   cp "${ASSETS_DIR}/beam.wasm" "${DIST_ASSETS_DIR}/beam.wasm"
+  cp "${ASSETS_DIR}/manifest.json" "${DIST_ASSETS_DIR}/manifest.json"
   cp -R "${ASSETS_DIR}/bin/." "${DIST_ASSETS_DIR}/bin/"
   cp -R "${ASSETS_DIR}/lib/." "${DIST_ASSETS_DIR}/lib/"
 }

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -35,8 +35,7 @@ const BASE_ARGS = [
   DEFAULT_HOME_DIR,
 ];
 
-const CORE_APPS = ["kernel", "stdlib", "compiler"];
-const CORE_APP_SET = new Set<string>(CORE_APPS);
+const CORE_APPS = new Set(["kernel", "stdlib", "compiler"]);
 
 export async function boot({
   manifestUrl,
@@ -44,6 +43,43 @@ export async function boot({
   createModule,
   emit,
 }: BeamBootOptions): Promise<Result<EmscriptenModule>> {
+  const loadedFsData = await loadFsData(manifestUrl);
+  if (!loadedFsData.ok) {
+    return { ok: false, error: loadedFsData.error };
+  }
+
+  const fsData = loadedFsData.data;
+  const moduleConfig: Partial<EmscriptenModule> = {
+    print: (text) => emit({ type: "otp:stdout", payload: text }),
+    printErr: (text) => emit({ type: "otp:stderr", payload: text }),
+    onExit: (code) =>
+      emit({ type: "otp:error", payload: { kind: "exit", data: code } }),
+    onAbort: (text) =>
+      emit({ type: "otp:error", payload: { kind: "abort", data: text } }),
+    onBeamMessage: (text) => {
+      const event = deserializeBridgeMessage(text);
+      if (event !== null) {
+        emit(event);
+      }
+    },
+    onError: (text) =>
+      emit({ type: "otp:error", payload: { kind: "error", data: text } }),
+    onTrackedValueDelete: (key) =>
+      emit({ type: "otp:tracked-value-delete", payload: key }),
+    arguments: buildArgs({
+      appNames: fsData.appNames,
+      extra: extraArgs ?? [],
+    }),
+    ENV: {
+      BINDIR: "/bin",
+      EMU: "beam",
+      HOME: DEFAULT_HOME_DIR,
+      USER: DEFAULT_USER,
+      LOGNAME: DEFAULT_USER,
+    },
+    preRun: [(mod) => initFs({ module: mod, fsData })],
+  };
+
   try {
     const module = await createModule(moduleConfig);
     return { ok: true, data: module };

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -41,7 +41,6 @@ const CORE_APPS = ["kernel", "stdlib", "compiler"];
 
 export async function boot({
   assetsUrl,
-  searchPaths,
   extraArgs,
   createModule,
   emit,
@@ -66,7 +65,6 @@ export async function boot({
     onTrackedValueDelete: (key) =>
       emit({ type: "otp:tracked-value-delete", payload: key }),
     arguments: buildArgs({
-      searchPaths: searchPaths ?? [],
       extra: extraArgs ?? [],
     }),
     ENV: {
@@ -108,11 +106,10 @@ function toPopcornError(error: unknown): PopcornError {
 }
 
 type BuildArgsArgs = {
-  searchPaths: string[];
   extra: string[];
 };
 
-function buildArgs({ searchPaths, extra }: BuildArgsArgs): string[] {
+function buildArgs({ extra }: BuildArgsArgs): string[] {
   const args = [...BASE_ARGS, "-boot", BOOT_NAME];
 
   if (true) {
@@ -123,10 +120,7 @@ function buildArgs({ searchPaths, extra }: BuildArgsArgs): string[] {
     args.push("-pa", `/lib/${app}/ebin`);
   }
 
-  for (const path of searchPaths ?? []) {
-    args.push("-pa", path);
-  }
-  for (const arg of extra ?? []) {
+  for (const arg of extra) {
     args.push(arg);
   }
 

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -22,7 +22,6 @@ const DEFAULT_HOME_DIR = "/home/web_user";
 const FS_DIRS = ["/bin", "/lib", "/etc", "/tmp", "/home", DEFAULT_HOME_DIR];
 const BOOT_NAME = "vm";
 const BOOT_PATH = `/bin/${BOOT_NAME}.boot`;
-const MANIFEST_PATH = "/lib/tarballs.json";
 const UTF8 = new TextEncoder();
 const BASE_ARGS = [
   "--",
@@ -36,63 +35,17 @@ const BASE_ARGS = [
   DEFAULT_HOME_DIR,
 ];
 
-// must be present to load vm
 const CORE_APPS = ["kernel", "stdlib", "compiler"];
+const CORE_APP_SET = new Set<string>(CORE_APPS);
 
 export async function boot({
-  assetsUrl,
+  manifestUrl,
   extraArgs,
   createModule,
   emit,
 }: BeamBootOptions): Promise<Result<EmscriptenModule>> {
-  let initError: PopcornError | null = null;
-
-  const moduleConfig: Partial<EmscriptenModule> = {
-    print: (text) => emit({ type: "otp:stdout", payload: text }),
-    printErr: (text) => emit({ type: "otp:stderr", payload: text }),
-    onExit: (code) =>
-      emit({ type: "otp:error", payload: { kind: "exit", data: code } }),
-    onAbort: (text) =>
-      emit({ type: "otp:error", payload: { kind: "abort", data: text } }),
-    onBeamMessage: (text) => {
-      const event = deserializeBridgeMessage(text);
-      if (event !== null) {
-        emit(event);
-      }
-    },
-    onError: (text) =>
-      emit({ type: "otp:error", payload: { kind: "error", data: text } }),
-    onTrackedValueDelete: (key) =>
-      emit({ type: "otp:tracked-value-delete", payload: key }),
-    arguments: buildArgs({
-      extra: extraArgs ?? [],
-    }),
-    ENV: {
-      BINDIR: "/bin",
-      EMU: "beam",
-      HOME: DEFAULT_HOME_DIR,
-      USER: DEFAULT_USER,
-      LOGNAME: DEFAULT_USER,
-    },
-    preRun: [
-      (mod) => {
-        void (async () => {
-          mod.addRunDependency("fs");
-          try {
-            await initFs({ module: mod, assetsUrl });
-          } catch (error) {
-            initError = toPopcornError(error);
-          } finally {
-            mod.removeRunDependency("fs");
-          }
-        })();
-      },
-    ],
-  };
-
   try {
     const module = await createModule(moduleConfig);
-    if (initError !== null) return { ok: false, error: initError };
     return { ok: true, data: module };
   } catch (error) {
     return { ok: false, error: toPopcornError(error) };
@@ -106,10 +59,11 @@ function toPopcornError(error: unknown): PopcornError {
 }
 
 type BuildArgsArgs = {
+  appNames: string[];
   extra: string[];
 };
 
-function buildArgs({ extra }: BuildArgsArgs): string[] {
+function buildArgs({ appNames, extra }: BuildArgsArgs): string[] {
   const args = [...BASE_ARGS, "-boot", BOOT_NAME];
 
   if (true) {
@@ -120,6 +74,11 @@ function buildArgs({ extra }: BuildArgsArgs): string[] {
     args.push("-pa", `/lib/${app}/ebin`);
   }
 
+  for (const app of appNames) {
+    if (CORE_APPS.has(app)) continue;
+    args.push("-pa", `/lib/${app}/ebin`);
+  }
+
   for (const arg of extra) {
     args.push(arg);
   }
@@ -127,40 +86,90 @@ function buildArgs({ extra }: BuildArgsArgs): string[] {
   return args;
 }
 
-type TarballManifest = { version: string } & {
-  [appName: string]: TarballManifestEntry;
+type BeamManifest = {
+  apps: Record<string, BeamManifestApp>;
+  vm: {
+    boot: string;
+  };
 };
 
-type TarballManifestEntry = {
-  tar: `/lib/${string}.tar` | `/lib/${string}.tar.gz`;
-  sha256: string;
+type BeamManifestApp = {
+  tar: string;
+};
+
+type LoadedFsData = {
+  appNames: string[];
+  bootFile: Uint8Array;
+  tarballs: Uint8Array[];
 };
 
 type InitFsArgs = {
   module: EmscriptenModule;
-  assetsUrl: string;
+  fsData: LoadedFsData;
 };
 
-async function initFs({ module, assetsUrl }: InitFsArgs): Promise<void> {
+async function loadFsData(manifestUrl: string): Promise<Result<LoadedFsData>> {
+  const manifest = await fetchJson<BeamManifest>(manifestUrl);
+  if (manifest === null) {
+    return {
+      ok: false,
+      error: err("beam:missing-manifest", { url: manifestUrl }),
+    };
+  }
+
+  const appNames = Object.keys(manifest.apps);
+  for (const name of CORE_APPS) {
+    if (!Object.hasOwn(manifest.apps, name)) {
+      return {
+        ok: false,
+        error: err("beam:missing-tarball", { name, all: appNames }),
+      };
+    }
+  }
+
+  const bootUrl = resolveManifestPath(manifestUrl, manifest.vm.boot);
+  const bootFile = await fetchBinary(bootUrl);
+  if (bootFile === null) {
+    return {
+      ok: false,
+      error: err("beam:missing-boot-script", { url: bootUrl }),
+    };
+  }
+
+  const loadedTarballs = await Promise.all(
+    appNames.map(async (name): Promise<Result<Uint8Array>> => {
+      const entry = manifest.apps[name];
+      const tarUrl = resolveManifestPath(manifestUrl, entry.tar);
+      const tar = await fetchBinary(tarUrl);
+      if (tar === null) {
+        return {
+          ok: false,
+          error: err("beam:missing-tarball", { name, all: appNames }),
+        };
+      }
+
+      return { ok: true, data: await maybeDecompressTar(tar) };
+    }),
+  );
+
+  const tarballs: Uint8Array[] = [];
+  for (const tarball of loadedTarballs) {
+    if (!tarball.ok) {
+      return { ok: false, error: tarball.error };
+    }
+
+    tarballs.push(tarball.data);
+  }
+
+  return { ok: true, data: { appNames, bootFile, tarballs } };
+}
+
+function initFs({ module, fsData }: InitFsArgs): void {
   for (const dir of FS_DIRS) {
     ensureDir(module.FS, dir);
   }
 
-  // vm.boot
-  const BOOT_URL = `${assetsUrl}${BOOT_PATH}`;
-  const bootFile = await fetchBinary(BOOT_URL);
-  if (bootFile === null) {
-    throw err("beam:missing-boot-script", { url: BOOT_URL });
-  }
-
-  module.FS.writeFile(BOOT_PATH, bootFile);
-
-  // tarballs.json
-  const MANIFEST_URL = `${assetsUrl}${MANIFEST_PATH}`;
-  const manifest = await fetchJson<TarballManifest>(MANIFEST_URL);
-  if (manifest === null) {
-    throw err("beam:missing-manifest", { url: MANIFEST_URL });
-  }
+  module.FS.writeFile(BOOT_PATH, fsData.bootFile);
 
   const createDir = (dirPath: string) => {
     ensureDir(module.FS, dirPath);
@@ -170,29 +179,21 @@ async function initFs({ module, assetsUrl }: InitFsArgs): Promise<void> {
     module.FS.writeFile(path, content);
   };
 
-  const tarballs = await Promise.all(
-    CORE_APPS.map(async (name) => {
-      const entry = manifest[name] ?? null;
-      if (entry === null) {
-        throw err("beam:missing-tarball", { name, all: getTarballs(manifest) });
-      }
-
-      const tar = await fetchBinary(`${assetsUrl}${entry.tar}`);
-      if (tar === null) {
-        throw err("beam:missing-tarball", { name, all: getTarballs(manifest) });
-      }
-
-      return maybeDecompressTar(tar);
-    }),
-  );
-
-  for (const tarball of tarballs) {
+  for (const tarball of fsData.tarballs) {
     extractTar(tarball, createDir, createFile);
   }
 }
 
-function getTarballs(manifest: TarballManifest): string[] {
-  return Object.keys(manifest).filter((name) => name !== "version");
+function resolveManifestPath(manifestUrl: string, path: string): string {
+  if (path.startsWith("/") || isAbsoluteUrl(path)) {
+    return path;
+  }
+
+  return new URL(path, new URL(manifestUrl, self.location.href)).toString();
+}
+
+function isAbsoluteUrl(path: string): boolean {
+  return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(path);
 }
 
 async function maybeDecompressTar(tar: Uint8Array): Promise<Uint8Array> {

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -10,7 +10,7 @@ import { check, objectWithKeys } from "./utils";
 
 type BootEvent = {
   type: "popcorn:boot";
-  payload: Pick<BeamBootOptions, "assetsUrl" | "extraArgs">;
+  payload: Pick<BeamBootOptions, "manifestUrl" | "extraArgs">;
 };
 
 type SendEvent = {

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -10,7 +10,7 @@ import { check, objectWithKeys } from "./utils";
 
 type BootEvent = {
   type: "popcorn:boot";
-  payload: Pick<BeamBootOptions, "assetsUrl" | "searchPaths" | "extraArgs">;
+  payload: Pick<BeamBootOptions, "assetsUrl" | "extraArgs">;
 };
 
 type SendEvent = {

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -20,7 +20,7 @@ type TrackedEntry = { value: unknown; cleanup?: () => void };
 const TRACKED_REF_KEY = "popcorn_ref";
 
 export type PopcornOpts = {
-  beam: Pick<BeamBootOptions, "assetsUrl" | "extraArgs">;
+  beam: Pick<BeamBootOptions, "manifestUrl" | "extraArgs">;
   timeoutsMs?: {
     boot?: number;
     send?: number;

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -20,7 +20,7 @@ type TrackedEntry = { value: unknown; cleanup?: () => void };
 const TRACKED_REF_KEY = "popcorn_ref";
 
 export type PopcornOpts = {
-  beam: Pick<BeamBootOptions, "assetsUrl" | "searchPaths" | "extraArgs">;
+  beam: Pick<BeamBootOptions, "assetsUrl" | "extraArgs">;
   timeoutsMs?: {
     boot?: number;
     send?: number;

--- a/otp/js/src/types.ts
+++ b/otp/js/src/types.ts
@@ -11,7 +11,7 @@ export type BeamSendPayload = {
 };
 
 export type BeamBootOptions = {
-  assetsUrl: string;
+  manifestUrl: string;
   extraArgs?: string[];
   createModule: CreateModuleFn<EmscriptenModule>;
   emit: (event: BeamEvent) => void;

--- a/otp/js/src/types.ts
+++ b/otp/js/src/types.ts
@@ -12,7 +12,6 @@ export type BeamSendPayload = {
 
 export type BeamBootOptions = {
   assetsUrl: string;
-  searchPaths?: string[];
   extraArgs?: string[];
   createModule: CreateModuleFn<EmscriptenModule>;
   emit: (event: BeamEvent) => void;

--- a/otp/js/src/worker.ts
+++ b/otp/js/src/worker.ts
@@ -18,7 +18,6 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
       const result = await boot({
         assetsUrl: data.payload.assetsUrl,
         extraArgs: data.payload.extraArgs,
-        searchPaths: data.payload.searchPaths,
         createModule,
         emit: toMain,
       });

--- a/otp/js/src/worker.ts
+++ b/otp/js/src/worker.ts
@@ -16,7 +16,7 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
       check(instance === null);
 
       const result = await boot({
-        assetsUrl: data.payload.assetsUrl,
+        manifestUrl: data.payload.manifestUrl,
         extraArgs: data.payload.extraArgs,
         createModule,
         emit: toMain,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.0
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       rollup:
         specifier: '>=4.59.0'
         version: 4.60.3

--- a/scripts/stdlib.sh
+++ b/scripts/stdlib.sh
@@ -46,11 +46,6 @@ EOF
 }
 
 
-sha256_hash() {
-    shasum -a 256 "$1" | cut -d' ' -f1
-}
-
-
 app_version_from_file() {
     local app_file="$1"
     local version
@@ -371,14 +366,14 @@ write_tarball_manifest() {
     local otp_version
     local app
     local tarball
-    local hash
     local version
+    local prefix
 
     otp_version="$(tr -d ' \n' < "${beam_dir}/OTP_VERSION")"
 
     {
-        printf '{'
-        printf '"version":"%s"' "${otp_version}"
+        printf '{"entrypoint":null,"apps":{'
+        prefix=""
 
         for app in "${SELECTED_APPS[@]}"; do
             tarball="${outdir}/${app}.tar.gz"
@@ -386,12 +381,12 @@ write_tarball_manifest() {
                 error "Expected tarball not found: ${tarball}"
             fi
 
-            hash=$(sha256_hash "${tarball}")
             version=$(app_version "${beam_dir}" "${elixir_dir}" "${app}")
-            printf ',"%s":{"tar":"/lib/%s.tar.gz","version":"%s","sha256":"%s"}' "${app}" "${app}" "${version}" "${hash}"
+            printf '%s"%s":{"tar":"lib/%s.tar.gz","version":"%s"}' "${prefix}" "${app}" "${app}" "${version}"
+            prefix=","
         done
 
-        printf '}\n'
+        printf '},"notes":[],"vm":{"boot":"bin/vm.boot","version":"%s"}}\n' "${otp_version}"
     } > "${manifest_path}"
 
     log "Wrote tarball manifest: ${manifest_path}"

--- a/scripts/stdlib.sh
+++ b/scripts/stdlib.sh
@@ -51,6 +51,39 @@ sha256_hash() {
 }
 
 
+app_version_from_file() {
+    local app_file="$1"
+    local version
+
+    version=$(sed -nE 's/.*\{vsn,[[:space:]]*"([^"]+)".*/\1/p' "${app_file}")
+    if [[ -z "${version}" ]]; then
+        error "Missing vsn in ${app_file}"
+    fi
+
+    echo "${version}"
+}
+
+
+app_version() {
+    local beam_dir="$1"
+    local elixir_dir="$2"
+    local app="$3"
+    local ebin
+
+    if is_elixir_app "${app}"; then
+        ebin=$(resolve_elixir_ebin_dir "${elixir_dir}" "${app}") || {
+            error "Missing Elixir app ebin dir for '${app}' in ${elixir_dir}."
+        }
+    else
+        ebin=$(select_otp_app_ebin_dir "${beam_dir}" "${app}") || {
+            error "Missing ebin dir for OTP app '${app}'."
+        }
+    fi
+
+    app_version_from_file "${ebin}/${app}.app"
+}
+
+
 is_elixir_app() {
     local app="$1"
     local elixir_app
@@ -333,11 +366,13 @@ create_elixir_tarballs() {
 write_tarball_manifest() {
     local beam_dir="$1"
     local outdir="$2"
+    local elixir_dir="$3"
     local manifest_path="${outdir}/tarballs.json"
     local otp_version
     local app
     local tarball
     local hash
+    local version
 
     otp_version="$(tr -d ' \n' < "${beam_dir}/OTP_VERSION")"
 
@@ -352,7 +387,8 @@ write_tarball_manifest() {
             fi
 
             hash=$(sha256_hash "${tarball}")
-            printf ',"%s":{"tar":"/lib/%s.tar.gz","sha256":"%s"}' "${app}" "${app}" "${hash}"
+            version=$(app_version "${beam_dir}" "${elixir_dir}" "${app}")
+            printf ',"%s":{"tar":"/lib/%s.tar.gz","version":"%s","sha256":"%s"}' "${app}" "${app}" "${version}" "${hash}"
         done
 
         printf '}\n'
@@ -453,7 +489,7 @@ main() {
     if [[ ${#SELECTED_ELIXIR_APPS[@]} -gt 0 ]]; then
         create_elixir_tarballs "${elixir_dir}" "${outdir}"
     fi
-    write_tarball_manifest "${beam_dir}" "${outdir}"
+    write_tarball_manifest "${beam_dir}" "${outdir}" "${elixir_dir}"
     emit_tarball_paths
 }
 


### PR DESCRIPTION
Changes the way we boot up the VM. Apart of built-in apps that are required (kernel, stdlib, compiler), we also need external modules (dirs with .beam files). This includes elixir and any user apps (entrypoint + deps). Previously, this was meant to be solved by `searchPaths` and shipping directories as tarballs.

We can do better, by doing transitive closure based on user entrypoint (gathering needed deps and load order) and shipping additional meta-config file. Running code without any modules is still possible by passing `-eval` to extraArgs.

This PR also adds plugins infra to prepare tarballs, json, and put files in appropriate places in bundler's output.
We try to avoid getting stdlib modules from user system and use ones from bootstrapped VM instead. This changeset also adds preliminary checking for dynamic NIF loading (we can only support NIFs compiled into VM and additionally we ship builds with and without crypto NIFs).

Rollup and vite plugins will be added in the followup.