### PR TITLE
[LLV] Handle push error

### DIFF
--- a/examples/local-lv-burrito/assets/js/app.js
+++ b/examples/local-lv-burrito/assets/js/app.js
@@ -351,7 +351,6 @@ liveSocket.connect();
 window.liveSocket = liveSocket;
 
 window.llvEngine = await LLVEngine.create(liveSocket, {
-  Socket,
   bundlePaths: ["/assets/js/wasm/bundle.avm"],
 });
 window.dispatchEvent(new CustomEvent("llv:ready"));

--- a/examples/local-lv-checkout/assets/js/app.js
+++ b/examples/local-lv-checkout/assets/js/app.js
@@ -41,7 +41,7 @@ window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 liveSocket.connect();
 
 import { LLVEngine } from "local_live_view";
-await LLVEngine.create(liveSocket, { Socket, bundlePaths: ["/assets/js/wasm/bundle.avm"] });
+await LLVEngine.create(liveSocket, { bundlePaths: ["/assets/js/wasm/bundle.avm"] });
 
 // expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()

--- a/examples/local-lv-compare/assets/js/app.js
+++ b/examples/local-lv-compare/assets/js/app.js
@@ -42,7 +42,6 @@ window.addEventListener("phx:page-loading-stop", (_info) => topbar.hide());
 // setup local live views, which will override the default pushWithReply and join functions of the live view to instead call popcorn
 import { LLVEngine } from "local_live_view";
 await LLVEngine.create(liveSocket, {
-  Socket,
   bundlePaths: ["/assets/js/wasm/bundle.avm"],
 });
 

--- a/examples/local-lv-forms/assets/js/app.js
+++ b/examples/local-lv-forms/assets/js/app.js
@@ -42,7 +42,6 @@ window.addEventListener("phx:page-loading-stop", (_info) => topbar.hide());
 // setup local live views, which will override the default pushWithReply and join functions of the live view to instead call popcorn
 import { LLVEngine } from "local_live_view";
 await LLVEngine.create(liveSocket, {
-  Socket,
   bundlePaths: ["/assets/js/wasm/bundle.avm"],
 });
 

--- a/examples/local-lv-kanban/assets/js/app.js
+++ b/examples/local-lv-kanban/assets/js/app.js
@@ -41,7 +41,7 @@ window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 liveSocket.connect();
 
 import { LLVEngine } from "local_live_view";
-await LLVEngine.create(liveSocket, { Socket, bundlePaths: ["/assets/js/wasm/bundle.avm"] });
+await LLVEngine.create(liveSocket, { bundlePaths: ["/assets/js/wasm/bundle.avm"] });
 
 // expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()

--- a/examples/local-lv-kanban/lib/local_lv_kanban_web/live/board_live.ex
+++ b/examples/local-lv-kanban/lib/local_lv_kanban_web/live/board_live.ex
@@ -5,7 +5,7 @@ defmodule LocalLvKanbanWeb.BoardLive do
   Server-authoritative collaborative flow:
 
     * The browser-side view applies edits optimistically and notifies this view
-      (`targets([@default, @server])` for adds/removes, `push_server_event` for drag-moves).
+      via `push_server_event`.
     * `handle_event` writes the edit to the DB. On success it broadcasts
       `:board_changed` to every `BoardLive` viewing this board (including itself);
       each re-reads the board and re-assigns it, so all clients converge.

--- a/examples/local-lv-kanban/lib/local_lv_kanban_web/live/boards_live.ex
+++ b/examples/local-lv-kanban/lib/local_lv_kanban_web/live/boards_live.ex
@@ -43,7 +43,9 @@ defmodule LocalLvKanbanWeb.BoardsLive do
           <button
             type="submit"
             style="background:#2563eb;color:#fff;border:none;border-radius:6px;padding:0.6em 1.1em;font-size:1em;cursor:pointer"
-          >Create</button>
+          >
+            Create
+          </button>
         </form>
 
         <div :if={@boards == []} style="color:#6b7280;font-style:italic">

--- a/examples/local-lv-kanban/local/lib/local/column_component.ex
+++ b/examples/local-lv-kanban/local/lib/local/column_component.ex
@@ -8,7 +8,6 @@ defmodule Local.ColumnComponent do
   def placeholder_height, do: @placeholder_height
 
   attr :col, :map, required: true
-  attr :target, :string, required: true
   attr :dragging, :map, default: nil
   attr :drag_target, :map, default: nil
 
@@ -30,7 +29,6 @@ defmodule Local.ColumnComponent do
         <button
           type="button"
           phx-click="remove_column"
-          phx-target={@target}
           phx-value-id={@col.id}
           title="Remove column"
           style="background:transparent;color:#9ca3af;border:none;cursor:pointer;font-size:1.1em;line-height:1;padding:0.1em 0.35em;border-radius:4px"
@@ -43,7 +41,6 @@ defmodule Local.ColumnComponent do
           <TaskComponent.card
             task={task}
             column_id={@col.id}
-            target={@target}
             is_dragging={dragging_task?(@dragging, task.id)}
           />
         <% end %>

--- a/examples/local-lv-kanban/local/lib/local/kanban.ex
+++ b/examples/local-lv-kanban/local/lib/local/kanban.ex
@@ -18,7 +18,9 @@ defmodule Local.Kanban do
   # drag-moves carry a client-generated position, so they apply locally and notify
   # the server via `push_server_event/3`. The server is authoritative: `update/2`
   # rebuilds the whole board (preserving server ids) whenever a new `rev` arrives,
-  # so a successful edit reconciles seamlessly and a failed one rolls back.
+  # so a successful edit reconciles seamlessly and a failed one rolls back. When a
+  # push never reaches the host at all (disconnected socket), `handle_push_error/4`
+  # rolls the board back to the last authoritative state.
 
   @impl true
   def mount(_params, _session, socket) do
@@ -48,6 +50,20 @@ defmodule Local.Kanban do
        |> assign(:last_rev, assigns[:rev])
        |> assign(:columns, build_board(assigns.board))}
     end
+  end
+
+  @impl true
+  def handle_push_error(_event, _params, server_assigns, socket) do
+    # The default (feeding server_assigns through update/2) would no-op here:
+    # the rolled-back rev already equals last_rev, so the guard skips the
+    # rebuild. Force it, and drop any in-flight drag state that referenced the
+    # rolled-back board.
+    {:noreply,
+     assign(socket,
+       columns: build_board(server_assigns.board),
+       dragging: nil,
+       drag_target: nil
+     )}
   end
 
   # --- Columns & tasks (optimistic) ------------------------------------------

--- a/examples/local-lv-kanban/local/lib/local/kanban.ex
+++ b/examples/local-lv-kanban/local/lib/local/kanban.ex
@@ -3,23 +3,6 @@ defmodule Local.Kanban do
 
   alias Local.{AddColumnComponent, ColumnComponent, Rank, TaskModalComponent}
 
-  # The board is a plain map `%{id => column}`; each column carries its tasks as
-  # `%{id => task}`. Nothing tracks order explicitly — columns and tasks are
-  # sorted by their `position` on render. Tasks use fractional-index string ranks
-  # (`Rank`) with the task's id baked on (so positions are globally unique);
-  # columns use the server's integer position. THE CLIENT generates task
-  # positions: a drag/add computes the new rank locally and sends the literal
-  # `position` to the host, which just persists it.
-  #
-  # This is the OPTIMISTIC, collaborative client: every edit is applied here
-  # instantly AND sent to the host `BoardLive` via `push_server_event/3`, which
-  # writes the DB and broadcasts so all viewers reconcile. The server is
-  # authoritative: `update/2` rebuilds the whole board (preserving server ids)
-  # whenever a new `rev` arrives, so a successful edit reconciles seamlessly and
-  # a failed one rolls back. When a push never reaches the host at all
-  # (disconnected socket), `handle_push_error/4` rolls the board back to the
-  # last authoritative state.
-
   @impl true
   def mount(_params, _session, socket) do
     {:ok,
@@ -132,22 +115,22 @@ defmodule Local.Kanban do
     end
   end
 
-  def handle_event("remove_column", %{"id" => id}, socket) do
+  def handle_event("remove_column", %{"id" => id} = payload, socket) do
     {_column, columns} = pop_in(socket.assigns.columns, [id])
 
     {:noreply,
      socket
      |> assign(:columns, columns)
-     |> push_server_event("remove_column", %{"id" => id})}
+     |> push_server_event("remove_column", payload)}
   end
 
-  def handle_event("remove_task", %{"column_id" => cid, "task_id" => tid}, socket) do
+  def handle_event("remove_task", %{"column_id" => cid, "task_id" => tid} = payload, socket) do
     {_task, columns} = pop_in(socket.assigns.columns, [cid, :tasks, tid])
 
     {:noreply,
      socket
      |> assign(:columns, columns)
-     |> push_server_event("remove_task", %{"column_id" => cid, "task_id" => tid})}
+     |> push_server_event("remove_task", payload)}
   end
 
   # --- Task modal (local-only UI state) --------------------------------------

--- a/examples/local-lv-kanban/local/lib/local/kanban.ex
+++ b/examples/local-lv-kanban/local/lib/local/kanban.ex
@@ -12,15 +12,13 @@ defmodule Local.Kanban do
   # `position` to the host, which just persists it.
   #
   # This is the OPTIMISTIC, collaborative client: every edit is applied here
-  # instantly AND sent to the host `BoardLive`, which writes the DB and broadcasts
-  # so all viewers reconcile. add_column/removes ride `phx-target={targets([@default,
-  # @server])}` (the same DOM event runs here and on the server); add_task and
-  # drag-moves carry a client-generated position, so they apply locally and notify
-  # the server via `push_server_event/3`. The server is authoritative: `update/2`
-  # rebuilds the whole board (preserving server ids) whenever a new `rev` arrives,
-  # so a successful edit reconciles seamlessly and a failed one rolls back. When a
-  # push never reaches the host at all (disconnected socket), `handle_push_error/4`
-  # rolls the board back to the last authoritative state.
+  # instantly AND sent to the host `BoardLive` via `push_server_event/3`, which
+  # writes the DB and broadcasts so all viewers reconcile. The server is
+  # authoritative: `update/2` rebuilds the whole board (preserving server ids)
+  # whenever a new `rev` arrives, so a successful edit reconciles seamlessly and
+  # a failed one rolls back. When a push never reaches the host at all
+  # (disconnected socket), `handle_push_error/4` rolls the board back to the
+  # last authoritative state.
 
   @impl true
   def mount(_params, _session, socket) do
@@ -136,12 +134,20 @@ defmodule Local.Kanban do
 
   def handle_event("remove_column", %{"id" => id}, socket) do
     {_column, columns} = pop_in(socket.assigns.columns, [id])
-    {:noreply, assign(socket, :columns, columns)}
+
+    {:noreply,
+     socket
+     |> assign(:columns, columns)
+     |> push_server_event("remove_column", %{"id" => id})}
   end
 
   def handle_event("remove_task", %{"column_id" => cid, "task_id" => tid}, socket) do
     {_task, columns} = pop_in(socket.assigns.columns, [cid, :tasks, tid])
-    {:noreply, assign(socket, :columns, columns)}
+
+    {:noreply,
+     socket
+     |> assign(:columns, columns)
+     |> push_server_event("remove_task", %{"column_id" => cid, "task_id" => tid})}
   end
 
   # --- Task modal (local-only UI state) --------------------------------------
@@ -309,13 +315,9 @@ defmodule Local.Kanban do
 
   @impl true
   def render(assigns) do
-    # Removes run both locally (optimistic) and on the host LiveView, so target
-    # both the local view (@default) and the server (@server). add_task/add_column
-    # are client-only (the client pushes its generated position itself).
     assigns =
-      assigns
-      |> assign(:target, targets([assigns.default, assigns.server]))
-      |> assign(
+      assign(
+        assigns,
         :columns_sorted,
         assigns.columns |> Map.values() |> Enum.sort_by(&{&1.position, &1.id})
       )
@@ -328,7 +330,6 @@ defmodule Local.Kanban do
         <ColumnComponent.column
           :for={col <- @columns_sorted}
           col={col}
-          target={@target}
           dragging={@dragging}
           drag_target={@drag_target}
         />

--- a/examples/local-lv-kanban/local/lib/local/task_component.ex
+++ b/examples/local-lv-kanban/local/lib/local/task_component.ex
@@ -3,7 +3,6 @@ defmodule Local.TaskComponent do
 
   attr :task, :map, required: true
   attr :column_id, :string, required: true
-  attr :target, :string, required: true
   attr :is_dragging, :boolean, default: false
 
   def card(assigns) do
@@ -26,7 +25,6 @@ defmodule Local.TaskComponent do
         type="button"
         draggable="false"
         phx-click="remove_task"
-        phx-target={@target}
         phx-value-column_id={@column_id}
         phx-value-task_id={@task.id}
         title="Remove task"

--- a/examples/local-lv-kanban/test/local_lv_kanban_web/controllers/error_html_test.exs
+++ b/examples/local-lv-kanban/test/local_lv_kanban_web/controllers/error_html_test.exs
@@ -9,6 +9,7 @@ defmodule LocalLvKanbanWeb.ErrorHTMLTest do
   end
 
   test "renders 500.html" do
-    assert render_to_string(LocalLvKanbanWeb.ErrorHTML, "500", "html", []) == "Internal Server Error"
+    assert render_to_string(LocalLvKanbanWeb.ErrorHTML, "500", "html", []) ==
+             "Internal Server Error"
   end
 end

--- a/examples/local-lv-kanban/test/playwright/tests/kanban.spec.js
+++ b/examples/local-lv-kanban/test/playwright/tests/kanban.spec.js
@@ -181,10 +181,49 @@ test.describe("push failure (handle_push_error)", () => {
     // Kill the host websocket: push_server_event rejects with "no connection".
     await page.evaluate(() => window.liveSocket.disconnect());
 
+    // The rollback can remove the optimistic column within milliseconds of it
+    // rendering — too fast for locator polling — so record its appearance with
+    // a MutationObserver instead.
+    await page.evaluate(() => {
+      window.__llvTestSawGhost = false;
+      new MutationObserver(() => {
+        if (document.body.textContent.includes("Ghost")) window.__llvTestSawGhost = true;
+      }).observe(document.body, { childList: true, subtree: true, characterData: true });
+    });
+
     // add_column applies optimistically in WASM, then the failed push triggers
     // handle_push_error, restoring the last authoritative board.
     await h.submitColumn(page, "Ghost");
+    await page.waitForFunction(() => window.__llvTestSawGhost, null, { timeout: 15_000 });
     await expect(h.columnByName(page, "Ghost")).toHaveCount(0, { timeout: 15_000 });
+    await expect(h.columns(page)).toHaveCount(3);
+  });
+
+  test("an optimistic remove via phx-target @server snaps back when the socket is down", async ({ page }) => {
+    await h.createBoard(page, uniqueName("PushErrDom"));
+    await expect(h.columns(page)).toHaveCount(3);
+
+    // Kill the host websocket: the @server leg of the remove's
+    // targets([@default, @server]) rejects with "no connection".
+    await page.evaluate(() => window.liveSocket.disconnect());
+
+    // The rollback can re-render the column within milliseconds of the
+    // optimistic removal — too fast for locator polling — so record the
+    // disappearance with a MutationObserver instead.
+    await page.evaluate(() => {
+      window.__llvTestSawRemoval = false;
+      new MutationObserver(() => {
+        const columns = document.querySelectorAll("[phx-dragover='drag_over_column']");
+        const present = [...columns].some((c) => c.textContent.includes("In Progress"));
+        if (!present) window.__llvTestSawRemoval = true;
+      }).observe(document.body, { childList: true, subtree: true, characterData: true });
+    });
+
+    // The @default leg removes the column optimistically, then the failed
+    // @server leg triggers handle_push_error, restoring the board.
+    await h.columnByName(page, "In Progress").getByTitle("Remove column").click();
+    await page.waitForFunction(() => window.__llvTestSawRemoval, null, { timeout: 15_000 });
+    await expect(h.columnByName(page, "In Progress")).toHaveCount(1, { timeout: 15_000 });
     await expect(h.columns(page)).toHaveCount(3);
   });
 });

--- a/examples/local-lv-kanban/test/playwright/tests/kanban.spec.js
+++ b/examples/local-lv-kanban/test/playwright/tests/kanban.spec.js
@@ -199,12 +199,12 @@ test.describe("push failure (handle_push_error)", () => {
     await expect(h.columns(page)).toHaveCount(3);
   });
 
-  test("an optimistic remove via phx-target @server snaps back when the socket is down", async ({ page }) => {
+  test("an optimistic remove snaps back when the socket is down", async ({ page }) => {
     await h.createBoard(page, uniqueName("PushErrDom"));
     await expect(h.columns(page)).toHaveCount(3);
 
-    // Kill the host websocket: the @server leg of the remove's
-    // targets([@default, @server]) rejects with "no connection".
+    // Kill the host websocket: the remove's push_server_event rejects with
+    // "no connection".
     await page.evaluate(() => window.liveSocket.disconnect());
 
     // The rollback can re-render the column within milliseconds of the
@@ -219,8 +219,8 @@ test.describe("push failure (handle_push_error)", () => {
       }).observe(document.body, { childList: true, subtree: true, characterData: true });
     });
 
-    // The @default leg removes the column optimistically, then the failed
-    // @server leg triggers handle_push_error, restoring the board.
+    // The local handler removes the column optimistically, then its failed
+    // push_server_event triggers handle_push_error, restoring the board.
     await h.columnByName(page, "In Progress").getByTitle("Remove column").click();
     await page.waitForFunction(() => window.__llvTestSawRemoval, null, { timeout: 15_000 });
     await expect(h.columnByName(page, "In Progress")).toHaveCount(1, { timeout: 15_000 });

--- a/examples/local-lv-kanban/test/playwright/tests/kanban.spec.js
+++ b/examples/local-lv-kanban/test/playwright/tests/kanban.spec.js
@@ -172,3 +172,19 @@ test.describe("optimistic rollback", () => {
     await expect(h.columns(page)).toHaveCount(3);
   });
 });
+
+test.describe("push failure (handle_push_error)", () => {
+  test("an optimistic add snaps back when the socket is down", async ({ page }) => {
+    await h.createBoard(page, uniqueName("PushErr"));
+    await expect(h.columns(page)).toHaveCount(3);
+
+    // Kill the host websocket: push_server_event rejects with "no connection".
+    await page.evaluate(() => window.liveSocket.disconnect());
+
+    // add_column applies optimistically in WASM, then the failed push triggers
+    // handle_push_error, restoring the last authoritative board.
+    await h.submitColumn(page, "Ghost");
+    await expect(h.columnByName(page, "Ghost")).toHaveCount(0, { timeout: 15_000 });
+    await expect(h.columns(page)).toHaveCount(3);
+  });
+});

--- a/examples/local-lv-pong/assets/js/app.js
+++ b/examples/local-lv-pong/assets/js/app.js
@@ -38,7 +38,7 @@ window.addEventListener("phx:page-loading-start", _info => topbar.show(300))
 window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 
 import { LLVEngine } from "local_live_view";
-await LLVEngine.create(liveSocket, { Socket, bundlePaths: ["/assets/js/wasm/bundle.avm"] });
+await LLVEngine.create(liveSocket, { bundlePaths: ["/assets/js/wasm/bundle.avm"] });
 
 // connect if there are any LiveViews on the page
 liveSocket.connect();

--- a/examples/local-lv-thermostat/assets/js/app.js
+++ b/examples/local-lv-thermostat/assets/js/app.js
@@ -42,7 +42,6 @@ window.addEventListener("phx:page-loading-stop", (_info) => topbar.hide());
 // setup local live views, which will override the default pushWithReply and join functions of the live view to instead call popcorn
 import { LLVEngine } from "local_live_view";
 await LLVEngine.create(liveSocket, {
-  Socket,
   bundlePaths: ["/assets/js/wasm/bundle.avm"],
 });
 

--- a/local-live-view/assets/local_live_view/helpers.ts
+++ b/local-live-view/assets/local_live_view/helpers.ts
@@ -10,9 +10,7 @@ export function resolveLlvId(viewOrId: string): string {
   return el ? el.id : viewOrId;
 }
 
-// Host-pushed server messages are not channel pushes — there is no ack to
-// carry the render, so the view delivers any resulting diff out-of-band
-// (__popcornTransportReceive). Hence the dedicated fire-and-forget action.
+// handles messages sent by the server via LocalLiveView.push_server_message
 export function sendServerMessage(pop: PopcornClient, detail: LLVServerMessageDetail) {
   pop.serverMessage(resolveLlvId(detail.view), {
     event: "llv_server_message",

--- a/local-live-view/assets/local_live_view/helpers.ts
+++ b/local-live-view/assets/local_live_view/helpers.ts
@@ -1,5 +1,4 @@
-import type { LLVSocket, LLVView, LLVServerMessageDetail } from "./types";
-import { PHX_VIEW_SELECTOR } from "./types";
+import type { LLVServerMessageDetail } from "./types";
 import type { PopcornClient } from "./index";
 
 // Resolve an LLV's element id from a view name or id: prefer the element whose
@@ -11,40 +10,11 @@ export function resolveLlvId(viewOrId: string): string {
   return el ? el.id : viewOrId;
 }
 
-// Resolve an LLV's host LiveView fresh on every call (a reconnect can swap the
-// [data-phx-session] element) and hand it to `fun`. We can't use
-// liveSocket.withinOwners(llvElement, fun) here: overriding the owner
-// connects [data-pop-view] elements with the fake local view, so we hop to the host
-// element ourselves first.
-export function withHostLV(
-  socket: LLVSocket,
-  llvId: string,
-  fun: (hostView: LLVView, hostEl: Element) => void,
-) {
-  const llvElement = document.getElementById(llvId);
-  if (!llvElement) {
-    console.error("LLV withHostLV: LLV element not found", llvId);
-    return;
-  }
-  const hostEl = llvElement.closest(PHX_VIEW_SELECTOR);
-  if (!hostEl) {
-    console.error("LLV withHostLV: no host LiveView for view", llvId);
-    return;
-  }
-  // liveSocket.owner only calls back when the element maps to a live view;
-  // surface the miss instead of dropping the event without a trace.
-  let dispatched = false;
-  socket.owner(hostEl, (hostView: LLVView) => {
-    dispatched = true;
-    fun(hostView, hostEl);
-  });
-  if (!dispatched) {
-    console.error("LLV withHostLV: host LiveView element has no live view", { llvId, hostEl });
-  }
-}
-
+// Host-pushed server messages are not channel pushes — there is no ack to
+// carry the render, so the view delivers any resulting diff out-of-band
+// (__popcornTransportReceive). Hence the dedicated fire-and-forget action.
 export function sendServerMessage(pop: PopcornClient, detail: LLVServerMessageDetail) {
-  pop.event(resolveLlvId(detail.view), {
+  pop.serverMessage(resolveLlvId(detail.view), {
     event: "llv_server_message",
     value: detail.payload,
     type: "llv_server_message",

--- a/local-live-view/assets/local_live_view/index.ts
+++ b/local-live-view/assets/local_live_view/index.ts
@@ -1,11 +1,20 @@
 import { Popcorn } from "@swmansion/popcorn";
-import type { Channel } from "phoenix";
+import type { Channel, Socket as PhoenixSocket } from "phoenix";
 import type { Hook, LiveSocketInstanceInterface } from "phoenix_live_view";
-import type { LLVConfig, LLVSocket, LLVView, LLVServerMessageDetail, ViewRegistry } from "./types";
+import type {
+  EventBusHook,
+  LLVConfig,
+  LLVSocket,
+  LLVServerMessageDetail,
+  LLVView,
+  RenderedDiff,
+  ViewRegistry,
+} from "./types";
 import { setupFakeView } from "./view_setup";
+import { createPopcornSocket, type PopcornLink } from "./transport";
 import { registerNavigationHandlers } from "./navigation";
 import { registerCustomEventBindings } from "./events";
-import { withHostLV, sendServerMessage, parseAssigns, resolveLlvId } from "./helpers";
+import { sendServerMessage, parseAssigns, resolveLlvId } from "./helpers";
 
 export type { LLVConfig };
 export type { PopcornClient };
@@ -76,8 +85,22 @@ class PopcornClient {
     this.fire("handle_params", { action: "handle_params", id, payload: { params, url } });
   }
 
-  event(id: string, payload: Record<string, unknown>): void {
-    this.fire("event", { action: "event", id, payload });
+  // A channel frame the view must answer: the view's process settles the
+  // call promise (Popcorn.Wasm.resolve) once the frame is processed, so the
+  // result carries the channel ack. The transport consumes it — no `fire`.
+  transportFrame(id: string, event: string, payload: unknown): Promise<CallResult> {
+    return this.call({ action: "transport_frame", id, event, payload });
+  }
+
+  serverMessage(id: string, payload: Record<string, unknown>): void {
+    this.fire("server_message", { action: "server_message", id, payload });
+  }
+
+  // Report a failed local→server push back to the view's process so its
+  // handle_push_error callback runs. `payload` is the map the view passed
+  // to push_server_event.
+  pushError(id: string, event: string, payload: Record<string, unknown>): void {
+    this.fire("push_error report", { action: "push_error", id, payload: { event, payload } });
   }
 
   push(id: string, event: string, payload: Record<string, unknown>): Promise<CallResult> {
@@ -92,6 +115,10 @@ export class LLVEngine {
   private views: ViewRegistry = new Map();
   private channels: Record<string, Channel> = {};
   private bufferedServerMessages: LLVServerMessageDetail[] = [];
+  // llvId -> mounted LocalLiveViewEventBus hook: the host-side channel used
+  // by __llvPushServer.
+  private eventBusHooks = new Map<string, EventBusHook>();
+  private popcornLink!: PopcornLink;
 
   private constructor(socket: LLVSocket, config: LLVConfig) {
     this.socket = socket;
@@ -116,6 +143,7 @@ export class LLVEngine {
     registerNavigationHandlers(engine.socket, engine.views, engine.pop, engine.config);
     engine.registerHooks();
     engine.bindFormsIfHostless();
+    engine.connectPopcornSocket();
 
     await engine.bootPopcorn();
 
@@ -130,6 +158,15 @@ export class LLVEngine {
     return engine;
   }
 
+  // The dedicated never-networked socket the fake views' channels live on.
+  // Connected before Popcorn boots: heartbeats are acked in place by the
+  // transport, and no answered frame flows until a view mounts (post-boot).
+  private connectPopcornSocket(): void {
+    const SocketClass =
+      this.config.Socket ?? (this.socket.getSocket().constructor as typeof PhoenixSocket);
+    this.popcornLink = createPopcornSocket(SocketClass, this.pop);
+  }
+
   // Start a view and wire it up.
   private async mountView(pop_view_el: HTMLElement): Promise<void> {
     const llvId = pop_view_el.id;
@@ -141,18 +178,16 @@ export class LLVEngine {
       urlParams: Object.fromEntries(new URLSearchParams(window.location.search)),
       assigns: parseAssigns(pop_view_el.getAttribute("data-pop-assigns")),
     });
+    // A rejected call resolves with ok: false (it does not throw). Bail on
+    // failed or duplicate creates — wiring a fake view without a live
+    // process would join a channel nobody answers.
     if (!result.ok) {
       console.error("LLV failed to create view", llvId, result.error);
       return;
     }
-    const data = result.data as { status: string; rendered: Record<string, unknown> };
-    if (data.status === "error") {
-      console.error("LLV view returned error status on create", llvId, data);
-      return;
-    }
     const liveEl = document.getElementById(llvId);
     if (liveEl?.matches("[data-pop-view]")) {
-      setupFakeView(this.socket, this.views, this.pop, liveEl, data.rendered);
+      setupFakeView(this.socket, this.views, this.popcornLink.socket, liveEl);
     } else {
       this.pop.destroy(llvId);
     }
@@ -184,10 +219,9 @@ export class LLVEngine {
     });
   }
 
-  // Hook that manages views rendered inside a host LiveView.
-  // Other views are rendered during startup scan.
-  // The startup scan also handles the case when hook's mount
-  // fires before Popcorn is ready.
+  // Hooks that manage views rendered inside a host LiveView (other views are
+  // mounted by the startup scan, which also catches hooks that fired before
+  // Popcorn was ready) and the per-view event bus.
   private registerHooks(): void {
     const pop = this.pop;
     const mountView = (el: HTMLElement) => this.mountView(el);
@@ -209,6 +243,26 @@ export class LLVEngine {
       },
       destroyed() {
         unmountView(this.el);
+      },
+    } satisfies Hook;
+
+    // Event bus for local→server pushes: a hidden sibling of each mount
+    // point, owned by the HOST LiveView (see LocalLiveView.Component). Its
+    // lifecycle IS the host resolution — LiveView mounts and destroys it
+    // with the host view across reconnects and re-renders, so the registry
+    // always holds a live hook and no host-element lookup can go stale.
+    // __llvPushServer pushes through it via the documented hook pushEvent.
+    const eventBusHooks = this.eventBusHooks;
+    this.socket.hooks.LocalLiveViewEventBus = {
+      mounted() {
+        const llvId = this.el.getAttribute("data-llv-event-bus-for");
+        if (llvId) eventBusHooks.set(llvId, this as unknown as EventBusHook);
+      },
+      destroyed() {
+        const llvId = this.el.getAttribute("data-llv-event-bus-for");
+        if (llvId && eventBusHooks.get(llvId) === (this as unknown as EventBusHook)) {
+          eventBusHooks.delete(llvId);
+        }
       },
     } satisfies Hook;
   }
@@ -280,30 +334,38 @@ export class LLVEngine {
   }
 
   private exposeGlobals(): void {
-    window.__popcornTransportReceive = (llvId: string, diff: Record<string, unknown>) => {
-      const view = this.views.get(llvId);
-      if (!view) {
-        console.error("LLV view not found:", llvId, "available:", this.views.keys());
-        return;
-      }
-      view.update(diff, []);
+    // Out-of-band diffs (handle_info renders, send_update, push_error
+    // rollbacks, server messages — anything not acking a push). Injected as
+    // a channel "diff" frame, handled by the stock bindChannel handler
+    // exactly like a server-pushed diff. A diff racing a just-unmounted
+    // view is dropped.
+    window.__popcornTransportReceive = (llvId: string, diff: RenderedDiff) => {
+      if (!this.views.has(llvId)) return;
+      this.popcornLink.inject({
+        topic: `lv:${llvId}`,
+        event: "diff",
+        payload: diff,
+        ref: null,
+        join_ref: null,
+      });
     };
 
-    // __llvPushServer: programmatic counterpart of phx-target=@server, called from
-    // a local view's Elixir via LocalLiveView.push_server_event/3. Resolves the
-    // LLV's host LiveView fresh each call (a reconnect can swap the
-    // [data-phx-session] element) and dispatches the event to it over the
-    // websocket.
+    // __llvPushServer: sends an event to the host LiveView, called from a
+    // local view's Elixir via LocalLiveView.push_server_event/3. Pushes
+    // through the event bus hook's documented, promise-returning pushEvent —
+    // it rejects when the host is disconnected, replies with an error, or
+    // times out; no event bus means no host LiveView on the page. Failures
+    // are reported back so the view's handle_push_error runs.
     window.__llvPushServer = (llvId: string, event: string, payload: Record<string, unknown>) => {
-      withHostLV(this.socket, llvId, (hostView, hostEl) => {
-        hostView.pushEvent(
-          "event",
-          hostEl,
-          null,
-          event,
-          payload as unknown as Parameters<LLVView["pushEvent"]>[4],
-          {},
-        );
+      const eventBus = this.eventBusHooks.get(llvId);
+      if (!eventBus) {
+        console.error("LLV push_server_event: no host event bus for view", llvId);
+        this.pop.pushError(llvId, event, payload);
+        return;
+      }
+      eventBus.pushEvent(event, payload).catch((err: unknown) => {
+        console.error("LLV push_server_event failed", err);
+        this.pop.pushError(llvId, event, payload);
       });
     };
   }
@@ -328,7 +390,7 @@ export class LLVEngine {
   // This is the mount path for host-less pages (no hooks fire there) and the
   // catch-up for hooks that fired before Popcorn was ready.
   // If a view is mounted twice (here and by the hook), the dispatcher
-  // on the Elixir side ignores the second mount.
+  // on the Elixir side rejects the second create.
   private async scanAndMount(): Promise<void> {
     const pop_view_els = Array.from(document.querySelectorAll<HTMLElement>("[data-pop-view]"));
     await Promise.all(pop_view_els.map((el) => this.mountView(el)));

--- a/local-live-view/assets/local_live_view/index.ts
+++ b/local-live-view/assets/local_live_view/index.ts
@@ -88,7 +88,7 @@ class PopcornClient {
   // A channel frame the view must answer: the view's process settles the
   // call promise (Popcorn.Wasm.resolve) once the frame is processed, so the
   // result carries the channel ack. The transport consumes it — no `fire`.
-  transportFrame(id: string, event: string, payload: unknown): Promise<CallResult> {
+  handleTransportFrame(id: string, event: string, payload: unknown): Promise<CallResult> {
     return this.call({ action: "transport_frame", id, event, payload });
   }
 
@@ -158,13 +158,15 @@ export class LLVEngine {
     return engine;
   }
 
-  // The dedicated never-networked socket the fake views' channels live on.
-  // Connected before Popcorn boots: heartbeats are acked in place by the
-  // transport, and no answered frame flows until a view mounts (post-boot).
+  // The app's Phoenix Socket class, recovered from the live instance the
+  // LiveSocket already holds — same class, same version, same module as the
+  // one LiveView runs on, with nothing to configure.
+  private socketClass(): typeof PhoenixSocket {
+    return this.socket.getSocket().constructor as typeof PhoenixSocket;
+  }
+
   private connectPopcornSocket(): void {
-    const SocketClass =
-      this.config.Socket ?? (this.socket.getSocket().constructor as typeof PhoenixSocket);
-    this.popcornLink = createPopcornSocket(SocketClass, this.pop);
+    this.popcornLink = createPopcornSocket(this.socketClass(), this.pop);
   }
 
   // Start a view and wire it up.
@@ -246,12 +248,10 @@ export class LLVEngine {
       },
     } satisfies Hook;
 
-    // Event bus for local→server pushes: a hidden sibling of each mount
-    // point, owned by the HOST LiveView (see LocalLiveView.Component). Its
-    // lifecycle IS the host resolution — LiveView mounts and destroys it
-    // with the host view across reconnects and re-renders, so the registry
-    // always holds a live hook and no host-element lookup can go stale.
-    // __llvPushServer pushes through it via the documented hook pushEvent.
+    // Hook for sending events from client to server via `LocalLiveView.push_server_event`
+    // Sending an event via a hook freezes the element the hook binds to along with all
+    // its descendants until the event is internally ACKed by LiveView, thus we use
+    // a dedicated, empty div for that.
     const eventBusHooks = this.eventBusHooks;
     this.socket.hooks.LocalLiveViewEventBus = {
       mounted() {
@@ -295,12 +295,8 @@ export class LLVEngine {
     );
     if (mirrorEls.length === 0) return;
 
-    const { Socket } = this.config;
+    const Socket = this.socketClass();
     const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
-
-    if (!Socket) {
-      throw new Error("LLV: config.Socket is required when using mirror channels");
-    }
 
     const llvSocket = new Socket("/llv_socket", {
       params: { _csrf_token: csrfToken },

--- a/local-live-view/assets/local_live_view/transport.ts
+++ b/local-live-view/assets/local_live_view/transport.ts
@@ -2,32 +2,12 @@ import type { Socket as PhoenixSocket, SocketConnectOption } from "phoenix";
 import type { TransportFrame } from "./types";
 import type { PopcornClient } from "./index";
 
-// ---- Popcorn channel transport -----------------------------------------
-//
-// Each fake view gets a REAL Phoenix Channel on a dedicated Socket whose
-// transport is the class below — the same public seam Phoenix.LongPoll
-// plugs into. No network connection ever exists: the "wire" is
-// popcorn.call one way and injected frames the other, and the socket's
-// encode/decode passthrough keeps frames plain objects (no serializer).
-//
-// The transport honors the channel ack contract: frames the WASM view
-// must answer (join, events, component-destruction bookkeeping) ride
-// popcorn.call, whose promise the view's process settles once the frame
-// is processed — the resolved {status, payload} (initial rendered, render
-// diff or %{} no-op, pruned cids) becomes the channel ack. So LiveView's
-// stock push lifecycle runs unmodified: apply the ack diff, undo the
-// push's element refs, resolve the {:reply, ...} payload. Ref locks and
-// phx-disable-with span the local round-trip exactly like a server
-// round-trip.
-
 const llvIdFromTopic = (topic: string) => topic.slice("lv:".length);
 
-// Frames the WASM view must answer: the channel join (ack carries the
-// initial rendered), DOM events (ack carries the render diff and reply)
-// and component-destruction bookkeeping (ack carries the pruned cids).
-// Anything else — heartbeats, phx_leave — is acked in place so the socket
-// stays healthy and teardown completes. Each entry needs a matching
+// Frames the WASM view must answer. Each entry needs a matching
 // Message clause in LocalLiveView.Server.
+// Anything else — heartbeats, phx_leave — is acked in place
+// as Popcorn may be not booted yet.
 const ANSWERED_EVENTS = ["phx_join", "event", "cids_will_destroy", "cids_destroyed"];
 
 export interface PopcornLink {
@@ -37,6 +17,8 @@ export interface PopcornLink {
   inject(frame: TransportFrame): void;
 }
 
+// A fake socket that connects LLV vievs to Popcorn.
+// Phoenix channels can be normally constructed on top of this socket.
 export function createPopcornSocket(
   SocketClass: typeof PhoenixSocket,
   pop: PopcornClient,
@@ -91,12 +73,7 @@ export function createPopcornSocket(
         return;
       }
 
-      // The view's process settles the call promise with {status, payload}
-      // once the frame is processed; a dispatcher-side reject resolves with
-      // ok: false. A call left unsettled (crashed view process) rejects at
-      // the call timeout. Every failure acks "error" — never "timeout",
-      // whose Push path triggers liveSocket.reloadWithJitter.
-      pop.transportFrame(llvIdFromTopic(topic), event, payload).then(
+      pop.handleTransportFrame(llvIdFromTopic(topic), event, payload).then(
         (result) => {
           if (result.ok) {
             const { status, payload: response } = result.data as {

--- a/local-live-view/assets/local_live_view/transport.ts
+++ b/local-live-view/assets/local_live_view/transport.ts
@@ -1,0 +1,136 @@
+import type { Socket as PhoenixSocket, SocketConnectOption } from "phoenix";
+import type { TransportFrame } from "./types";
+import type { PopcornClient } from "./index";
+
+// ---- Popcorn channel transport -----------------------------------------
+//
+// Each fake view gets a REAL Phoenix Channel on a dedicated Socket whose
+// transport is the class below — the same public seam Phoenix.LongPoll
+// plugs into. No network connection ever exists: the "wire" is
+// popcorn.call one way and injected frames the other, and the socket's
+// encode/decode passthrough keeps frames plain objects (no serializer).
+//
+// The transport honors the channel ack contract: frames the WASM view
+// must answer (join, events, component-destruction bookkeeping) ride
+// popcorn.call, whose promise the view's process settles once the frame
+// is processed — the resolved {status, payload} (initial rendered, render
+// diff or %{} no-op, pruned cids) becomes the channel ack. So LiveView's
+// stock push lifecycle runs unmodified: apply the ack diff, undo the
+// push's element refs, resolve the {:reply, ...} payload. Ref locks and
+// phx-disable-with span the local round-trip exactly like a server
+// round-trip.
+
+const llvIdFromTopic = (topic: string) => topic.slice("lv:".length);
+
+// Frames the WASM view must answer: the channel join (ack carries the
+// initial rendered), DOM events (ack carries the render diff and reply)
+// and component-destruction bookkeeping (ack carries the pruned cids).
+// Anything else — heartbeats, phx_leave — is acked in place so the socket
+// stays healthy and teardown completes. Each entry needs a matching
+// Message clause in LocalLiveView.Server.
+const ANSWERED_EVENTS = ["phx_join", "event", "cids_will_destroy", "cids_destroyed"];
+
+export interface PopcornLink {
+  /** The never-networked Phoenix socket the fake views' channels live on. */
+  socket: PhoenixSocket;
+  /** Deliver an inbound frame (out-of-band diffs) to the channel layer. */
+  inject(frame: TransportFrame): void;
+}
+
+export function createPopcornSocket(
+  SocketClass: typeof PhoenixSocket,
+  pop: PopcornClient,
+): PopcornLink {
+  let transport: PopcornTransport | null = null;
+
+  class PopcornTransport {
+    readyState = 0; // CONNECTING
+    onopen: () => void = () => {};
+    onerror: (error: unknown) => void = () => {};
+    onmessage: (event: { data: TransportFrame }) => void = () => {};
+    onclose: (event: { code: number; wasClean: boolean }) => void = () => {};
+
+    // The WebSocket-shaped signature the Socket constructs us with; the URL
+    // is a dead label.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    constructor(_endpointURL: string, _protocols?: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      transport = this;
+      // The Socket assigns onopen/onmessage/onclose after `new`, so the
+      // "connection" must open asynchronously.
+      queueMicrotask(() => {
+        this.readyState = 1; // OPEN
+        this.onopen();
+      });
+    }
+
+    // Deliver an inbound frame. Async so an ack never re-enters Socket code
+    // in the middle of an outbound send.
+    inject(frame: TransportFrame): void {
+      queueMicrotask(() => {
+        if (this.readyState === 1) this.onmessage({ data: frame });
+      });
+    }
+
+    // Ack an outbound frame in place (joins, leaves, heartbeats, no-ops).
+    ack(frame: TransportFrame, status: string, response: unknown): void {
+      this.inject({
+        topic: frame.topic,
+        event: "phx_reply",
+        payload: { status, response },
+        ref: frame.ref,
+        join_ref: frame.join_ref,
+      });
+    }
+
+    send(frame: TransportFrame): void {
+      const { topic, event, payload } = frame;
+
+      if (!ANSWERED_EVENTS.includes(event)) {
+        this.ack(frame, "ok", {});
+        return;
+      }
+
+      // The view's process settles the call promise with {status, payload}
+      // once the frame is processed; a dispatcher-side reject resolves with
+      // ok: false. A call left unsettled (crashed view process) rejects at
+      // the call timeout. Every failure acks "error" — never "timeout",
+      // whose Push path triggers liveSocket.reloadWithJitter.
+      pop.transportFrame(llvIdFromTopic(topic), event, payload).then(
+        (result) => {
+          if (result.ok) {
+            const { status, payload: response } = result.data as {
+              status: string;
+              payload: unknown;
+            };
+            this.ack(frame, status, response);
+          } else {
+            this.ack(frame, "error", result.error);
+          }
+        },
+        (err) => this.ack(frame, "error", String(err)),
+      );
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    close(_code?: number, _reason?: string): void {
+      this.readyState = 3; // CLOSED
+      queueMicrotask(() => this.onclose({ code: 1000, wasClean: true }));
+    }
+  }
+
+  // The endpoint URL is only a label — the transport never dereferences it.
+  const socket = new SocketClass("/llv-popcorn", {
+    transport: PopcornTransport,
+    encode: (payload: unknown, callback: (encoded: unknown) => void) => callback(payload),
+    decode: (rawPayload: unknown, callback: (decoded: unknown) => void) => callback(rawPayload),
+  } as unknown as Partial<SocketConnectOption>);
+  socket.connect();
+
+  return {
+    socket,
+    inject(frame: TransportFrame): void {
+      transport?.inject(frame);
+    },
+  };
+}

--- a/local-live-view/assets/local_live_view/types.ts
+++ b/local-live-view/assets/local_live_view/types.ts
@@ -1,4 +1,4 @@
-import type { Socket as PhoenixSocket } from "phoenix";
+import type { Channel, Socket as PhoenixSocket } from "phoenix";
 import type { LiveSocketInstanceInterface } from "phoenix_live_view";
 
 // --- Public API ---
@@ -25,14 +25,13 @@ export interface LLVConfig {
 /** Opaque rendered diff payload delivered from WASM via structuredClone */
 export type RenderedDiff = Record<string, unknown>;
 
-export type RefGenerator = (opts: { payload: EventPayload }) => [unknown, Element[], object];
-
-export interface EventPayload {
-  cid?: number;
-  event?: string;
-  value?: unknown;
-  type?: string;
-  [key: string]: unknown;
+/** A raw Phoenix channel frame as it crosses the (fake) transport. */
+export interface TransportFrame {
+  topic: string;
+  event: string;
+  payload: unknown;
+  ref: string | null;
+  join_ref: string | null;
 }
 
 export interface PointerData {
@@ -58,20 +57,18 @@ export interface LLVServerMessageDetail {
   payload: unknown;
 }
 
-export const LLV_DEFAULT_TARGET = "__llv_default__";
-export const LLV_SERVER_TARGET = "__llv_server__";
-export const LLV_TARGET_SEP = "\x1f";
-
-// Phoenix tags every real LiveView root element with data-phx-session; this is
-// the selector phoenix_live_view uses internally (PHX_VIEW_SELECTOR).
-export const PHX_VIEW_SELECTOR = "[data-phx-session]";
-
-/** Phoenix View properties and methods that LLV reads or calls but does not replace. */
-interface PhxView {
+/**
+ * Phoenix View surface LLV touches on the object returned by
+ * socket.newRootView(). `channel` and `addHook` are reassigned in
+ * view_setup (property syntax so TypeScript allows reassignment on the
+ * concrete instance); everything else is stock and merely called.
+ */
+export interface LLVView {
   el: HTMLElement;
-  liveSocket: LLVSocket;
-  joinCount: number;
-  joinCallback: (onDone?: () => void) => void;
+  /** Reassigned to a channel on the popcorn socket before join(). */
+  channel: Channel;
+  /** Stock join: bindChannel + channel.join over the popcorn transport. */
+  join(): void;
   pushEvent(
     type: string,
     el: Element,
@@ -80,46 +77,25 @@ interface PhxView {
     meta: PointerData,
     opts: object,
   ): void;
-  showLoader(timeout: number): void;
-  onJoin(resp: { rendered: RenderedDiff }): void;
-  update(diff: RenderedDiff, events: unknown[]): boolean;
-  undoRefs(ref: unknown, event: string): void;
+  addHook: (el: Element) => unknown;
   destroy?: (callback?: () => void) => void;
 }
-
-/**
- * Phoenix View methods that LLV replaces via monkey-patching on the object
- * returned by socket.newRootView(). Property (arrow) syntax is required so
- * TypeScript allows reassignment on the concrete instance.
- */
-interface PhxViewPatchable {
-  withinTargets: (
-    phxTarget: unknown,
-    callback: (view: LLVView, ctx: null) => void,
-    dom?: unknown,
-  ) => void;
-  addHook: (el: Element) => unknown;
-  isConnected: () => boolean;
-  join: (callback?: (count: number, onDone?: () => void) => void) => void;
-  pushWithReply: (
-    refGenerator: RefGenerator | null,
-    event: string,
-    payload: EventPayload,
-  ) => Promise<{ resp: object; reply: null; ref: unknown }>;
-  maybePushComponentsDestroyed: (destroyedCIDs: number[]) => void;
-  bindChannel: () => void;
-}
-
-/** Phoenix View shape after LLV patches it in view_setup. */
-export type LLVView = PhxView & PhxViewPatchable;
 
 /** Registry of the fake Phoenix views LLV mounts, keyed by element id. */
 export type ViewRegistry = Map<string, LLVView>;
 
+/**
+ * A mounted LocalLiveViewEventBus hook instance: the host-side channel used
+ * by __llvPushServer. pushEvent is the documented promise-returning hook API.
+ */
+export interface EventBusHook {
+  el: HTMLElement;
+  pushEvent(event: string, payload: Record<string, unknown>): Promise<unknown>;
+}
+
 /** Private phoenix_live_view LiveSocket API that LLV accesses via type-cast. */
 interface PhxLiveSocketInternals {
   newRootView(el: HTMLElement, flash?: unknown, liveReferer?: unknown): LLVView;
-  requestDOMUpdate(callback: () => void): void;
   isConnected(): boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   hooks: Record<string, any>;
@@ -133,7 +109,6 @@ interface PhxLiveSocketInternals {
     targetEl: Element | null,
   ): void;
   bindForms(): void;
-  loaderTimeout: number;
 }
 
 /** Public LiveSocket interface extended with Phoenix internals accessed by LLV. */

--- a/local-live-view/assets/local_live_view/types.ts
+++ b/local-live-view/assets/local_live_view/types.ts
@@ -1,11 +1,9 @@
-import type { Channel, Socket as PhoenixSocket } from "phoenix";
+import type { Channel } from "phoenix";
 import type { LiveSocketInstanceInterface } from "phoenix_live_view";
 
 // --- Public API ---
 
 export interface LLVConfig {
-  /** Phoenix Socket class — required when using mirror channels */
-  Socket?: typeof PhoenixSocket;
   /** Paths to compiled WASM bundle files. Defaults to `["wasm/bundle.avm"]` */
   bundlePaths?: string[];
   /** Enable Popcorn debug logging */
@@ -57,17 +55,9 @@ export interface LLVServerMessageDetail {
   payload: unknown;
 }
 
-/**
- * Phoenix View surface LLV touches on the object returned by
- * socket.newRootView(). `channel` and `addHook` are reassigned in
- * view_setup (property syntax so TypeScript allows reassignment on the
- * concrete instance); everything else is stock and merely called.
- */
 export interface LLVView {
   el: HTMLElement;
-  /** Reassigned to a channel on the popcorn socket before join(). */
   channel: Channel;
-  /** Stock join: bindChannel + channel.join over the popcorn transport. */
   join(): void;
   pushEvent(
     type: string,
@@ -86,7 +76,7 @@ export type ViewRegistry = Map<string, LLVView>;
 
 /**
  * A mounted LocalLiveViewEventBus hook instance: the host-side channel used
- * by __llvPushServer. pushEvent is the documented promise-returning hook API.
+ * by __llvPushServer.
  */
 export interface EventBusHook {
   el: HTMLElement;

--- a/local-live-view/assets/local_live_view/view_setup.ts
+++ b/local-live-view/assets/local_live_view/view_setup.ts
@@ -1,57 +1,24 @@
-import type {
-  LLVSocket,
-  LLVView,
-  RenderedDiff,
-  RefGenerator,
-  EventPayload,
-  ViewRegistry,
-} from "./types";
-import { LLV_DEFAULT_TARGET, LLV_SERVER_TARGET, LLV_TARGET_SEP } from "./types";
-import { withHostLV } from "./helpers";
-import type { PopcornClient } from "./index";
+import type { Socket as PhoenixSocket } from "phoenix";
+import type { LLVSocket, LLVView, ViewRegistry } from "./types";
 
 // Wire a fake Phoenix root view around a [data-pop-view] element so the
 // browser renders the runtime's diffs and routes events to it.
 export function setupFakeView(
   socket: LLVSocket,
   views: ViewRegistry,
-  pop: PopcornClient,
+  popcornSocket: PhoenixSocket,
   pop_view_el: HTMLElement,
-  initialRendered: RenderedDiff,
 ) {
   const llvId = pop_view_el.id;
 
   const view = socket.newRootView(pop_view_el);
   views.set(llvId, view);
 
-  // Handle LLV's custom targets (default, server, targets composed by LocalLiveView.targets/1)
-  const origWithinTargets = view.withinTargets.bind(view);
-  view.withinTargets = function (
-    phxTarget: unknown,
-    callback: (view: LLVView, ctx: null) => void,
-    dom?: unknown,
-  ) {
-    const dispatchToken = (t: string) => {
-      if (t === LLV_DEFAULT_TARGET) {
-        callback(this, null);
-      } else if (t === LLV_SERVER_TARGET) {
-        withHostLV(socket, llvId, (hostView) => callback(hostView, null));
-      } else {
-        origWithinTargets(t, callback, dom);
-      }
-    };
-
-    if (
-      typeof phxTarget === "string" &&
-      (phxTarget.includes(LLV_TARGET_SEP) ||
-        phxTarget === LLV_DEFAULT_TARGET ||
-        phxTarget === LLV_SERVER_TARGET)
-    ) {
-      for (const t of phxTarget.split(LLV_TARGET_SEP)) if (t) dispatchToken(t);
-      return;
-    }
-    return origWithinTargets(phxTarget, callback, dom);
-  };
+  // The view's channel: a real Phoenix Channel on the popcorn socket.
+  // Everything channel-shaped — join handshake, event acks carrying
+  // diffs, out-of-band "diff" frames, ref bookkeeping — runs through the
+  // stock Channel/Push machinery over the PopcornTransport.
+  view.channel = popcornSocket.channel(`lv:${llvId}`);
 
   // addHook: skip the root element to prevent Phoenix from trying to register it
   // as a hook within this view's scope — hooks on children are still processed normally.
@@ -61,66 +28,11 @@ export function setupFakeView(
     return origAddHook(el);
   };
 
-  // isConnected: we are always "connected" to Popcorn
-  view.isConnected = function () {
-    return true;
-  };
-
-  // join: skip bindChannel + channel.join — onJoin is called below after Popcorn mounts.
-  // No need to set data-phx-session / data-phx-root-id: owner() is overridden below
-  // to route events via [data-pop-view] lookup instead of attribute-based lookup.
-  view.join = function (this: LLVView, callback?) {
-    this.showLoader(this.liveSocket.loaderTimeout);
-    this.joinCallback = (onDone) => {
-      onDone = onDone ?? function () {};
-      if (callback) {
-        callback(this.joinCount, onDone);
-      } else {
-        onDone();
-      }
-    };
-  };
-
-  // pushWithReply: send event to Popcorn, return a resolved Promise so callers
-  // like pushInput can safely chain .then() on it.
-  // The actual diff arrives asynchronously via window.__popcornTransportReceive.
-  view.pushWithReply = function (
-    this: LLVView,
-    refGenerator: RefGenerator | null,
-    event: string,
-    payload: EventPayload,
-  ) {
-    const [ref] = refGenerator ? refGenerator({ payload }) : [null, [], {}];
-
-    if (typeof payload.cid !== "number") {
-      delete payload.cid;
-    }
-
-    pop.event(this.el.id, payload);
-
-    // In the real Phoenix flow, undoRefs is called synchronously inside
-    // pushWithReply's channel reply handler — just before this.update(diff).
-    // Since our diff arrives asynchronously via __popcornTransportReceive,
-    // we must release the ref locks now. Otherwise DOMPatch sees PHX_REF_LOCK
-    // on the form (set by pushInput for both the input AND the form element)
-    // and applies all diff changes to a clone instead of the real DOM.
-    if (ref !== null) {
-      this.undoRefs(ref, (payload.event as string | undefined) ?? event);
-    }
-
-    return Promise.resolve({ resp: {}, reply: null, ref });
-  };
-
-  // maybePushComponentsDestroyed: component lifecycle is managed by Popcorn/WASM,
-  // no need to notify the server about destroyed CIDs from the JS side
-  view.maybePushComponentsDestroyed = function () {};
-
-  view.bindChannel = function () {};
+  // Stock join: bindChannel + channel.join over the popcorn transport.
+  // The join frame is answered by the view's process itself, serving the
+  // rendered it produced at mount — so onJoin runs the regular path.
+  // No need to set data-phx-session / data-phx-root-id: owner() is
+  // overridden by the engine to route events via [data-pop-view] lookup
+  // instead of attribute-based lookup.
   view.join();
-
-  if (initialRendered) {
-    socket.requestDOMUpdate(() => view.onJoin({ rendered: initialRendered }));
-  } else {
-    console.error("LLV no initial rendered for view", llvId);
-  }
 }

--- a/local-live-view/lib/local_live_view/dispatcher.ex
+++ b/local-live-view/lib/local_live_view/dispatcher.ex
@@ -27,43 +27,62 @@ defmodule LocalLiveView.Dispatcher do
 
   @impl GenServer
   def handle_info(raw_msg, state) when is_wasm_message(raw_msg) do
-    state = Wasm.handle_message!(raw_msg, &handle_wasm(&1, state))
-    {:noreply, state}
+    {:wasm_call, msg, promise} = Wasm.parse_message!(raw_msg)
+
+    case handle_wasm_call(msg, promise, state) do
+      {:resolve, reply, state} ->
+        Wasm.resolve(reply, promise)
+        {:noreply, state}
+
+      {:reject, reason, state} ->
+        Wasm.reject(reason, promise)
+        {:noreply, state}
+
+      {:ignore, state} ->
+        {:noreply, state}
+    end
   end
 
-  defp handle_wasm(
-         {:wasm_call, %{"action" => "reconnected", "id" => id}},
-         state
-       ) do
+  defp handle_wasm_call(%{"action" => "transport_frame", "id" => id} = msg, promise, state)
+       when is_map_key(state.views, id) do
+    send(state.views[id], %Message{event: msg["event"], payload: msg["payload"], promise: promise})
+
+    {:ignore, state}
+  end
+
+  defp handle_wasm_call(%{"action" => "transport_frame"}, _promise, state) do
+    {:reject, "view not mounted", state}
+  end
+
+  defp handle_wasm_call(%{"action" => "reconnected", "id" => id}, _promise, state) do
     send_to_view(state, id, %Message{event: "llv_reconnected", payload: %{}})
     {:resolve, :ok, state}
   end
 
-  defp handle_wasm(
-         {:wasm_call, %{"action" => "push", "id" => id, "payload" => payload}},
-         state
-       ) do
+  defp handle_wasm_call(%{"action" => "push", "id" => id, "payload" => payload}, _promise, state) do
     send_to_view(state, id, %Message{event: "js_push", payload: payload})
     {:resolve, :ok, state}
   end
 
-  defp handle_wasm(
-         {:wasm_call, %{"action" => "push_error", "id" => id, "payload" => payload}},
+  defp handle_wasm_call(
+         %{"action" => "push_error", "id" => id, "payload" => payload},
+         _promise,
          state
        ) do
     send_to_view(state, id, %Message{event: "push_error", payload: payload})
     {:resolve, :ok, state}
   end
 
-  defp handle_wasm(
-         {:wasm_call, %{"action" => "update_assigns", "id" => id, "assigns" => assigns}},
+  defp handle_wasm_call(
+         %{"action" => "update_assigns", "id" => id, "assigns" => assigns},
+         _promise,
          state
        ) do
     send_to_view(state, id, %Message{event: "update_assigns", payload: assigns})
     {:resolve, :ok, state}
   end
 
-  defp handle_wasm({:wasm_call, %{"action" => "destroy", "id" => id}}, state) do
+  defp handle_wasm_call(%{"action" => "destroy", "id" => id}, _promise, state) do
     # The host LiveView removed a mount point. Stop its process and forget it.
     case Map.get(state.views, id) do
       nil -> :ok
@@ -75,45 +94,45 @@ defmodule LocalLiveView.Dispatcher do
 
   # This event may be fired multiple times for the same view from JS,
   # in such case we only handle the first event.
-  defp handle_wasm({:wasm_call, %{"action" => "create", "id" => id} = msg}, state)
+  defp handle_wasm_call(%{"action" => "create", "id" => id} = msg, _promise, state)
        when not is_map_key(state.views, id) do
-    view = String.to_existing_atom("Elixir." <> Map.fetch!(msg, "view"))
+    view = String.to_atom("Elixir." <> Map.fetch!(msg, "view"))
 
     params =
       Map.take(msg, ~w"id assigns url url_params")
       |> Map.put("session", %Session{view: view})
 
     case start_local_live_view(params) do
-      {:ok, pid, rendered} ->
-        {:resolve, %{status: :ok, rendered: rendered}, put_in(state.views[id], pid)}
+      {:ok, pid} ->
+        {:resolve, :ok, put_in(state.views[id], pid)}
 
       :error ->
-        {:resolve, %{status: :error}, state}
+        {:reject, "error creating LLV", state}
     end
   end
 
-  defp handle_wasm({:wasm_call, %{"action" => "create"}}, state) do
-    {:resolve, %{status: :error}, state}
+  defp handle_wasm_call(%{"action" => "create"}, _promise, state) do
+    {:reject, "error creating LLV", state}
   end
 
-  defp handle_wasm(
-         {:wasm_call, %{"action" => "handle_params", "id" => id, "payload" => payload}},
+  defp handle_wasm_call(
+         %{"action" => "handle_params", "id" => id, "payload" => payload},
+         _promise,
          state
        ) do
     send_to_view(state, id, %Message{event: "handle_params", payload: payload})
     {:resolve, :ok, state}
   end
 
-  defp handle_wasm(
-         {:wasm_call, %{"action" => "event", "id" => id, "payload" => payload} = msg},
+  defp handle_wasm_call(
+         %{"action" => "server_message", "id" => id, "payload" => payload},
+         _promise,
          state
        ) do
-    # "ref" is the channel push ref from the browser's popcorn transport. The
-    # view acks the push through it — a reply carrying the render diff — which
-    # drives LiveView's regular push lifecycle (apply ack diff, undo element
-    # refs, resolve the reply). Absent for uncorrelated sends like
-    # llv_server_message.
-    send_to_view(state, id, %Message{payload: payload, event: "event", ref: msg["ref"]})
+    # Host-pushed llv_server_message: not a channel push, so there is no ack
+    # to carry the render — the view handles it like an event and pushes any
+    # resulting diff out-of-band (nil promise).
+    send_to_view(state, id, %Message{event: "event", payload: payload})
     {:resolve, :ok, state}
   end
 
@@ -131,10 +150,10 @@ defmodule LocalLiveView.Dispatcher do
     ref = make_ref()
 
     {:ok, pid} = LocalLiveView.Server.start_llv_process()
-    send(pid, {LocalLiveView.Server, params, {self(), ref}, %Phoenix.Socket{}})
+    send(pid, {LocalLiveView.Server, params, {self(), ref}})
 
     receive do
-      {^ref, {:ok, rendered}} -> {:ok, pid, rendered}
+      {^ref, :ok} -> {:ok, pid}
       {^ref, {:error, _reply}} -> :error
     end
   end

--- a/local-live-view/lib/local_live_view/dispatcher.ex
+++ b/local-live-view/lib/local_live_view/dispatcher.ex
@@ -105,10 +105,15 @@ defmodule LocalLiveView.Dispatcher do
   end
 
   defp handle_wasm(
-         {:wasm_call, %{"action" => "event", "id" => id, "payload" => payload}},
+         {:wasm_call, %{"action" => "event", "id" => id, "payload" => payload} = msg},
          state
        ) do
-    send_to_view(state, id, %Message{payload: payload, event: "event"})
+    # "ref" is the channel push ref from the browser's popcorn transport. The
+    # view acks the push through it — a reply carrying the render diff — which
+    # drives LiveView's regular push lifecycle (apply ack diff, undo element
+    # refs, resolve the reply). Absent for uncorrelated sends like
+    # llv_server_message.
+    send_to_view(state, id, %Message{payload: payload, event: "event", ref: msg["ref"]})
     {:resolve, :ok, state}
   end
 

--- a/local-live-view/lib/local_live_view/dispatcher.ex
+++ b/local-live-view/lib/local_live_view/dispatcher.ex
@@ -48,6 +48,14 @@ defmodule LocalLiveView.Dispatcher do
   end
 
   defp handle_wasm(
+         {:wasm_call, %{"action" => "push_error", "id" => id, "payload" => payload}},
+         state
+       ) do
+    send_to_view(state, id, %Message{event: "push_error", payload: payload})
+    {:resolve, :ok, state}
+  end
+
+  defp handle_wasm(
          {:wasm_call, %{"action" => "update_assigns", "id" => id, "assigns" => assigns}},
          state
        ) do

--- a/local-live-view/lib/local_live_view/local_live_view.ex
+++ b/local-live-view/lib/local_live_view/local_live_view.ex
@@ -94,6 +94,19 @@ defmodule LocalLiveView do
   updates the LocalLiveView's assigns: the local update is optimistic,
   then the server update can possibly override it.
 
+  ## Handling failed server pushes
+
+  A `push_server_event/3` can fail: the page may have no host LiveView,
+  the websocket may be disconnected, or the host may reply with an error
+  or time out. When that happens, the view's `c:handle_push_error/4`
+  callback is invoked with the event, its params and `server_assigns` —
+  the last value of each assign received from the host server. The
+  default implementation feeds `server_assigns` through `c:update/2`,
+  rolling optimistic local edits back to the latest authoritative state.
+
+  Note this covers only `push_server_event/3`; events dispatched via
+  `phx-target={@server}` are not tracked.
+
   Another way of communicating the server is by using `mirror_sync/2`.
   '''
 
@@ -159,6 +172,9 @@ defmodule LocalLiveView do
   `handle_event/3` or `handle_info/2` (so the payload can be computed — e.g. a
   drag result), it delivers `event`/`payload` to the host LiveView's
   `handle_event(event, payload, socket)` over the regular Phoenix websocket.
+
+  If the push fails (no host LiveView, disconnected socket, error reply or
+  timeout), the view's `c:handle_push_error/4` callback is invoked.
   """
   def push_server_event(%Socket{} = socket, event, payload \\ %{}) do
     Popcorn.Wasm.run_js(
@@ -209,7 +225,13 @@ defmodule LocalLiveView do
         {:noreply, socket}
       end
 
-      defoverridable handle_server_event: 3, update: 2, handle_info: 2
+      @impl true
+      def handle_push_error(_event, _params, server_assigns, socket) do
+        {:ok, socket} = update(server_assigns, socket)
+        {:noreply, socket}
+      end
+
+      defoverridable handle_server_event: 3, update: 2, handle_info: 2, handle_push_error: 4
     end
   end
 
@@ -299,5 +321,34 @@ defmodule LocalLiveView do
 
   @callback handle_info(message :: term, socket :: Socket.t()) :: {:noreply, Socket.t()}
 
-  @optional_callbacks mount: 3, update: 2, handle_event: 3, handle_info: 2, handle_params: 3
+  @doc """
+  Invoked when a `push_server_event/3` fails: there is no host LiveView on the
+  page, the websocket is disconnected, or the host replies with an error or
+  times out. Events dispatched via `phx-target={@server}` are not covered.
+
+  `event` and `params` are the event name and payload the failed push carried
+  (`params` has string keys, after a JSON round-trip, like `c:handle_event/3`
+  params). `server_assigns` holds the last value of each assign received from
+  the host server (through mount and `c:update/2`) — assigns only ever set
+  locally are absent.
+
+  The default implementation feeds `server_assigns` through `c:update/2`, as if
+  the host had re-sent them — restoring the latest authoritative state through
+  the view's usual derivation path. A view whose `c:update/2` skips unchanged
+  data (e.g. guarded by a revision counter) should override this callback and
+  force its rollback explicitly.
+  """
+  @callback handle_push_error(
+              event :: binary,
+              params :: unsigned_params(),
+              server_assigns :: map(),
+              socket :: Socket.t()
+            ) :: {:noreply, Socket.t()}
+
+  @optional_callbacks mount: 3,
+                      update: 2,
+                      handle_event: 3,
+                      handle_info: 2,
+                      handle_params: 3,
+                      handle_push_error: 4
 end

--- a/local-live-view/lib/local_live_view/local_live_view.ex
+++ b/local-live-view/lib/local_live_view/local_live_view.ex
@@ -96,16 +96,15 @@ defmodule LocalLiveView do
 
   ## Handling failed server pushes
 
-  A `push_server_event/3` can fail: the page may have no host LiveView,
-  the websocket may be disconnected, or the host may reply with an error
-  or time out. When that happens, the view's `c:handle_push_error/4`
-  callback is invoked with the event, its params and `server_assigns` —
-  the last value of each assign received from the host server. The
-  default implementation feeds `server_assigns` through `c:update/2`,
-  rolling optimistic local edits back to the latest authoritative state.
-
-  Note this covers only `push_server_event/3`; events dispatched via
-  `phx-target={@server}` are not tracked.
+  A push to the server — `push_server_event/3` or an event dispatched via
+  `phx-target={@server}` (including the `@server` leg of `targets/1`) — can
+  fail: the page may have no host LiveView, the websocket may be
+  disconnected, or the host may reply with an error or time out. When that
+  happens, the view's `c:handle_push_error/4` callback is invoked with the
+  event, its params and `server_assigns` — the last value of each assign
+  received from the host server. The default implementation feeds
+  `server_assigns` through `c:update/2`, rolling optimistic local edits back
+  to the latest authoritative state.
 
   Another way of communicating the server is by using `mirror_sync/2`.
   '''

--- a/local-live-view/lib/local_live_view/local_live_view.ex
+++ b/local-live-view/lib/local_live_view/local_live_view.ex
@@ -71,40 +71,32 @@ defmodule LocalLiveView do
 
   ## Sending events to the server
 
-  When a local live view is rendered inside a `Phoenix.LiveView`,
-  it's possible to send events to that server-side live view, by using
-  `phx-target={@server}`, for example:
+  When a local live view is rendered inside a `Phoenix.LiveView`, it can
+  send events to that server-side live view by calling `push_server_event/3`
+  from `c:Phoenix.LiveView.handle_event/3` or `c:handle_info/2`:
 
   ```
-  <button phx-click="archive" phx-target={@server}>Archive</button>
+  def handle_event("archive", %{"id" => id}, socket) do
+    {:noreply,
+     socket
+     |> assign(:items, archive_item(socket.assigns.items, id))
+     |> push_server_event("archive", %{"id" => id})}
+  end
   ```
 
-  or by calling `push_server_event/3`.
-
-  Events can be sent to multiple targets with `targets/1`.
-  For example, to send an event to the LocalLiveView itself _and_ the server,
-  set the target to `targets([@default, @server])`:
-
-  ```
-  <button phx-click="archive" phx-target={targets([@default, @server])}>Archive</button>
-  ```
-
-  This approach is useful for optimistic updates. The event is first
-  handled locally, then it's also handled on the server. Each of them
-  updates the LocalLiveView's assigns: the local update is optimistic,
-  then the server update can possibly override it.
+  This pattern gives optimistic updates: the event is handled locally
+  first (the optimistic edit), then delivered to the host LiveView's
+  `handle_event/3`, whose authoritative state can later override it.
 
   ## Handling failed server pushes
 
-  A push to the server — `push_server_event/3` or an event dispatched via
-  `phx-target={@server}` (including the `@server` leg of `targets/1`) — can
-  fail: the page may have no host LiveView, the websocket may be
-  disconnected, or the host may reply with an error or time out. When that
-  happens, the view's `c:handle_push_error/4` callback is invoked with the
-  event, its params and `server_assigns` — the last value of each assign
-  received from the host server. The default implementation feeds
-  `server_assigns` through `c:update/2`, rolling optimistic local edits back
-  to the latest authoritative state.
+  A `push_server_event/3` can fail: the page may have no host LiveView,
+  the websocket may be disconnected, or the host may reply with an error
+  or time out. When that happens, the view's `c:handle_push_error/4`
+  callback is invoked with the event, its params and `server_assigns` —
+  the last value of each assign received from the host server. The
+  default implementation feeds `server_assigns` through `c:update/2`,
+  rolling optimistic local edits back to the latest authoritative state.
 
   Another way of communicating the server is by using `mirror_sync/2`.
   '''
@@ -145,32 +137,12 @@ defmodule LocalLiveView do
   """
   def connected?(_socket), do: true
 
-  # Delimiter joining composed phx-target tokens (see targets/1). ASCII Unit
-  # Separator — it never appears in a CSS selector or cid, so the JS can split it
-  # back unambiguously. Keep in sync with LLV_TARGET_SEP in assets/local_live_view.js.
-  @target_sep "\x1f"
-
-  @doc """
-  Composes a `phx-target` from a list of targets.
-
-  Combine the `@default` (local, as if no target) and `@server` (host LiveView)
-  assigns with each other and/or ordinary `phx-target` selectors/cids, dispatching
-  the event to every target in the list:
-
-      <button phx-click="save" phx-target={targets([@default, @server])}>Save</button>
-      <button phx-click="ping" phx-target={targets([@default, @server, "#cart"])}>Ping</button>
-
-  A single target needs no helper — `phx-target={@server}` works on its own.
-  """
-  def targets(list) when is_list(list), do: Enum.map_join(list, @target_sep, &to_string/1)
-
   @doc """
   Sends an event to the host (server) `LiveView` that mounts this local live view.
 
-  The programmatic counterpart of `phx-target={@server}`: callable from
-  `handle_event/3` or `handle_info/2` (so the payload can be computed — e.g. a
-  drag result), it delivers `event`/`payload` to the host LiveView's
-  `handle_event(event, payload, socket)` over the regular Phoenix websocket.
+  Callable from `handle_event/3` or `handle_info/2`, it delivers
+  `event`/`payload` to the host LiveView's `handle_event(event, payload, socket)`
+  over the regular Phoenix websocket.
 
   If the push fails (no host LiveView, disconnected socket, error reply or
   timeout), the view's `c:handle_push_error/4` callback is invoked.
@@ -196,7 +168,7 @@ defmodule LocalLiveView do
 
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts] do
-      import LocalLiveView, only: [mirror_sync: 2, targets: 1, push_server_event: 3]
+      import LocalLiveView, only: [mirror_sync: 2, push_server_event: 2, push_server_event: 3]
       @behaviour LocalLiveView
       @before_compile Phoenix.LiveView.Renderer
       @phoenix_live_opts []
@@ -323,7 +295,7 @@ defmodule LocalLiveView do
   @doc """
   Invoked when a `push_server_event/3` fails: there is no host LiveView on the
   page, the websocket is disconnected, or the host replies with an error or
-  times out. Events dispatched via `phx-target={@server}` are not covered.
+  times out.
 
   `event` and `params` are the event name and payload the failed push carried
   (`params` has string keys, after a JSON round-trip, like `c:handle_event/3`

--- a/local-live-view/lib/local_live_view/server.ex
+++ b/local-live-view/lib/local_live_view/server.ex
@@ -115,9 +115,22 @@ defmodule LocalLiveView.Server do
 
   def handle_info(%Message{event: "update_assigns", payload: assigns}, %{socket: socket} = state) do
     # The host LiveView re-rendered with new assigns for this view: run its
-    # update/2 and push the resulting diff.
+    # update/2 and push the resulting diff. data-pop-assigns carries the full
+    # set of host-forwarded assigns each render, so it replaces server_assigns.
+    assigns = normalize_assigns(assigns)
     new_socket = call_update!(socket.view, assigns, socket)
-    handle_changed(state, new_socket, nil)
+    handle_changed(%{state | server_assigns: assigns}, new_socket, nil)
+  end
+
+  def handle_info(
+        %Message{event: "push_error", payload: %{"event" => event, "payload" => params}},
+        %{socket: socket} = state
+      ) do
+    # A push_server_event failed to reach the host: hand the view the last
+    # assigns received from it, so it can roll back to authoritative state.
+    event
+    |> socket.view.handle_push_error(params, state.server_assigns, socket)
+    |> handle_result({:handle_push_error, 4, nil}, state)
   end
 
   def handle_info({:phoenix, :send_update, update}, state) do
@@ -184,10 +197,10 @@ defmodule LocalLiveView.Server do
     view.handle_info(msg, socket)
   end
 
-  # Run the view's update/2 for the (JSON, string-keyed) assigns the host passed,
-  # raising on a bad return. Returns the updated %Socket{}.
+  # Run the view's update/2 for the host-passed assigns (already normalized by
+  # the caller), raising on a bad return. Returns the updated %Socket{}.
   defp call_update!(view, assigns, %Socket{} = socket) do
-    case view.update(normalize_assigns(assigns), socket) do
+    case view.update(assigns, socket) do
       {:ok, %Socket{} = socket} ->
         socket
 
@@ -521,7 +534,7 @@ defmodule LocalLiveView.Server do
     # Assigns passed via the `<.local_live_view assigns... />` component reach us
     # here as a string-keyed map. They become the first argument to the view's
     # mount/3 callback and are then fed through its update/2.
-    initial_assigns = params["assigns"] || %{}
+    initial_assigns = normalize_assigns(params["assigns"] || %{})
     llv_id = params["id"]
 
     socket = %Socket{
@@ -552,7 +565,7 @@ defmodule LocalLiveView.Server do
             |> then(&call_update!(view, initial_assigns, &1))
 
           mounted_socket
-          |> build_state(phx_socket, llv_id)
+          |> build_state(phx_socket, llv_id, initial_assigns)
           |> maybe_call_mount_handle_params(params)
           |> reply_mount(from, verified)
         rescue
@@ -621,7 +634,7 @@ defmodule LocalLiveView.Server do
     end
   end
 
-  defp build_state(%Socket{} = lv_socket, %Phoenix.Socket{} = phx_socket, llv_id) do
+  defp build_state(%Socket{} = lv_socket, %Phoenix.Socket{} = phx_socket, llv_id, server_assigns) do
     %{
       join_ref: phx_socket.join_ref,
       serializer: phx_socket.serializer,
@@ -632,7 +645,11 @@ defmodule LocalLiveView.Server do
       redirect_count: 0,
       upload_names: %{},
       upload_pids: %{},
-      llv_id: llv_id
+      llv_id: llv_id,
+      # Last (normalized) assigns received from the host, for handle_push_error.
+      # Updated only on mount and "update_assigns"; if the mirror channel's
+      # "set_assigns" push ever gets a JS consumer, it must update this too.
+      server_assigns: server_assigns
     }
   end
 

--- a/local-live-view/lib/local_live_view/server.ex
+++ b/local-live-view/lib/local_live_view/server.ex
@@ -123,11 +123,15 @@ defmodule LocalLiveView.Server do
   end
 
   def handle_info(
-        %Message{event: "push_error", payload: %{"event" => event, "payload" => params}},
+        %Message{event: "push_error", payload: %{"event" => event, "payload" => raw} = payload},
         %{socket: socket} = state
       ) do
-    # A push_server_event failed to reach the host: hand the view the last
-    # assigns received from it, so it can roll back to authoritative state.
+    # A local→server push (push_server_event or a @server-targeted DOM event)
+    # failed to reach the host: hand the view the last assigns received from
+    # it, so it can roll back to authoritative state. Form pushes carry their
+    # params URL-encoded, same as regular events.
+    params = decode_event_type(payload["type"], raw, payload)
+
     event
     |> socket.view.handle_push_error(params, state.server_assigns, socket)
     |> handle_result({:handle_push_error, 4, nil}, state)

--- a/local-live-view/lib/local_live_view/server.ex
+++ b/local-live-view/lib/local_live_view/server.ex
@@ -120,7 +120,8 @@ defmodule LocalLiveView.Server do
           {rendered, %{state | initial_rendered: nil}}
       end
 
-    {:noreply, reply(state, msg.promise, :ok, %{rendered: rendered})}
+    reply(msg.promise, :ok, %{rendered: rendered})
+    {:noreply, state}
   end
 
   # Component-destruction bookkeeping, mirroring Phoenix.LiveView.Channel: the
@@ -133,7 +134,8 @@ defmodule LocalLiveView.Server do
     components =
       Enum.reduce(cids, state.components, &Diff.mark_for_deletion_component/2)
 
-    {:noreply, reply(%{state | components: components}, msg.promise, :ok, %{})}
+    reply(msg.promise, :ok, %{})
+    {:noreply, %{state | components: components}}
   end
 
   def handle_info(
@@ -145,7 +147,8 @@ defmodule LocalLiveView.Server do
 
     # The ack carries the cids actually deleted; the browser prunes exactly
     # those from its rendered tree (a cid re-added mid-flight is kept).
-    {:noreply, reply(%{state | components: components}, msg.promise, :ok, %{cids: deleted_cids})}
+    reply(msg.promise, :ok, %{cids: deleted_cids})
+    {:noreply, %{state | components: components}}
   end
 
   def handle_info(
@@ -181,7 +184,9 @@ defmodule LocalLiveView.Server do
   def handle_info({:phoenix, :send_update, update}, state) do
     case Diff.update_component(state.socket, state.components, update) do
       {diff, new_components} ->
-        {:noreply, push_diff(%{state | components: new_components}, diff, nil)}
+        new_state = %{state | components: new_components}
+        push_diff(new_state, diff, nil)
+        {:noreply, new_state}
 
       :noop ->
         {:noreply, state}
@@ -209,10 +214,13 @@ defmodule LocalLiveView.Server do
 
     case result do
       {diff, new_components, _extra} ->
-        {:noreply, push_diff(%{state | components: new_components}, diff, promise)}
+        new_state = %{state | components: new_components}
+        push_diff(new_state, diff, promise)
+        {:noreply, new_state}
 
       :error ->
-        {:noreply, push_noop(state, promise)}
+        push_noop(promise)
+        {:noreply, state}
     end
   end
 
@@ -396,10 +404,9 @@ defmodule LocalLiveView.Server do
 
     case maybe_diff(new_state, false) do
       {:diff, diff, new_state} ->
-        {:noreply,
-         new_state
-         |> clear_live_patch_counter()
-         |> push_diff(diff, promise)}
+        new_state = clear_live_patch_counter(new_state)
+        push_diff(new_state, diff, promise)
+        {:noreply, new_state}
 
       {:live, :patch, opts} ->
         handle_live_patch(new_state, opts, promise)
@@ -456,15 +463,11 @@ defmodule LocalLiveView.Server do
     %{state | redirect_count: 0}
   end
 
-  defp push_noop(state, nil = _promise), do: state
-  defp push_noop(state, promise), do: reply(state, promise, :ok, %{})
+  defp push_noop(nil = _promise), do: :ok
+  defp push_noop(promise), do: reply(promise, :ok, %{})
 
-  defp push_diff(state, diff, promise) when diff == %{}, do: push_noop(state, promise)
+  defp push_diff(_state, diff, promise) when diff == %{}, do: push_noop(promise)
 
-  # Out-of-band diff (handle_info renders, update_assigns, push_error
-  # rollbacks, server messages — nothing answering a browser frame): injected
-  # browser-side as a channel "diff" frame, handled exactly like a
-  # server-pushed diff.
   defp push_diff(state, diff, nil = _promise) do
     Popcorn.Wasm.run_js(
       """
@@ -475,10 +478,10 @@ defmodule LocalLiveView.Server do
       %{id: state.llv_id, diff: diff}
     )
 
-    state
+    :ok
   end
 
-  defp push_diff(state, diff, promise), do: reply(state, promise, :ok, %{diff: diff})
+  defp push_diff(_state, diff, promise), do: reply(promise, :ok, %{diff: diff})
 
   defp maybe_diff(%{socket: socket} = state, force?) do
     socket.redirected || render_diff(state, socket, force?)
@@ -519,14 +522,9 @@ defmodule LocalLiveView.Server do
     Phoenix.LiveView.Renderer.to_rendered(socket, socket.view)
   end
 
-  # Answer a browser frame by settling its popcorn.call promise (threaded
-  # through Message.promise by the dispatcher). The browser transport turns
-  # the resolved {status, payload} — %{diff: diff} or %{} for a no-op —
-  # into the channel push ack, driving LiveView's stock push lifecycle:
-  # apply the ack diff, undo the push's element refs, resolve the reply.
-  defp reply(state, promise, status, payload) do
+  defp reply(promise, status, payload) do
     Popcorn.Wasm.resolve(%{status: status, payload: payload}, promise)
-    state
+    :ok
   end
 
   ## Mount
@@ -548,7 +546,10 @@ defmodule LocalLiveView.Server do
   end
 
   defp mount(%{} = params, from) do
-    Logger.error("Mounting LocalLiveView #{inspect(params["id"])} failed because no session was provided")
+    Logger.error(
+      "Mounting LocalLiveView #{inspect(params["id"])} failed because no session was provided"
+    )
+
     GenServer.reply(from, {:error, %{reason: "stale"}})
     {:stop, :shutdown, :no_session}
   end

--- a/local-live-view/lib/local_live_view/server.ex
+++ b/local-live-view/lib/local_live_view/server.ex
@@ -449,6 +449,12 @@ defmodule LocalLiveView.Server do
         {socket, %{}, state.fingerprints, state.components}
       end
 
+    # Same as Phoenix.LiveView.Channel: fold the handle_event reply (:r) and
+    # push_event events (:e) into the diff — even when nothing re-rendered —
+    # so the browser's Rendered.extract delivers them. clear_temp below
+    # ensures they ride at most one diff.
+    diff = Diff.render_private(socket, diff)
+
     new_socket = Utils.clear_temp(socket)
 
     {:diff, diff,
@@ -463,11 +469,30 @@ defmodule LocalLiveView.Server do
     reply(state, ref, status, Map.merge(payload, extra))
   end
 
-  defp reply(state, _ref, _status, %{diff: diff}) do
-    push(state, "diff", diff)
-  end
+  # Safety net: an uncorrelated diff still reaches the page out-of-band.
+  # push_diff routes nil refs to push/3 directly, so these normally don't hit.
+  defp reply(state, nil = _ref, _status, %{diff: diff}), do: push(state, "diff", diff)
+  defp reply(state, nil = _ref, _status, _payload), do: state
 
-  defp reply(state, _ref, _status, _payload), do: state
+  # Ack a correlated push (ref = the browser transport's channel push ref,
+  # threaded through Message.ref by the dispatcher). The payload — %{diff: diff}
+  # or %{} for a no-op — resolves the pending channel push in the browser,
+  # driving LiveView's stock push lifecycle: apply the ack diff, undo the
+  # push's element refs, resolve the reply.
+  defp reply(state, ref, status, payload) do
+    Popcorn.Wasm.run_js(
+      """
+      ({ args }) => {
+        if (window.__llvChannelReply) {
+          window.__llvChannelReply(args.id, args.ref, args.status, args.payload);
+        }
+      }
+      """,
+      %{id: state.llv_id, ref: ref, status: status, payload: payload}
+    )
+
+    state
+  end
 
   defp push(state, "diff", diff) do
     llv_id = state.llv_id

--- a/local-live-view/lib/local_live_view/server.ex
+++ b/local-live-view/lib/local_live_view/server.ex
@@ -1,6 +1,9 @@
 defmodule LocalLiveView.Message do
   @moduledoc false
-  defstruct topic: nil, event: nil, payload: nil, ref: nil, join_ref: nil
+  # `promise` is the popcorn.call promise of the browser frame this message
+  # answers (settled via Popcorn.Wasm.resolve when processed); nil for
+  # uncorrelated sends.
+  defstruct event: nil, payload: nil, promise: nil
 end
 
 defmodule LocalLiveView.Server do
@@ -31,12 +34,6 @@ defmodule LocalLiveView.Server do
 
   alias LocalLiveView.Message
 
-  # Sentinels seeded into every view's @default / @server assigns; the
-  # LocalLiveView JS recognizes these exact values (keep in sync with
-  # LLV_DEFAULT_TARGET / LLV_SERVER_TARGET in assets/local_live_view.js).
-  @default_target "__llv_default__"
-  @server_target "__llv_server__"
-
   @doc """
   Starts LocalLiveView.Server process.
   """
@@ -58,9 +55,9 @@ defmodule LocalLiveView.Server do
   end
 
   @impl true
-  def handle_info({LocalLiveView.Server, params, from, phx_socket}, _ref) do
+  def handle_info({LocalLiveView.Server, params, from}, _ref) do
     try do
-      mount(params, from, phx_socket)
+      mount(params, from)
     rescue
       e ->
         reraise(e, __STACKTRACE__)
@@ -84,9 +81,7 @@ defmodule LocalLiveView.Server do
   end
 
   def handle_info(%Message{event: "llv_reconnected"}, state) do
-    # The seeded @default / @server target sentinels are runtime plumbing, not
-    # view state — keep them out of the mirror resync.
-    keys = Map.keys(state.socket.assigns) -- [:default, :server]
+    keys = Map.keys(state.socket.assigns)
     LocalLiveView.mirror_sync(state.socket, keys)
     {:noreply, state}
   end
@@ -96,12 +91,61 @@ defmodule LocalLiveView.Server do
     val = decode_event_type(type, raw_val, msg.payload)
 
     if cid = msg.payload["cid"] do
-      component_handle_event(state, cid, event, val, msg.ref)
+      component_handle_event(state, cid, event, val, msg.promise)
     else
       state.socket
       |> view_handle_event(event, val)
-      |> handle_result({:handle_event, 3, msg.ref}, state)
+      |> handle_result({:handle_event, 3, msg.promise}, state)
     end
+  end
+
+  def handle_info(%Message{event: "phx_join"} = msg, state) do
+    # The channel join ack carries the rendered produced at mount. On a rejoin
+    # (channel error recovery) that's already consumed — serve a fresh full
+    # render instead, resetting diff tracking to match the client's clean
+    # slate.
+    {rendered, state} =
+      case state.initial_rendered do
+        nil ->
+          state = %{
+            state
+            | fingerprints: Diff.new_fingerprints(),
+              components: Diff.new_components()
+          }
+
+          {:diff, diff, state} = render_diff(state, state.socket, true)
+          {diff, state}
+
+        rendered ->
+          {rendered, %{state | initial_rendered: nil}}
+      end
+
+    {:noreply, reply(state, msg.promise, :ok, %{rendered: rendered})}
+  end
+
+  # Component-destruction bookkeeping, mirroring Phoenix.LiveView.Channel: the
+  # browser announces cids about to leave the DOM, then confirms removal. Without
+  # the prune, state.components would retain dead component state forever.
+  def handle_info(
+        %Message{event: "cids_will_destroy", payload: %{"cids" => cids}} = msg,
+        state
+      ) do
+    components =
+      Enum.reduce(cids, state.components, &Diff.mark_for_deletion_component/2)
+
+    {:noreply, reply(%{state | components: components}, msg.promise, :ok, %{})}
+  end
+
+  def handle_info(
+        %Message{event: "cids_destroyed", payload: %{"cids" => cids}} = msg,
+        state
+      ) do
+    {deleted_cids, components} =
+      Enum.flat_map_reduce(cids, state.components, &Diff.delete_component/2)
+
+    # The ack carries the cids actually deleted; the browser prunes exactly
+    # those from its rendered tree (a cid re-added mid-flight is kept).
+    {:noreply, reply(%{state | components: components}, msg.promise, :ok, %{cids: deleted_cids})}
   end
 
   def handle_info(
@@ -123,15 +167,12 @@ defmodule LocalLiveView.Server do
   end
 
   def handle_info(
-        %Message{event: "push_error", payload: %{"event" => event, "payload" => raw} = payload},
+        %Message{event: "push_error", payload: %{"event" => event, "payload" => params}},
         %{socket: socket} = state
       ) do
-    # A local→server push (push_server_event or a @server-targeted DOM event)
-    # failed to reach the host: hand the view the last assigns received from
-    # it, so it can roll back to authoritative state. Form pushes carry their
-    # params URL-encoded, same as regular events.
-    params = decode_event_type(payload["type"], raw, payload)
-
+    # A push_server_event failed to reach the host: hand the view the last
+    # assigns received from it, so it can roll back to authoritative state.
+    # `params` is the exact map the view passed to push_server_event.
     event
     |> socket.view.handle_push_error(params, state.server_assigns, socket)
     |> handle_result({:handle_push_error, 4, nil}, state)
@@ -157,7 +198,7 @@ defmodule LocalLiveView.Server do
     {:noreply, do_handle_event(socket.view, socket, event, val)}
   end
 
-  defp component_handle_event(state, cid, event, val, ref) do
+  defp component_handle_event(state, cid, event, val, promise) do
     %{socket: socket, components: components} = state
 
     result =
@@ -168,10 +209,10 @@ defmodule LocalLiveView.Server do
 
     case result do
       {diff, new_components, _extra} ->
-        {:noreply, push_diff(%{state | components: new_components}, diff, ref)}
+        {:noreply, push_diff(%{state | components: new_components}, diff, promise)}
 
       :error ->
-        {:noreply, push_noop(state, ref)}
+        {:noreply, push_noop(state, promise)}
     end
   end
 
@@ -304,8 +345,8 @@ defmodule LocalLiveView.Server do
     end
   end
 
-  defp handle_result({:noreply, %Socket{} = new_socket}, {_from, _arity, ref}, state) do
-    handle_changed(state, new_socket, ref)
+  defp handle_result({:noreply, %Socket{} = new_socket}, {_from, _arity, promise}, state) do
+    handle_changed(state, new_socket, promise)
   end
 
   defp handle_result(result, {name, arity, _ref}, state) do
@@ -350,7 +391,7 @@ defmodule LocalLiveView.Server do
     """
   end
 
-  defp handle_changed(state, %Socket{} = new_socket, ref, pending_live_patch \\ nil) do
+  defp handle_changed(state, %Socket{} = new_socket, promise) do
     new_state = %{state | socket: new_socket}
 
     case maybe_diff(new_state, false) do
@@ -358,18 +399,17 @@ defmodule LocalLiveView.Server do
         {:noreply,
          new_state
          |> clear_live_patch_counter()
-         |> push_live_patch(pending_live_patch)
-         |> push_diff(diff, ref)}
+         |> push_diff(diff, promise)}
 
       {:live, :patch, opts} ->
-        handle_live_patch(new_state, opts, ref)
+        handle_live_patch(new_state, opts, promise)
 
       _result ->
         {:noreply, state}
     end
   end
 
-  defp handle_live_patch(state, opts, ref) do
+  defp handle_live_patch(state, opts, promise) do
     to = opts.to
     replace = opts.kind == :replace
 
@@ -390,7 +430,7 @@ defmodule LocalLiveView.Server do
     if lifecycle.any? do
       socket
       |> call_handle_params(view, lifecycle.exported?, url_params, to)
-      |> handle_result({:handle_params, 3, ref}, new_state)
+      |> handle_result({:handle_params, 3, promise}, new_state)
     else
       {:noreply, new_state}
     end
@@ -416,15 +456,29 @@ defmodule LocalLiveView.Server do
     %{state | redirect_count: 0}
   end
 
-  defp push_live_patch(state, nil), do: state
-  defp push_live_patch(state, opts), do: push(state, "live_patch", opts)
+  defp push_noop(state, nil = _promise), do: state
+  defp push_noop(state, promise), do: reply(state, promise, :ok, %{})
 
-  defp push_noop(state, nil = _ref), do: state
-  defp push_noop(state, ref), do: reply(state, ref, :ok, %{})
+  defp push_diff(state, diff, promise) when diff == %{}, do: push_noop(state, promise)
 
-  defp push_diff(state, diff, ref) when diff == %{}, do: push_noop(state, ref)
-  defp push_diff(state, diff, nil = _ref), do: push(state, "diff", diff)
-  defp push_diff(state, diff, ref), do: reply(state, ref, :ok, %{diff: diff})
+  # Out-of-band diff (handle_info renders, update_assigns, push_error
+  # rollbacks, server messages — nothing answering a browser frame): injected
+  # browser-side as a channel "diff" frame, handled exactly like a
+  # server-pushed diff.
+  defp push_diff(state, diff, nil = _promise) do
+    Popcorn.Wasm.run_js(
+      """
+      ({ args }) => {
+        window.__popcornTransportReceive(args.id, args.diff);
+      }
+      """,
+      %{id: state.llv_id, diff: diff}
+    )
+
+    state
+  end
+
+  defp push_diff(state, diff, promise), do: reply(state, promise, :ok, %{diff: diff})
 
   defp maybe_diff(%{socket: socket} = state, force?) do
     socket.redirected || render_diff(state, socket, force?)
@@ -465,63 +519,26 @@ defmodule LocalLiveView.Server do
     Phoenix.LiveView.Renderer.to_rendered(socket, socket.view)
   end
 
-  defp reply(state, {ref, extra}, status, payload) do
-    reply(state, ref, status, Map.merge(payload, extra))
-  end
-
-  # Safety net: an uncorrelated diff still reaches the page out-of-band.
-  # push_diff routes nil refs to push/3 directly, so these normally don't hit.
-  defp reply(state, nil = _ref, _status, %{diff: diff}), do: push(state, "diff", diff)
-  defp reply(state, nil = _ref, _status, _payload), do: state
-
-  # Ack a correlated push (ref = the browser transport's channel push ref,
-  # threaded through Message.ref by the dispatcher). The payload — %{diff: diff}
-  # or %{} for a no-op — resolves the pending channel push in the browser,
-  # driving LiveView's stock push lifecycle: apply the ack diff, undo the
-  # push's element refs, resolve the reply.
-  defp reply(state, ref, status, payload) do
-    Popcorn.Wasm.run_js(
-      """
-      ({ args }) => {
-        if (window.__llvChannelReply) {
-          window.__llvChannelReply(args.id, args.ref, args.status, args.payload);
-        }
-      }
-      """,
-      %{id: state.llv_id, ref: ref, status: status, payload: payload}
-    )
-
+  # Answer a browser frame by settling its popcorn.call promise (threaded
+  # through Message.promise by the dispatcher). The browser transport turns
+  # the resolved {status, payload} — %{diff: diff} or %{} for a no-op —
+  # into the channel push ack, driving LiveView's stock push lifecycle:
+  # apply the ack diff, undo the push's element refs, resolve the reply.
+  defp reply(state, promise, status, payload) do
+    Popcorn.Wasm.resolve(%{status: status, payload: payload}, promise)
     state
   end
-
-  defp push(state, "diff", diff) do
-    llv_id = state.llv_id
-
-    Popcorn.Wasm.run_js(
-      """
-      ({ args }) => {
-        window.__popcornTransportReceive(args.id, args.diff);
-      }
-      """,
-      %{id: llv_id, diff: diff}
-    )
-
-    state
-  end
-
-  defp push(state, _event, _payload), do: state
 
   ## Mount
 
-  defp mount(%{"session" => session} = params, from, phx_socket) do
+  defp mount(%{"session" => session} = params, from) do
     with %Phoenix.LiveView.Session{view: view} <- session,
          {:ok, config} <- load_live_view(view) do
       verified_mount(
         session,
         config,
         params,
-        from,
-        phx_socket
+        from
       )
     else
       {:error, _reason} ->
@@ -530,8 +547,8 @@ defmodule LocalLiveView.Server do
     end
   end
 
-  defp mount(%{}, from, phx_socket) do
-    Logger.error("Mounting #{phx_socket.topic} failed because no session was provided")
+  defp mount(%{} = params, from) do
+    Logger.error("Mounting LocalLiveView #{inspect(params["id"])} failed because no session was provided")
     GenServer.reply(from, {:error, %{reason: "stale"}})
     {:stop, :shutdown, :no_session}
   end
@@ -548,13 +565,11 @@ defmodule LocalLiveView.Server do
     _ -> {:error, :stale}
   end
 
-  #
   defp verified_mount(
          %Session{} = verified,
          config,
          params,
-         from,
-         phx_socket
+         from
        ) do
     %Session{
       view: view
@@ -583,18 +598,15 @@ defmodule LocalLiveView.Server do
         }
 
         try do
-          # Seed the @default / @server target sentinels, run mount/3 (params are
-          # the host-passed assigns), then feed those assigns through update/2,
-          # LiveComponent-style.
+          # Run mount/3 (params are the host-passed assigns), then feed those
+          # assigns through update/2, LiveComponent-style.
           mounted_socket =
             %Socket{socket | view: view}
-            |> Phoenix.Component.assign(:default, @default_target)
-            |> Phoenix.Component.assign(:server, @server_target)
             |> Utils.maybe_call_live_view_mount!(view, params, verified)
             |> then(&call_update!(view, initial_assigns, &1))
 
           mounted_socket
-          |> build_state(phx_socket, llv_id, initial_assigns)
+          |> build_state(llv_id, initial_assigns)
           |> maybe_call_mount_handle_params(params)
           |> reply_mount(from, verified)
         rescue
@@ -639,8 +651,8 @@ defmodule LocalLiveView.Server do
     case result do
       {:ok, diff, :mount, new_state} ->
         reply = put_container(session, nil, diff)
-        GenServer.reply(from, {:ok, reply})
-        {:noreply, post_verified_mount(new_state)}
+        GenServer.reply(from, :ok)
+        {:noreply, post_verified_mount(%{new_state | initial_rendered: reply})}
 
       {:ok, diff, {:live_patch, opts}, new_state} ->
         reply =
@@ -650,8 +662,8 @@ defmodule LocalLiveView.Server do
             liveview_version: lv_vsn
           })
 
-        GenServer.reply(from, {:ok, reply})
-        {:noreply, post_verified_mount(new_state)}
+        GenServer.reply(from, :ok)
+        {:noreply, post_verified_mount(%{new_state | initial_rendered: reply})}
 
       {:live_redirect, opts, new_state} ->
         GenServer.reply(from, {:error, %{live_redirect: opts}})
@@ -663,18 +675,15 @@ defmodule LocalLiveView.Server do
     end
   end
 
-  defp build_state(%Socket{} = lv_socket, %Phoenix.Socket{} = phx_socket, llv_id, server_assigns) do
+  defp build_state(%Socket{} = lv_socket, llv_id, server_assigns) do
     %{
-      join_ref: phx_socket.join_ref,
-      serializer: phx_socket.serializer,
       socket: lv_socket,
-      topic: phx_socket.topic,
       components: Diff.new_components(),
       fingerprints: Diff.new_fingerprints(),
       redirect_count: 0,
-      upload_names: %{},
-      upload_pids: %{},
       llv_id: llv_id,
+      # The mount rendered, held until the channel join ack consumes it.
+      initial_rendered: nil,
       # Last (normalized) assigns received from the host, for handle_push_error.
       # Updated only on mount and "update_assigns"; if the mirror channel's
       # "set_assigns" push ever gets a JS consumer, it must update this too.

--- a/local-live-view/lib/mix/tasks/llv.install.ex
+++ b/local-live-view/lib/mix/tasks/llv.install.ex
@@ -222,7 +222,7 @@ defmodule Mix.Tasks.Llv.Install do
 
   @llv_js """
   import { LLVEngine } from "local_live_view";
-  await LLVEngine.create(liveSocket, { Socket, bundlePaths: ["/assets/js/wasm/bundle.avm"] });
+  await LLVEngine.create(liveSocket, { bundlePaths: ["/assets/js/wasm/bundle.avm"] });
   """
 
   defp inject_app_js(igniter) do

--- a/local-live-view/lib/server/component.ex
+++ b/local-live-view/lib/server/component.ex
@@ -84,6 +84,13 @@ defmodule LocalLiveView.Component do
       phx-update="ignore"
     >
     </div>
+    <%!-- Event bus for local→server pushes (push_server_event): the browser
+          runtime sends them through this element's hook, whose mounted /
+          destroyed lifecycle tracks the host LiveView across reconnects and
+          re-renders. A sibling (not a child) of the mount point, so the host
+          LiveView owns it. Renders inert on pages without a host. --%>
+    <div id={"#{@id}-llv-event-bus"} data-llv-event-bus-for={@id} phx-hook="LocalLiveViewEventBus" hidden>
+    </div>
     """
   end
 

--- a/local-live-view/lib/server/component.ex
+++ b/local-live-view/lib/server/component.ex
@@ -84,11 +84,7 @@ defmodule LocalLiveView.Component do
       phx-update="ignore"
     >
     </div>
-    <%!-- Event bus for local→server pushes (push_server_event): the browser
-          runtime sends them through this element's hook, whose mounted /
-          destroyed lifecycle tracks the host LiveView across reconnects and
-          re-renders. A sibling (not a child) of the mount point, so the host
-          LiveView owns it. Renders inert on pages without a host. --%>
+    <%!-- Stub for sending events from client to server. See LLVEngine class. --%>
     <div id={"#{@id}-llv-event-bus"} data-llv-event-bus-for={@id} phx-hook="LocalLiveViewEventBus" hidden>
     </div>
     """

--- a/local-live-view/priv/static/local_live_view.d.ts
+++ b/local-live-view/priv/static/local_live_view.d.ts
@@ -1,10 +1,7 @@
 import { Popcorn } from '@swmansion/popcorn';
 import { LiveSocketInstanceInterface } from 'phoenix_live_view';
-import { Socket } from 'phoenix';
 
 interface LLVConfig {
-    /** Phoenix Socket class — required when using mirror channels */
-    Socket?: typeof Socket;
     /** Paths to compiled WASM bundle files. Defaults to `["wasm/bundle.avm"]` */
     bundlePaths?: string[];
     /** Enable Popcorn debug logging */
@@ -47,7 +44,7 @@ declare class PopcornClient {
     reconnected(id: string): void;
     updateAssigns(id: string, assigns: Record<string, unknown>): void;
     handleParams(id: string, params: Record<string, string>, url: string): void;
-    transportFrame(id: string, event: string, payload: unknown): Promise<CallResult>;
+    handleTransportFrame(id: string, event: string, payload: unknown): Promise<CallResult>;
     serverMessage(id: string, payload: Record<string, unknown>): void;
     pushError(id: string, event: string, payload: Record<string, unknown>): void;
     push(id: string, event: string, payload: Record<string, unknown>): Promise<CallResult>;
@@ -69,6 +66,7 @@ declare class LLVEngine {
      * @param config - Optional LLV configuration.
      */
     static create(liveSocket: LiveSocketInstanceInterface, config?: LLVConfig): Promise<LLVEngine>;
+    private socketClass;
     private connectPopcornSocket;
     private mountView;
     private unmountView;

--- a/local-live-view/priv/static/local_live_view.d.ts
+++ b/local-live-view/priv/static/local_live_view.d.ts
@@ -47,7 +47,9 @@ declare class PopcornClient {
     reconnected(id: string): void;
     updateAssigns(id: string, assigns: Record<string, unknown>): void;
     handleParams(id: string, params: Record<string, string>, url: string): void;
-    event(id: string, payload: Record<string, unknown>): void;
+    transportFrame(id: string, event: string, payload: unknown): Promise<CallResult>;
+    serverMessage(id: string, payload: Record<string, unknown>): void;
+    pushError(id: string, event: string, payload: Record<string, unknown>): void;
     push(id: string, event: string, payload: Record<string, unknown>): Promise<CallResult>;
 }
 declare class LLVEngine {
@@ -57,6 +59,8 @@ declare class LLVEngine {
     private views;
     private channels;
     private bufferedServerMessages;
+    private eventBusHooks;
+    private popcornLink;
     private constructor();
     /**
      * Initializes LLVEngine and connects the LiveSocket.
@@ -65,6 +69,7 @@ declare class LLVEngine {
      * @param config - Optional LLV configuration.
      */
     static create(liveSocket: LiveSocketInstanceInterface, config?: LLVConfig): Promise<LLVEngine>;
+    private connectPopcornSocket;
     private mountView;
     private unmountView;
     private registerServerMessageListener;

--- a/local-live-view/priv/static/local_live_view.js
+++ b/local-live-view/priv/static/local_live_view.js
@@ -541,31 +541,14 @@ function setupFakeView(socket, views, popcornSocket, pop_view_el) {
     view.join();
 }
 
-// ---- Popcorn channel transport -----------------------------------------
-//
-// Each fake view gets a REAL Phoenix Channel on a dedicated Socket whose
-// transport is the class below — the same public seam Phoenix.LongPoll
-// plugs into. No network connection ever exists: the "wire" is
-// popcorn.call one way and injected frames the other, and the socket's
-// encode/decode passthrough keeps frames plain objects (no serializer).
-//
-// The transport honors the channel ack contract: frames the WASM view
-// must answer (join, events, component-destruction bookkeeping) ride
-// popcorn.call, whose promise the view's process settles once the frame
-// is processed — the resolved {status, payload} (initial rendered, render
-// diff or %{} no-op, pruned cids) becomes the channel ack. So LiveView's
-// stock push lifecycle runs unmodified: apply the ack diff, undo the
-// push's element refs, resolve the {:reply, ...} payload. Ref locks and
-// phx-disable-with span the local round-trip exactly like a server
-// round-trip.
 const llvIdFromTopic = (topic) => topic.slice("lv:".length);
-// Frames the WASM view must answer: the channel join (ack carries the
-// initial rendered), DOM events (ack carries the render diff and reply)
-// and component-destruction bookkeeping (ack carries the pruned cids).
-// Anything else — heartbeats, phx_leave — is acked in place so the socket
-// stays healthy and teardown completes. Each entry needs a matching
+// Frames the WASM view must answer. Each entry needs a matching
 // Message clause in LocalLiveView.Server.
+// Anything else — heartbeats, phx_leave — is acked in place
+// as Popcorn may be not booted yet.
 const ANSWERED_EVENTS = ["phx_join", "event", "cids_will_destroy", "cids_destroyed"];
+// A fake socket that connects LLV vievs to Popcorn.
+// Phoenix channels can be normally constructed on top of this socket.
 function createPopcornSocket(SocketClass, pop) {
     let transport = null;
     class PopcornTransport {
@@ -611,12 +594,7 @@ function createPopcornSocket(SocketClass, pop) {
                 this.ack(frame, "ok", {});
                 return;
             }
-            // The view's process settles the call promise with {status, payload}
-            // once the frame is processed; a dispatcher-side reject resolves with
-            // ok: false. A call left unsettled (crashed view process) rejects at
-            // the call timeout. Every failure acks "error" — never "timeout",
-            // whose Push path triggers liveSocket.reloadWithJitter.
-            pop.transportFrame(llvIdFromTopic(topic), event, payload).then((result) => {
+            pop.handleTransportFrame(llvIdFromTopic(topic), event, payload).then((result) => {
                 if (result.ok) {
                     const { status, payload: response } = result.data;
                     this.ack(frame, status, response);
@@ -859,9 +837,7 @@ function resolveLlvId(viewOrId) {
     const el = Array.from(document.querySelectorAll("[data-pop-view]")).find((e) => e.getAttribute("data-pop-view") === viewOrId);
     return el ? el.id : viewOrId;
 }
-// Host-pushed server messages are not channel pushes — there is no ack to
-// carry the render, so the view delivers any resulting diff out-of-band
-// (__popcornTransportReceive). Hence the dedicated fire-and-forget action.
+// handles messages sent by the server via LocalLiveView.push_server_message
 function sendServerMessage(pop, detail) {
     pop.serverMessage(resolveLlvId(detail.view), {
         event: "llv_server_message",
@@ -930,7 +906,7 @@ class PopcornClient {
     // A channel frame the view must answer: the view's process settles the
     // call promise (Popcorn.Wasm.resolve) once the frame is processed, so the
     // result carries the channel ack. The transport consumes it — no `fire`.
-    transportFrame(id, event, payload) {
+    handleTransportFrame(id, event, payload) {
         return this.call({ action: "transport_frame", id, event, payload });
     }
     serverMessage(id, payload) {
@@ -985,12 +961,14 @@ class LLVEngine {
         engine.flushBufferedServerMessages();
         return engine;
     }
-    // The dedicated never-networked socket the fake views' channels live on.
-    // Connected before Popcorn boots: heartbeats are acked in place by the
-    // transport, and no answered frame flows until a view mounts (post-boot).
+    // The app's Phoenix Socket class, recovered from the live instance the
+    // LiveSocket already holds — same class, same version, same module as the
+    // one LiveView runs on, with nothing to configure.
+    socketClass() {
+        return this.socket.getSocket().constructor;
+    }
     connectPopcornSocket() {
-        const SocketClass = this.config.Socket ?? this.socket.getSocket().constructor;
-        this.popcornLink = createPopcornSocket(SocketClass, this.pop);
+        this.popcornLink = createPopcornSocket(this.socketClass(), this.pop);
     }
     // Start a view and wire it up.
     async mountView(pop_view_el) {
@@ -1073,12 +1051,10 @@ class LLVEngine {
                 unmountView(this.el);
             },
         };
-        // Event bus for local→server pushes: a hidden sibling of each mount
-        // point, owned by the HOST LiveView (see LocalLiveView.Component). Its
-        // lifecycle IS the host resolution — LiveView mounts and destroys it
-        // with the host view across reconnects and re-renders, so the registry
-        // always holds a live hook and no host-element lookup can go stale.
-        // __llvPushServer pushes through it via the documented hook pushEvent.
+        // Hook for sending events from client to server via `LocalLiveView.push_server_event`
+        // Sending an event via a hook freezes the element the hook binds to along with all
+        // its descendants until the event is internally ACKed by LiveView, thus we use
+        // a dedicated, empty div for that.
         const eventBusHooks = this.eventBusHooks;
         this.socket.hooks.LocalLiveViewEventBus = {
             mounted() {
@@ -1117,11 +1093,8 @@ class LLVEngine {
         const mirrorEls = document.querySelectorAll("[data-pop-view][data-pop-mirror-token]");
         if (mirrorEls.length === 0)
             return;
-        const { Socket } = this.config;
+        const Socket = this.socketClass();
         const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
-        if (!Socket) {
-            throw new Error("LLV: config.Socket is required when using mirror channels");
-        }
         const llvSocket = new Socket("/llv_socket", {
             params: { _csrf_token: csrfToken },
         });

--- a/local-live-view/priv/static/local_live_view.js
+++ b/local-live-view/priv/static/local_live_view.js
@@ -513,99 +513,17 @@ async function resolveBundleURL(primary, fallback) {
     }
 }
 
-const LLV_DEFAULT_TARGET = "__llv_default__";
-const LLV_SERVER_TARGET = "__llv_server__";
-const LLV_TARGET_SEP = "\x1f";
-// Phoenix tags every real LiveView root element with data-phx-session; this is
-// the selector phoenix_live_view uses internally (PHX_VIEW_SELECTOR).
-const PHX_VIEW_SELECTOR = "[data-phx-session]";
-
-// Resolve an LLV's element id from a view name or id: prefer the element whose
-// data-pop-view matches, else fall back to treating the argument as an id.
-function resolveLlvId(viewOrId) {
-    const el = Array.from(document.querySelectorAll("[data-pop-view]")).find((e) => e.getAttribute("data-pop-view") === viewOrId);
-    return el ? el.id : viewOrId;
-}
-// Resolve an LLV's host LiveView fresh on every call (a reconnect can swap the
-// [data-phx-session] element) and hand it to `fun`. We can't use
-// liveSocket.withinOwners(llvElement, fun) here: overriding the owner
-// connects [data-pop-view] elements with the fake local view, so we hop to the host
-// element ourselves first.
-function withHostLV(socket, llvId, fun) {
-    const llvElement = document.getElementById(llvId);
-    if (!llvElement) {
-        console.error("LLV withHostLV: LLV element not found", llvId);
-        return;
-    }
-    const hostEl = llvElement.closest(PHX_VIEW_SELECTOR);
-    if (!hostEl) {
-        console.error("LLV withHostLV: no host LiveView for view", llvId);
-        return;
-    }
-    // liveSocket.owner only calls back when the element maps to a live view;
-    // surface the miss instead of dropping the event without a trace.
-    let dispatched = false;
-    socket.owner(hostEl, (hostView) => {
-        dispatched = true;
-        fun(hostView, hostEl);
-    });
-    if (!dispatched) {
-        console.error("LLV withHostLV: host LiveView element has no live view", { llvId, hostEl });
-    }
-}
-function sendServerMessage(pop, detail) {
-    pop.event(resolveLlvId(detail.view), {
-        event: "llv_server_message",
-        value: detail.payload,
-        type: "llv_server_message",
-    });
-}
-// data-pop-assigns holds the JSON a local_component serialized from its inline
-// assigns. Absent/empty for plain local views — default to {} so the process is
-// always handed a map.
-function parseAssigns(raw) {
-    if (!raw)
-        return {};
-    try {
-        return JSON.parse(raw);
-    }
-    catch (err) {
-        console.error("LLV failed to parse data-pop-assigns:", raw, err);
-        return {};
-    }
-}
-
 // Wire a fake Phoenix root view around a [data-pop-view] element so the
 // browser renders the runtime's diffs and routes events to it.
-function setupFakeView(socket, views, pop, pop_view_el, initialRendered) {
+function setupFakeView(socket, views, popcornSocket, pop_view_el) {
     const llvId = pop_view_el.id;
     const view = socket.newRootView(pop_view_el);
     views.set(llvId, view);
-    // Handle LLV's custom targets (default, server, targets composed by LocalLiveView.targets/1)
-    const origWithinTargets = view.withinTargets.bind(view);
-    view.withinTargets = function (phxTarget, callback, dom) {
-        const dispatchToken = (t) => {
-            if (t === LLV_DEFAULT_TARGET) {
-                callback(this, null);
-            }
-            else if (t === LLV_SERVER_TARGET) {
-                withHostLV(socket, llvId, (hostView) => callback(hostView, null));
-            }
-            else {
-                origWithinTargets(t, callback, dom);
-            }
-        };
-        if (typeof phxTarget === "string" &&
-            (phxTarget.includes(LLV_TARGET_SEP) ||
-                phxTarget === LLV_DEFAULT_TARGET ||
-                phxTarget === LLV_SERVER_TARGET)) {
-            for (const t of phxTarget.split(LLV_TARGET_SEP))
-                if (t)
-                    dispatchToken(t);
-            return;
-        }
-        return origWithinTargets(phxTarget, callback, dom);
-    };
+    // The view's channel: a real Phoenix Channel on the popcorn socket.
+    // Everything channel-shaped — join handshake, event acks carrying
+    // diffs, out-of-band "diff" frames, ref bookkeeping — runs through the
+    // stock Channel/Push machinery over the PopcornTransport.
+    view.channel = popcornSocket.channel(`lv:${llvId}`);
     // addHook: skip the root element to prevent Phoenix from trying to register it
     // as a hook within this view's scope — hooks on children are still processed normally.
     const origAddHook = view.addHook.bind(view);
@@ -614,56 +532,119 @@ function setupFakeView(socket, views, pop, pop_view_el, initialRendered) {
             return;
         return origAddHook(el);
     };
-    // isConnected: we are always "connected" to Popcorn
-    view.isConnected = function () {
-        return true;
-    };
-    // join: skip bindChannel + channel.join — onJoin is called below after Popcorn mounts.
-    // No need to set data-phx-session / data-phx-root-id: owner() is overridden below
-    // to route events via [data-pop-view] lookup instead of attribute-based lookup.
-    view.join = function (callback) {
-        this.showLoader(this.liveSocket.loaderTimeout);
-        this.joinCallback = (onDone) => {
-            onDone = onDone ?? function () { };
-            if (callback) {
-                callback(this.joinCount, onDone);
-            }
-            else {
-                onDone();
-            }
-        };
-    };
-    // pushWithReply: send event to Popcorn, return a resolved Promise so callers
-    // like pushInput can safely chain .then() on it.
-    // The actual diff arrives asynchronously via window.__popcornTransportReceive.
-    view.pushWithReply = function (refGenerator, event, payload) {
-        const [ref] = refGenerator ? refGenerator({ payload }) : [null, [], {}];
-        if (typeof payload.cid !== "number") {
-            delete payload.cid;
-        }
-        pop.event(this.el.id, payload);
-        // In the real Phoenix flow, undoRefs is called synchronously inside
-        // pushWithReply's channel reply handler — just before this.update(diff).
-        // Since our diff arrives asynchronously via __popcornTransportReceive,
-        // we must release the ref locks now. Otherwise DOMPatch sees PHX_REF_LOCK
-        // on the form (set by pushInput for both the input AND the form element)
-        // and applies all diff changes to a clone instead of the real DOM.
-        if (ref !== null) {
-            this.undoRefs(ref, payload.event ?? event);
-        }
-        return Promise.resolve({ resp: {}, reply: null, ref });
-    };
-    // maybePushComponentsDestroyed: component lifecycle is managed by Popcorn/WASM,
-    // no need to notify the server about destroyed CIDs from the JS side
-    view.maybePushComponentsDestroyed = function () { };
-    view.bindChannel = function () { };
+    // Stock join: bindChannel + channel.join over the popcorn transport.
+    // The join frame is answered by the view's process itself, serving the
+    // rendered it produced at mount — so onJoin runs the regular path.
+    // No need to set data-phx-session / data-phx-root-id: owner() is
+    // overridden by the engine to route events via [data-pop-view] lookup
+    // instead of attribute-based lookup.
     view.join();
-    if (initialRendered) {
-        socket.requestDOMUpdate(() => view.onJoin({ rendered: initialRendered }));
+}
+
+// ---- Popcorn channel transport -----------------------------------------
+//
+// Each fake view gets a REAL Phoenix Channel on a dedicated Socket whose
+// transport is the class below — the same public seam Phoenix.LongPoll
+// plugs into. No network connection ever exists: the "wire" is
+// popcorn.call one way and injected frames the other, and the socket's
+// encode/decode passthrough keeps frames plain objects (no serializer).
+//
+// The transport honors the channel ack contract: frames the WASM view
+// must answer (join, events, component-destruction bookkeeping) ride
+// popcorn.call, whose promise the view's process settles once the frame
+// is processed — the resolved {status, payload} (initial rendered, render
+// diff or %{} no-op, pruned cids) becomes the channel ack. So LiveView's
+// stock push lifecycle runs unmodified: apply the ack diff, undo the
+// push's element refs, resolve the {:reply, ...} payload. Ref locks and
+// phx-disable-with span the local round-trip exactly like a server
+// round-trip.
+const llvIdFromTopic = (topic) => topic.slice("lv:".length);
+// Frames the WASM view must answer: the channel join (ack carries the
+// initial rendered), DOM events (ack carries the render diff and reply)
+// and component-destruction bookkeeping (ack carries the pruned cids).
+// Anything else — heartbeats, phx_leave — is acked in place so the socket
+// stays healthy and teardown completes. Each entry needs a matching
+// Message clause in LocalLiveView.Server.
+const ANSWERED_EVENTS = ["phx_join", "event", "cids_will_destroy", "cids_destroyed"];
+function createPopcornSocket(SocketClass, pop) {
+    let transport = null;
+    class PopcornTransport {
+        readyState = 0; // CONNECTING
+        onopen = () => { };
+        onerror = () => { };
+        onmessage = () => { };
+        onclose = () => { };
+        // The WebSocket-shaped signature the Socket constructs us with; the URL
+        // is a dead label.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        constructor(_endpointURL, _protocols) {
+            // eslint-disable-next-line @typescript-eslint/no-this-alias
+            transport = this;
+            // The Socket assigns onopen/onmessage/onclose after `new`, so the
+            // "connection" must open asynchronously.
+            queueMicrotask(() => {
+                this.readyState = 1; // OPEN
+                this.onopen();
+            });
+        }
+        // Deliver an inbound frame. Async so an ack never re-enters Socket code
+        // in the middle of an outbound send.
+        inject(frame) {
+            queueMicrotask(() => {
+                if (this.readyState === 1)
+                    this.onmessage({ data: frame });
+            });
+        }
+        // Ack an outbound frame in place (joins, leaves, heartbeats, no-ops).
+        ack(frame, status, response) {
+            this.inject({
+                topic: frame.topic,
+                event: "phx_reply",
+                payload: { status, response },
+                ref: frame.ref,
+                join_ref: frame.join_ref,
+            });
+        }
+        send(frame) {
+            const { topic, event, payload } = frame;
+            if (!ANSWERED_EVENTS.includes(event)) {
+                this.ack(frame, "ok", {});
+                return;
+            }
+            // The view's process settles the call promise with {status, payload}
+            // once the frame is processed; a dispatcher-side reject resolves with
+            // ok: false. A call left unsettled (crashed view process) rejects at
+            // the call timeout. Every failure acks "error" — never "timeout",
+            // whose Push path triggers liveSocket.reloadWithJitter.
+            pop.transportFrame(llvIdFromTopic(topic), event, payload).then((result) => {
+                if (result.ok) {
+                    const { status, payload: response } = result.data;
+                    this.ack(frame, status, response);
+                }
+                else {
+                    this.ack(frame, "error", result.error);
+                }
+            }, (err) => this.ack(frame, "error", String(err)));
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        close(_code, _reason) {
+            this.readyState = 3; // CLOSED
+            queueMicrotask(() => this.onclose({ code: 1000, wasClean: true }));
+        }
     }
-    else {
-        console.error("LLV no initial rendered for view", llvId);
-    }
+    // The endpoint URL is only a label — the transport never dereferences it.
+    const socket = new SocketClass("/llv-popcorn", {
+        transport: PopcornTransport,
+        encode: (payload, callback) => callback(payload),
+        decode: (rawPayload, callback) => callback(rawPayload),
+    });
+    socket.connect();
+    return {
+        socket,
+        inject(frame) {
+            transport?.inject(frame);
+        },
+    };
 }
 
 // LLV navigation runs in one of two modes:
@@ -872,6 +853,37 @@ function registerCustomEventBindings(socket) {
     }
 }
 
+// Resolve an LLV's element id from a view name or id: prefer the element whose
+// data-pop-view matches, else fall back to treating the argument as an id.
+function resolveLlvId(viewOrId) {
+    const el = Array.from(document.querySelectorAll("[data-pop-view]")).find((e) => e.getAttribute("data-pop-view") === viewOrId);
+    return el ? el.id : viewOrId;
+}
+// Host-pushed server messages are not channel pushes — there is no ack to
+// carry the render, so the view delivers any resulting diff out-of-band
+// (__popcornTransportReceive). Hence the dedicated fire-and-forget action.
+function sendServerMessage(pop, detail) {
+    pop.serverMessage(resolveLlvId(detail.view), {
+        event: "llv_server_message",
+        value: detail.payload,
+        type: "llv_server_message",
+    });
+}
+// data-pop-assigns holds the JSON a local_component serialized from its inline
+// assigns. Absent/empty for plain local views — default to {} so the process is
+// always handed a map.
+function parseAssigns(raw) {
+    if (!raw)
+        return {};
+    try {
+        return JSON.parse(raw);
+    }
+    catch (err) {
+        console.error("LLV failed to parse data-pop-assigns:", raw, err);
+        return {};
+    }
+}
+
 const DEFAULT_CALL_TIMEOUT_MS = 10_000;
 class PopcornClient {
     popcorn = null;
@@ -915,8 +927,20 @@ class PopcornClient {
     handleParams(id, params, url) {
         this.fire("handle_params", { action: "handle_params", id, payload: { params, url } });
     }
-    event(id, payload) {
-        this.fire("event", { action: "event", id, payload });
+    // A channel frame the view must answer: the view's process settles the
+    // call promise (Popcorn.Wasm.resolve) once the frame is processed, so the
+    // result carries the channel ack. The transport consumes it — no `fire`.
+    transportFrame(id, event, payload) {
+        return this.call({ action: "transport_frame", id, event, payload });
+    }
+    serverMessage(id, payload) {
+        this.fire("server_message", { action: "server_message", id, payload });
+    }
+    // Report a failed local→server push back to the view's process so its
+    // handle_push_error callback runs. `payload` is the map the view passed
+    // to push_server_event.
+    pushError(id, event, payload) {
+        this.fire("push_error report", { action: "push_error", id, payload: { event, payload } });
     }
     push(id, event, payload) {
         return this.call({ action: "push", id, payload: { event, payload } });
@@ -929,6 +953,10 @@ class LLVEngine {
     views = new Map();
     channels = {};
     bufferedServerMessages = [];
+    // llvId -> mounted LocalLiveViewEventBus hook: the host-side channel used
+    // by __llvPushServer.
+    eventBusHooks = new Map();
+    popcornLink;
     constructor(socket, config) {
         this.socket = socket;
         this.config = config;
@@ -947,6 +975,7 @@ class LLVEngine {
         registerNavigationHandlers(engine.socket, engine.views, engine.pop, engine.config);
         engine.registerHooks();
         engine.bindFormsIfHostless();
+        engine.connectPopcornSocket();
         await engine.bootPopcorn();
         engine.setupMirrorChannels();
         engine.exposeGlobals();
@@ -955,6 +984,13 @@ class LLVEngine {
         await engine.scanAndMount();
         engine.flushBufferedServerMessages();
         return engine;
+    }
+    // The dedicated never-networked socket the fake views' channels live on.
+    // Connected before Popcorn boots: heartbeats are acked in place by the
+    // transport, and no answered frame flows until a view mounts (post-boot).
+    connectPopcornSocket() {
+        const SocketClass = this.config.Socket ?? this.socket.getSocket().constructor;
+        this.popcornLink = createPopcornSocket(SocketClass, this.pop);
     }
     // Start a view and wire it up.
     async mountView(pop_view_el) {
@@ -968,18 +1004,16 @@ class LLVEngine {
             urlParams: Object.fromEntries(new URLSearchParams(window.location.search)),
             assigns: parseAssigns(pop_view_el.getAttribute("data-pop-assigns")),
         });
+        // A rejected call resolves with ok: false (it does not throw). Bail on
+        // failed or duplicate creates — wiring a fake view without a live
+        // process would join a channel nobody answers.
         if (!result.ok) {
             console.error("LLV failed to create view", llvId, result.error);
             return;
         }
-        const data = result.data;
-        if (data.status === "error") {
-            console.error("LLV view returned error status on create", llvId, data);
-            return;
-        }
         const liveEl = document.getElementById(llvId);
         if (liveEl?.matches("[data-pop-view]")) {
-            setupFakeView(this.socket, this.views, this.pop, liveEl, data.rendered);
+            setupFakeView(this.socket, this.views, this.popcornLink.socket, liveEl);
         }
         else {
             this.pop.destroy(llvId);
@@ -1010,10 +1044,9 @@ class LLVEngine {
             sendServerMessage(this.pop, detail);
         });
     }
-    // Hook that manages views rendered inside a host LiveView.
-    // Other views are rendered during startup scan.
-    // The startup scan also handles the case when hook's mount
-    // fires before Popcorn is ready.
+    // Hooks that manage views rendered inside a host LiveView (other views are
+    // mounted by the startup scan, which also catches hooks that fired before
+    // Popcorn was ready) and the per-view event bus.
     registerHooks() {
         const pop = this.pop;
         const mountView = (el) => this.mountView(el);
@@ -1038,6 +1071,26 @@ class LLVEngine {
             },
             destroyed() {
                 unmountView(this.el);
+            },
+        };
+        // Event bus for local→server pushes: a hidden sibling of each mount
+        // point, owned by the HOST LiveView (see LocalLiveView.Component). Its
+        // lifecycle IS the host resolution — LiveView mounts and destroys it
+        // with the host view across reconnects and re-renders, so the registry
+        // always holds a live hook and no host-element lookup can go stale.
+        // __llvPushServer pushes through it via the documented hook pushEvent.
+        const eventBusHooks = this.eventBusHooks;
+        this.socket.hooks.LocalLiveViewEventBus = {
+            mounted() {
+                const llvId = this.el.getAttribute("data-llv-event-bus-for");
+                if (llvId)
+                    eventBusHooks.set(llvId, this);
+            },
+            destroyed() {
+                const llvId = this.el.getAttribute("data-llv-event-bus-for");
+                if (llvId && eventBusHooks.get(llvId) === this) {
+                    eventBusHooks.delete(llvId);
+                }
             },
         };
     }
@@ -1097,22 +1150,38 @@ class LLVEngine {
         };
     }
     exposeGlobals() {
+        // Out-of-band diffs (handle_info renders, send_update, push_error
+        // rollbacks, server messages — anything not acking a push). Injected as
+        // a channel "diff" frame, handled by the stock bindChannel handler
+        // exactly like a server-pushed diff. A diff racing a just-unmounted
+        // view is dropped.
         window.__popcornTransportReceive = (llvId, diff) => {
-            const view = this.views.get(llvId);
-            if (!view) {
-                console.error("LLV view not found:", llvId, "available:", this.views.keys());
+            if (!this.views.has(llvId))
+                return;
+            this.popcornLink.inject({
+                topic: `lv:${llvId}`,
+                event: "diff",
+                payload: diff,
+                ref: null,
+                join_ref: null,
+            });
+        };
+        // __llvPushServer: sends an event to the host LiveView, called from a
+        // local view's Elixir via LocalLiveView.push_server_event/3. Pushes
+        // through the event bus hook's documented, promise-returning pushEvent —
+        // it rejects when the host is disconnected, replies with an error, or
+        // times out; no event bus means no host LiveView on the page. Failures
+        // are reported back so the view's handle_push_error runs.
+        window.__llvPushServer = (llvId, event, payload) => {
+            const eventBus = this.eventBusHooks.get(llvId);
+            if (!eventBus) {
+                console.error("LLV push_server_event: no host event bus for view", llvId);
+                this.pop.pushError(llvId, event, payload);
                 return;
             }
-            view.update(diff, []);
-        };
-        // __llvPushServer: programmatic counterpart of phx-target=@server, called from
-        // a local view's Elixir via LocalLiveView.push_server_event/3. Resolves the
-        // LLV's host LiveView fresh each call (a reconnect can swap the
-        // [data-phx-session] element) and dispatches the event to it over the
-        // websocket.
-        window.__llvPushServer = (llvId, event, payload) => {
-            withHostLV(this.socket, llvId, (hostView, hostEl) => {
-                hostView.pushEvent("event", hostEl, null, event, payload, {});
+            eventBus.pushEvent(event, payload).catch((err) => {
+                console.error("LLV push_server_event failed", err);
+                this.pop.pushError(llvId, event, payload);
             });
         };
     }
@@ -1135,7 +1204,7 @@ class LLVEngine {
     // This is the mount path for host-less pages (no hooks fire there) and the
     // catch-up for hooks that fired before Popcorn was ready.
     // If a view is mounted twice (here and by the hook), the dispatcher
-    // on the Elixir side ignores the second mount.
+    // on the Elixir side rejects the second create.
     async scanAndMount() {
         const pop_view_els = Array.from(document.querySelectorAll("[data-pop-view]"));
         await Promise.all(pop_view_els.map((el) => this.mountView(el)));

--- a/local-live-view/test/mix/tasks/llv_install_test.exs
+++ b/local-live-view/test/mix/tasks/llv_install_test.exs
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.Llv.InstallTest do
       + |import { LLVEngine } from "local_live_view";
       """)
       |> assert_has_patch(@app_js_path, """
-      + |await LLVEngine.create(liveSocket, { Socket, bundlePaths: ["/assets/js/wasm/bundle.avm"] });
+      + |await LLVEngine.create(liveSocket, { bundlePaths: ["/assets/js/wasm/bundle.avm"] });
       """)
     end
   end


### PR DESCRIPTION
The main goal for this PR was to add `handle_push_error` callback, called when `push_server_event` fails. It's done, and the callback receives the last assigns passed to `update`, so it can roll back its state. Achieving this in the current state of the JS part of LLV was extremely convoluted and relied very much on the LLV internals, thus I made the following changes:
- Instead of patching fake view's methods (`pushWithReply`, etc), now we're injecting a fake transport that forwards messages to Popcorn. The transport API is not public either, but it's basically the WebSocket API, so it's simpler and less likely to change. That required some additions extending the LLV `server.ex` unfortunately, but it aligns with the original impl so maybe we can reuse it in the future?
- Instead of using `hostView.pushEvent`, we're now using a hook to push events to the server. Since LiveView freezes all updates on the hook's element until an event is ACKed by the server, we can't use the LLV's hook, as it would effectively freeze the LLV until the event is handled. Thus we have a dedicated empty `div` with a simple hook that's only job is to send events.
- The two points above made it impossible to have the `phx-target=@server`, so I removed it and `push_server_event` is the only way now. I think keeping `phx-target=@server` wasn't worth the hassle and we may figure out how to re-introduce it if it's missed.