### PR TITLE
otp: compress .tar and .wasm in plugin

### DIFF
--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -12,7 +12,7 @@ import {
 function evalOpts(code: string) {
   return {
     beam: {
-      manifestUrl: "/otp-assets/manifest.json",
+      manifestUrl: "/assets/otp/manifest.json",
       extraArgs: ["-eval", code],
     },
   };
@@ -20,7 +20,7 @@ function evalOpts(code: string) {
 
 test("boots", async ({ otp }) => {
   const result = await otp.boot({
-    beam: { manifestUrl: "/otp-assets/manifest.json" },
+    beam: { manifestUrl: "/assets/otp/manifest.json" },
   });
 
   expect(result).toEqual({ ok: true, data: null });
@@ -28,7 +28,7 @@ test("boots", async ({ otp }) => {
 
 test("auto-starts the manifest entrypoint app", async ({ otp }) => {
   const result = await otp.boot({
-    beam: { manifestUrl: "/otp-assets/manifest-entrypoint.json" },
+    beam: { manifestUrl: "/assets/otp/manifest-entrypoint.json" },
   });
   expect(result).toEqual({ ok: true, data: null });
 
@@ -38,7 +38,7 @@ test("auto-starts the manifest entrypoint app", async ({ otp }) => {
 
 test("reports timeouts on init", async ({ otp }) => {
   const result = await otp.boot({
-    beam: { manifestUrl: "/otp-assets/manifest.json" },
+    beam: { manifestUrl: "/assets/otp/manifest.json" },
     timeoutsMs: { boot: 0 },
   });
 
@@ -50,14 +50,14 @@ test("reports timeouts on init", async ({ otp }) => {
 
 test("handles missing manifest", async ({ otp }) => {
   const result = await otp.boot({
-    beam: { manifestUrl: "/otp-assets/missing/manifest.json" },
+    beam: { manifestUrl: "/assets/otp/missing/manifest.json" },
   });
 
   expect(result).toEqual({
     ok: false,
     error: {
       t: "beam:missing-manifest",
-      data: { url: "/otp-assets/missing/manifest.json" },
+      data: { url: "/assets/otp/missing/manifest.json" },
     },
   });
 });
@@ -66,7 +66,7 @@ test("failures on boot aren't sent to onEvent()", async ({ page }) => {
   const result = await page.evaluate(async () => {
     const errors: unknown[] = [];
     const popcorn = new window.Popcorn({
-      beam: { manifestUrl: "/otp-assets/missing/manifest.json" },
+      beam: { manifestUrl: "/assets/otp/missing/manifest.json" },
       onError: (event) => errors.push(event),
     });
 
@@ -84,7 +84,7 @@ test("failures on boot aren't sent to onEvent()", async ({ page }) => {
     ok: false,
     error: {
       t: "beam:missing-manifest",
-      data: { url: "/otp-assets/missing/manifest.json" },
+      data: { url: "/assets/otp/missing/manifest.json" },
     },
   });
 });
@@ -92,7 +92,7 @@ test("failures on boot aren't sent to onEvent()", async ({ page }) => {
 test("can reboot after deinit", async ({ page }) => {
   const result = await page.evaluate(async () => {
     const popcorn = new window.Popcorn({
-      beam: { manifestUrl: "/otp-assets/manifest.json" },
+      beam: { manifestUrl: "/assets/otp/manifest.json" },
     });
     type BootResult = Awaited<ReturnType<typeof popcorn.boot>>;
 
@@ -118,7 +118,7 @@ test("event hooks preserved after a reboot", async ({ page }) => {
     const READY_BOOT_EVAL = "ok = wasm:send(#{ready => true}).";
     const opts = {
       beam: {
-        manifestUrl: "/otp-assets/manifest.json",
+        manifestUrl: "/assets/otp/manifest.json",
         extraArgs: ["-eval", READY_BOOT_EVAL],
       },
     };
@@ -168,7 +168,7 @@ test("event hooks preserved after a reboot", async ({ page }) => {
 test("failing boot fails immediately", async ({ page }) => {
   const result = await page.evaluate(async () => {
     const popcorn = new window.Popcorn({
-      beam: { manifestUrl: "/otp-assets/manifest.json" },
+      beam: { manifestUrl: "/assets/otp/manifest.json" },
       workerUrl: "/fault-worker.mjs",
       timeoutsMs: { boot: 30_000 },
     });
@@ -546,7 +546,7 @@ test("send() to unregistered process", async ({ otp }) => {
 
 test("send() timeout", async ({ otp }) => {
   const boot = await otp.boot({
-    beam: { manifestUrl: "/otp-assets/manifest.json" },
+    beam: { manifestUrl: "/assets/otp/manifest.json" },
     timeoutsMs: { send: 0 },
   });
   assert(boot.ok);

--- a/otp/js/e2e/setup/entrypoint-app/build-fixture.escript
+++ b/otp/js/e2e/setup/entrypoint-app/build-fixture.escript
@@ -10,5 +10,5 @@ main([SrcDir, StageDir, OutTar]) ->
             filename:join(SrcDir, "test_entrypoint.app"),
             filename:join(EbinDir, "test_entrypoint.app")
         ),
-    ok = erl_tar:create(OutTar, [{"lib/test_entrypoint/ebin", EbinDir}], [compressed]),
+    ok = erl_tar:create(OutTar, [{"lib/test_entrypoint/ebin", EbinDir}], []),
     ok.

--- a/otp/js/e2e/setup/global-setup.ts
+++ b/otp/js/e2e/setup/global-setup.ts
@@ -83,7 +83,7 @@ async function buildEntrypointFixture(env: NodeJS.ProcessEnv): Promise<void> {
   const fixtureSrcDir = resolve(__dirname, "entrypoint-app");
   const escript = resolve(fixtureSrcDir, "build-fixture.escript");
   const stageDir = resolve(distAssetsDir, ".entrypoint-stage");
-  const tar = "lib/test_entrypoint.tar.gz";
+  const tar = "lib/test_entrypoint.tar";
 
   await runCommand(
     "escript",

--- a/otp/js/e2e/setup/vite.config.ts
+++ b/otp/js/e2e/setup/vite.config.ts
@@ -17,19 +17,19 @@ const CORS_HEADERS = {
 
 type Res = ServerResponse<IncomingMessage>;
 
-function otpAssetsPlugin(): Plugin {
+function otpPlugin(): Plugin {
   const serveAsset = async (
     req: IncomingMessage,
     res: Res,
     next: () => void,
   ) => {
     const requestUrl = req.url;
-    if (requestUrl === undefined || !requestUrl.startsWith("/otp-assets/")) {
+    if (requestUrl === undefined || !requestUrl.startsWith("/assets/otp/")) {
       next();
       return;
     }
 
-    const relativePath = requestUrl.slice("/otp-assets/".length);
+    const relativePath = requestUrl.slice("/assets/otp/".length);
     const filePath = resolve(assetsDir, relativePath);
     const assetRelativePath = relative(assetsDir, filePath);
     if (assetRelativePath.startsWith("..") || isAbsolute(assetRelativePath)) {
@@ -52,7 +52,7 @@ function otpAssetsPlugin(): Plugin {
   };
 
   return {
-    name: "otp-assets",
+    name: "otp",
     configureServer(server) {
       server.middlewares.use(serveAsset);
     },
@@ -86,7 +86,7 @@ function setContentType(res: Res, path: string) {
 
 export default defineConfig({
   root: __dirname,
-  plugins: [otpAssetsPlugin()],
+  plugins: [otpPlugin()],
   server: {
     host: "127.0.0.1",
     port: 5173,

--- a/otp/js/plugins/shared.ts
+++ b/otp/js/plugins/shared.ts
@@ -1,18 +1,29 @@
-import assert from "node:assert";
 import { execFile } from "node:child_process";
-import { copyFile, mkdir, mkdtemp, readdir, rm } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { basename, dirname, normalize, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
+import { brotliCompress, constants, gzip } from "node:zlib";
 
 const execFileAsync = promisify(execFile);
-const otpAssetsDirName = "otp-assets";
-const manifestUrl = `/${otpAssetsDirName}/manifest.json`;
+const brotliCompressAsync = promisify(brotliCompress);
+const gzipAsync = promisify(gzip);
+const OTP_DIR = "assets/otp";
+const manifestUrl = `/${OTP_DIR}/manifest.json`;
 
 export type Options = {
   rootDir: string;
   app: string | null;
+  brotli?: boolean;
 };
 
 export type Prepared = {
@@ -21,51 +32,76 @@ export type Prepared = {
   notes: unknown[];
 };
 
-type Report = {
-  ok: boolean;
-  notes?: unknown[];
-  error?: unknown;
+type Report =
+  | {
+      ok: true;
+      manifestPath: string;
+      tarPaths: string[];
+      notes?: unknown[];
+    }
+  | { ok: false; error: unknown };
+
+type CopyVariant = "gzip" | "brotli" | "uncompressed";
+type CopyOptions = {
+  variants?: (CopyVariant | false | null | undefined)[];
 };
 
 export async function popcorn(opts: Options): Promise<Prepared> {
-  const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const distAssetsDir = join(distDir, "assets");
-  const preparedDir = await mkdtemp(join(tmpdir(), "popcorn-otp-"));
-  const distPath = (name: string) => join(distDir, name);
-  const distAssetsPath = (name: string) => join(distAssetsDir, name);
-  const preparedPath = (name: string) => join(preparedDir, name);
-  const otpAssetsPath = (name: string) =>
-    preparedPath(join(otpAssetsDirName, name));
-  const providedAppsManifestPath = distAssetsPath("manifest.json");
+  const useBrotli = opts.brotli ?? false;
+  const assetVariants: CopyOptions["variants"] = [
+    "gzip",
+    useBrotli && "brotli",
+  ];
+  const distDir = p`${dirname(fileURLToPath(import.meta.url))}/..`;
+  const preparedDir = await mkdtemp(p`${tmpdir()}/popcorn-otp-`);
+  const coreTarballs = await pathsIn(p`${distDir}/assets/lib`, ".tar");
 
   try {
     await Promise.all([
-      copy(distPath("worker.mjs"), preparedPath("worker.mjs")),
-      copy(distAssetsPath("beam.mjs"), preparedPath("assets/beam.mjs")),
+      copy(p`${distDir}/worker.mjs`, p`${preparedDir}/worker.mjs`),
+      copy(p`${distDir}/assets/beam.mjs`, p`${preparedDir}/assets/beam.mjs`),
       copy(
-        distAssetsPath("beam.emu.mjs"),
-        preparedPath("assets/beam.emu.mjs"),
+        p`${distDir}/assets/beam.emu.mjs`,
+        p`${preparedDir}/assets/beam.emu.mjs`,
       ),
-      copy(distAssetsPath("beam.wasm"), preparedPath("assets/beam.wasm")),
-      copy(distAssetsPath("bin/vm.boot"), otpAssetsPath("bin/vm.boot")),
+      copy(p`${distDir}/assets/beam.wasm`, p`${preparedDir}/assets/beam.wasm`, {
+        variants: assetVariants,
+      }),
       copy(
-        distAssetsPath("lib/tarballs.json"),
-        otpAssetsPath("lib/tarballs.json"),
+        p`${distDir}/assets/bin/vm.boot`,
+        p`${preparedDir}/${OTP_DIR}/bin/vm.boot`,
       ),
-      copyCoreTarballs(distAssetsPath("lib"), otpAssetsPath("lib")),
+      copy(
+        p`${distDir}/assets/lib/tarballs.json`,
+        p`${preparedDir}/${OTP_DIR}/lib/tarballs.json`,
+      ),
+      copy(coreTarballs, p`${preparedDir}/${OTP_DIR}/lib`, {
+        variants: assetVariants,
+      }),
     ]);
 
-    const report = await packTarballs({
-      rootDir: resolve(opts.rootDir),
-      outDir: otpAssetsPath(""),
-      providedAppsManifestPath,
-      app: opts.app,
-    });
+    const report = await withTmp(async (packedDir) => {
+      const report = await packTarballs({
+        rootDir: resolve(opts.rootDir),
+        outDir: packedDir,
+        providedAppsManifestPath: p`${distDir}/assets/manifest.json`,
+        app: opts.app,
+      });
 
-    assert(
-      report.ok,
-      `[popcorn-otp] tarballs.exs failed: ${JSON.stringify(report.error)}`,
-    );
+      if (!report.ok) {
+        throw new Error(
+          `[popcorn-otp] tarballs.exs failed: ${JSON.stringify(report.error)}`,
+        );
+      }
+
+      await Promise.all([
+        copy(report.manifestPath, p`${preparedDir}/${OTP_DIR}/manifest.json`),
+        copy(report.tarPaths, p`${preparedDir}/${OTP_DIR}/lib`, {
+          variants: assetVariants,
+        }),
+      ]);
+      return report;
+    });
 
     return {
       dir: preparedDir,
@@ -76,19 +112,6 @@ export async function popcorn(opts: Options): Promise<Prepared> {
     await rm(preparedDir, { recursive: true, force: true });
     throw error;
   }
-}
-
-async function copyCoreTarballs(
-  sourceLibDir: string,
-  targetLibDir: string,
-): Promise<void> {
-  const names = await readdir(sourceLibDir);
-
-  await Promise.all(
-    names
-      .filter((name) => name.endsWith(".tar.gz"))
-      .map((name) => copy(join(sourceLibDir, name), join(targetLibDir, name))),
-  );
 }
 
 async function packTarballs({
@@ -102,7 +125,7 @@ async function packTarballs({
   providedAppsManifestPath: string;
   app: string | null;
 }): Promise<Report> {
-  const scriptPath = join(dirname(fileURLToPath(import.meta.url)), "tarballs.exs");
+  const scriptPath = p`${dirname(fileURLToPath(import.meta.url))}/tarballs.exs`;
   const args = [
     scriptPath,
     "--root-dir",
@@ -121,7 +144,72 @@ async function packTarballs({
   return JSON.parse(stdout) as Report;
 }
 
-async function copy(source: string, target: string): Promise<void> {
-  await mkdir(dirname(target), { recursive: true });
-  await copyFile(source, target);
+async function copy(
+  source: string | string[],
+  target: string,
+  { variants = ["uncompressed"] }: CopyOptions = {},
+): Promise<void> {
+  const sources = typeof source === "string" ? [source] : source;
+  const targetIsDir = typeof source !== "string";
+
+  await Promise.all(
+    sources.map(async (sourcePath) => {
+      const targetPath = targetIsDir
+        ? p`${target}/${basename(sourcePath)}`
+        : target;
+      await mkdir(dirname(targetPath), { recursive: true });
+      let content: Promise<Buffer> | undefined;
+      const read = () => (content ??= readFile(sourcePath));
+
+      await Promise.all(
+        variants
+          .filter((variant): variant is CopyVariant => Boolean(variant))
+          .map(async (variant) => {
+            switch (variant) {
+              case "uncompressed":
+                await copyFile(sourcePath, targetPath);
+                break;
+
+              case "gzip":
+                await writeFile(
+                  `${targetPath}.gz`,
+                  await gzipAsync(await read(), { level: 9 }),
+                );
+                break;
+
+              case "brotli":
+                await writeFile(
+                  `${targetPath}.br`,
+                  await brotliCompressAsync(await read(), {
+                    params: { [constants.BROTLI_PARAM_QUALITY]: 11 },
+                  }),
+                );
+                break;
+            }
+          }),
+      );
+    }),
+  );
+}
+
+function p(
+  strings: TemplateStringsArray,
+  ...values: (string | number)[]
+): string {
+  return normalize(String.raw(strings, ...values));
+}
+
+async function pathsIn(dir: string, suffix: string): Promise<string[]> {
+  return (await readdir(dir))
+    .filter((name) => name.endsWith(suffix))
+    .map((name) => p`${dir}/${name}`);
+}
+
+async function withTmp<T>(f: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(p`${tmpdir()}/popcorn-otp-`);
+  try {
+    return await f(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 }

--- a/otp/js/plugins/tarballs.exs
+++ b/otp/js/plugins/tarballs.exs
@@ -60,6 +60,11 @@ defmodule Tarballs do
       manifest_path = Path.join(args.out_dir, "manifest.json")
       manifest_apps = Map.merge(packed_apps, provided_apps.apps)
 
+      tar_paths =
+        packed_apps
+        |> Map.values()
+        |> Enum.map(&Path.expand(Path.join(args.out_dir, &1.tar)))
+
       manifest = %{
         entrypoint: args.entrypoint_app,
         apps: manifest_apps,
@@ -74,6 +79,7 @@ defmodule Tarballs do
          ok: true,
          entrypoint: args.entrypoint_app,
          manifestPath: Path.expand(manifest_path),
+         tarPaths: tar_paths,
          apps: manifest_apps,
          notes: notes
        }}
@@ -161,14 +167,14 @@ defmodule Tarballs do
   end
 
   defp create_tarball(outdir, app, ebin_dir) do
-    tar = "lib/#{app}.tar.gz"
+    tar = "lib/#{app}.tar"
     tar_path = Path.join(outdir, tar)
     tar_path_c = to_charlist(tar_path)
     arc_name = ~c"lib/#{app}/ebin"
     ebin_dir_c = to_charlist(ebin_dir)
 
     File.mkdir_p!(Path.dirname(tar_path))
-    :ok = :erl_tar.create(tar_path_c, [{arc_name, ebin_dir_c}], [:compressed])
+    :ok = :erl_tar.create(tar_path_c, [{arc_name, ebin_dir_c}], [])
 
     tar
   end

--- a/otp/js/plugins/vite.ts
+++ b/otp/js/plugins/vite.ts
@@ -56,7 +56,18 @@ export function popcorn(options: Options): Plugin {
     next: (error?: unknown) => void,
   ) => {
     const url = req.url;
-    if (url === undefined || !url.startsWith("/otp-assets/")) {
+    if (url === undefined) {
+      next();
+      return;
+    }
+
+    const requestPath = decodeURIComponent(
+      new URL(url, "http://localhost").pathname,
+    );
+    const isOtpAsset = requestPath.startsWith("/assets/otp/");
+    const isBuiltWasm = requestPath === "/assets/beam.wasm";
+    const isSourceWasm = requestPath === `/@fs${distDir}/assets/beam.wasm`;
+    if (!isOtpAsset && !isBuiltWasm && !isSourceWasm) {
       next();
       return;
     }
@@ -69,8 +80,10 @@ export function popcorn(options: Options): Plugin {
       return;
     }
 
-    const assetsRoot = join(dir, "otp-assets");
-    const rel = url.slice("/otp-assets/".length).split("?")[0];
+    const assetsRoot = join(dir, "assets");
+    const rel = isSourceWasm
+      ? "beam.wasm"
+      : requestPath.slice("/assets/".length);
     const filePath = resolve(assetsRoot, rel);
     if (!isUnder(assetsRoot, filePath)) {
       res.statusCode = 403;
@@ -80,9 +93,27 @@ export function popcorn(options: Options): Plugin {
     }
 
     try {
-      const content = await readFile(filePath);
+      const compressible = isCompressible(filePath);
+      const encoding = compressible
+        ? selectEncoding(
+            req.headers["accept-encoding"]?.toString(),
+            options.brotli ?? false,
+          )
+        : { name: null, suffix: "" } as const;
+      if (compressible && encoding.name === null) {
+        res.statusCode = 406;
+        setHeaders(res);
+        res.setHeader("Vary", "Accept-Encoding");
+        res.end("No supported content encoding");
+        return;
+      }
+      const content = await readFile(`${filePath}${encoding.suffix}`);
       setHeaders(res);
       setContentType(res, filePath);
+      res.setHeader("Vary", "Accept-Encoding");
+      if (encoding.name !== null) {
+        res.setHeader("Content-Encoding", encoding.name);
+      }
       res.end(content);
     } catch {
       res.statusCode = 404;
@@ -136,6 +167,21 @@ export function popcorn(options: Options): Plugin {
       }
     },
   };
+}
+
+function isCompressible(path: string): boolean {
+  return path.endsWith(".tar") || path.endsWith(".wasm");
+}
+
+function selectEncoding(header: string | undefined, useBrotli: boolean): {
+  name: "br" | "gzip" | null;
+  suffix: ".br" | ".gz" | "";
+} {
+  if (useBrotli && header?.includes("br")) {
+    return { name: "br", suffix: ".br" };
+  }
+  if (header?.includes("gzip")) return { name: "gzip", suffix: ".gz" };
+  return { name: null, suffix: "" };
 }
 
 function isUnder(dir: string, file: string): boolean {

--- a/otp/js/scripts/setup-assets.sh
+++ b/otp/js/scripts/setup-assets.sh
@@ -32,6 +32,7 @@ ensure_runtime_artifacts() {
 }
 
 copy_runtime_assets() {
+  rm -rf "${ASSETS_DIR}/bin" "${ASSETS_DIR}/lib"
   mkdir -p "${ASSETS_DIR}" "${ASSETS_DIR}/bin" "${ASSETS_DIR}/lib"
 
   for path in beam.wasm beam.smp beam.emu; do
@@ -72,6 +73,7 @@ EOF
 }
 
 copy_dist_assets() {
+  rm -rf "${DIST_ASSETS_DIR}"
   mkdir -p "${DIST_ASSETS_DIR}" "${DIST_ASSETS_DIR}/bin" "${DIST_ASSETS_DIR}/lib"
 
   cp "${ASSETS_DIR}/beam.mjs" "${DIST_ASSETS_DIR}/beam.mjs"

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -8,12 +8,10 @@ import type {
   EmscriptenModule,
 } from "./types";
 import {
-  decompressGzip,
   dirname,
   ensureDir,
   fetchBinary,
   fetchJson,
-  isGzip,
   unreachable,
 } from "./utils";
 
@@ -192,7 +190,7 @@ async function loadFsData(manifestUrl: string): Promise<Result<LoadedFsData>> {
         };
       }
 
-      return { ok: true, data: await maybeDecompressTar(tar) };
+      return { ok: true, data: tar };
     }),
   );
 
@@ -241,14 +239,6 @@ function resolveManifestPath(manifestUrl: string, path: string): string {
 
 function isAbsoluteUrl(path: string): boolean {
   return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(path);
-}
-
-async function maybeDecompressTar(tar: Uint8Array): Promise<Uint8Array> {
-  if (!isGzip(tar)) {
-    return tar;
-  }
-
-  return decompressGzip(tar);
 }
 
 export function send(

--- a/otp/js/src/utils.ts
+++ b/otp/js/src/utils.ts
@@ -36,21 +36,6 @@ export async function fetchJson<T>(url: string): Promise<T | null> {
   }
 }
 
-export function isGzip(data: Uint8Array): boolean {
-  return (
-    data.length >= 3 && data[0] === 0x1f && data[1] === 0x8b && data[2] === 0x08
-  );
-}
-
-export async function decompressGzip(data: Uint8Array): Promise<Uint8Array> {
-  const bytes = data.slice();
-  const stream = new Blob([bytes])
-    .stream()
-    .pipeThrough(new DecompressionStream("gzip"));
-  const buffer = await new Response(stream).arrayBuffer();
-  return new Uint8Array(buffer);
-}
-
 export function check(ok: boolean, msg?: string): asserts ok {
   if (!ok) throw err("internal:check", { detail: msg });
 }

--- a/scripts/stdlib.sh
+++ b/scripts/stdlib.sh
@@ -297,7 +297,7 @@ prepare_outdir() {
     mkdir -p "${outdir}"
 
     shopt -s nullglob
-    for path in "${outdir}"/*.tar.gz; do
+    for path in "${outdir}"/*.tar "${outdir}"/*.tar.br "${outdir}"/*.tar.gz; do
         rm -f "${path}"
     done
     shopt -u nullglob
@@ -328,8 +328,8 @@ create_otp_tarballs() {
             src_root="${beam_dir}/bootstrap"
         fi
 
-        tarball="${outdir}/${app}.tar.gz"
-        tar -C "${src_root}" -czf "${tarball}" "lib/${app}/ebin"
+        tarball="${outdir}/${app}.tar"
+        tar -C "${src_root}" -cf "${tarball}" "lib/${app}/ebin"
         GENERATED_TARBALLS+=("${tarball}")
     done
 
@@ -350,8 +350,8 @@ create_elixir_tarballs() {
             error "Missing Elixir app ebin dir for '${app}' in ${elixir_dir}."
         }
 
-        tarball="${outdir}/${app}.tar.gz"
-        tar -C "${elixir_dir}" -czf "${tarball}" "lib/${app}/ebin"
+        tarball="${outdir}/${app}.tar"
+        tar -C "${elixir_dir}" -cf "${tarball}" "lib/${app}/ebin"
         GENERATED_TARBALLS+=("${tarball}")
     done
 
@@ -379,13 +379,13 @@ write_tarball_manifest() {
         prefix=""
 
         for app in "${SELECTED_APPS[@]}"; do
-            tarball="${outdir}/${app}.tar.gz"
+            tarball="${outdir}/${app}.tar"
             if [[ ! -f "${tarball}" ]]; then
                 error "Expected tarball not found: ${tarball}"
             fi
 
             version=$(app_version "${beam_dir}" "${elixir_dir}" "${app}")
-            printf '%s"%s":{"tar":"lib/%s.tar.gz","version":"%s"}' "${prefix}" "${app}" "${app}" "${version}"
+            printf '%s"%s":{"tar":"lib/%s.tar","version":"%s"}' "${prefix}" "${app}" "${app}" "${version}"
             prefix=","
         done
 


### PR DESCRIPTION
Always gzip, brotli when requested by `{brotli: true}` (lvl 11, quite slow). Make compression browser-level concern, so JS doesn't need to use DecompressionStream.

Renames otp-assets to otp and simplifies path joining while we're at it.