### PR TITLE
otp: include logger in manifest

### DIFF
--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -241,6 +241,20 @@ test("loads manifest apps before eval", async ({ otp }) => {
   expect(otp.events).toContainEqual({ manifest_app: true });
 });
 
+test("starts the provided logger app", async ({ otp }) => {
+  const boot = await otp.boot(
+    evalOpts(`
+      {ok, _} = application:ensure_all_started(logger),
+      _ = 'Elixir.Logger':level(),
+      ok = wasm:send(#{logger_started => true}).
+    `),
+  );
+  assert(boot.ok);
+
+  await otp.waitForEvent("logger_started");
+  expect(otp.events).toContainEqual({ logger_started: true });
+});
+
 test("run_js -> send", async ({ otp }) => {
   const RUN_JS_BOOT_EVAL = trimLeft(`
     V = wasm:run_js(<<"(args) => 1 + 2">>, #{}),

--- a/scripts/stdlib.sh
+++ b/scripts/stdlib.sh
@@ -19,7 +19,10 @@ source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
 DEFAULT_ELIXIR_TAG="v1.19.5"
 DEFAULT_PRESET="core"
 SOURCES_DIR="${PROJECT_ROOT}/otp/sources"
-ELIXIR_CORE_APPS=(elixir)
+# logger is in core because `mix new` scaffolds `extra_applications: [:logger]`,
+# so almost every user app depends on it. It is pure BEAM (no NIF), so shipping
+# it as a provided tarball is enough for it to load in WASM.
+ELIXIR_CORE_APPS=(elixir logger)
 ELIXIR_ALL_APPS=(eex elixir ex_unit iex logger mix)
 CORE_APPS=(kernel stdlib compiler "${ELIXIR_CORE_APPS[@]}")
 CORE_CRYPTO_EXTRA_APPS=(asn1 crypto public_key ssl inets)


### PR DESCRIPTION
`mix new` adds logger as default extra app, there's no harm in including it by default.