### PR TITLE
otp: migrate e2e tests to plugin

### DIFF
--- a/.github/workflows/otp_js_e2e_test.yml
+++ b/.github/workflows/otp_js_e2e_test.yml
@@ -74,12 +74,13 @@ jobs:
         with:
           version: "1.60.0"
 
-      # The e2e suite compiles a small OTP fixture app with escript, so host
-      # Erlang must be present even when the WASM build is restored from cache.
-      - name: Setup Erlang
+      # The e2e suite compiles and packages an OTP fixture app, so a host
+      # toolchain matching the WASM runtime is required even on cache hits.
+      - name: Setup Elixir and Erlang
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
-          otp-version: "26.0.2"
+          elixir-version: "1.19.5"
+          otp-version: "28.3.1"
 
       - name: Run e2e tests
         run: pnpm e2e

--- a/otp/js/e2e/otp.spec.ts
+++ b/otp/js/e2e/otp.spec.ts
@@ -28,7 +28,7 @@ test("boots", async ({ otp }) => {
 
 test("auto-starts the manifest entrypoint app", async ({ otp }) => {
   const result = await otp.boot({
-    beam: { manifestUrl: "/assets/otp/manifest-entrypoint.json" },
+    beam: { manifestUrl: "/assets/otp/manifest.json" },
   });
   expect(result).toEqual({ ok: true, data: null });
 

--- a/otp/js/e2e/setup/entrypoint-app/build-fixture.escript
+++ b/otp/js/e2e/setup/entrypoint-app/build-fixture.escript
@@ -1,7 +1,7 @@
 #!/usr/bin/env escript
 
-main([SrcDir, StageDir, OutTar]) ->
-    EbinDir = filename:join([StageDir, "lib", "test_entrypoint", "ebin"]),
+main([SrcDir]) ->
+    EbinDir = filename:join([SrcDir, "_build", "dev", "lib", "test_entrypoint", "ebin"]),
     ok = filelib:ensure_dir(filename:join(EbinDir, "keep")),
     {ok, _} =
         compile:file(filename:join(SrcDir, "test_entrypoint_app.erl"), [{outdir, EbinDir}, report]),
@@ -10,5 +10,4 @@ main([SrcDir, StageDir, OutTar]) ->
             filename:join(SrcDir, "test_entrypoint.app"),
             filename:join(EbinDir, "test_entrypoint.app")
         ),
-    ok = erl_tar:create(OutTar, [{"lib/test_entrypoint/ebin", EbinDir}], []),
     ok.

--- a/otp/js/e2e/setup/global-setup.ts
+++ b/otp/js/e2e/setup/global-setup.ts
@@ -1,5 +1,4 @@
 import { spawn, ChildProcess } from "child_process";
-import { readFile, writeFile } from "fs/promises";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -73,40 +72,18 @@ async function globalSetup() {
 
 export default globalSetup;
 
-// Packs a tiny OTP application whose start/2 sends a wasm message, and writes a
-// manifest with `entrypoint` set to it, so the entrypoint auto-start can be
-// exercised end-to-end without any extraArgs.
 async function buildEntrypointFixture(env: NodeJS.ProcessEnv): Promise<void> {
   console.log("e2e: building entrypoint fixture app...");
 
-  const distAssetsDir = resolve(jsRootDir, "dist/assets");
   const fixtureSrcDir = resolve(__dirname, "entrypoint-app");
   const escript = resolve(fixtureSrcDir, "build-fixture.escript");
-  const stageDir = resolve(distAssetsDir, ".entrypoint-stage");
-  const tar = "lib/test_entrypoint.tar";
 
   await runCommand(
     "escript",
-    [escript, fixtureSrcDir, stageDir, resolve(distAssetsDir, tar)],
+    [escript, fixtureSrcDir],
     fixtureSrcDir,
-    "compiling and packing entrypoint fixture",
+    "compiling entrypoint fixture",
     env,
-  );
-
-  const baseManifest = JSON.parse(
-    await readFile(resolve(distAssetsDir, "manifest.json"), "utf8"),
-  );
-  const manifest = {
-    ...baseManifest,
-    entrypoint: "test_entrypoint",
-    apps: {
-      ...baseManifest.apps,
-      test_entrypoint: { tar, version: "0.1.0" },
-    },
-  };
-  await writeFile(
-    resolve(distAssetsDir, "manifest-entrypoint.json"),
-    JSON.stringify(manifest),
   );
 }
 

--- a/otp/js/e2e/setup/vite.config.ts
+++ b/otp/js/e2e/setup/vite.config.ts
@@ -1,108 +1,27 @@
-import { readFile } from "fs/promises";
-import { resolve, dirname, relative, isAbsolute } from "path";
+import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
-import { defineConfig, type Plugin } from "vite";
-
-import type { IncomingMessage, ServerResponse } from "http";
+import { defineConfig } from "vite";
+import { popcorn } from "@swmansion/popcorn-otp/vite";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const otpJsRootDir = resolve(__dirname, "../..");
-const assetsDir = resolve(otpJsRootDir, "dist/assets");
-const CORS_HEADERS = {
-  "Cross-Origin-Opener-Policy": "same-origin",
-  "Cross-Origin-Embedder-Policy": "require-corp",
-};
-
-type Res = ServerResponse<IncomingMessage>;
-
-function otpPlugin(): Plugin {
-  const serveAsset = async (
-    req: IncomingMessage,
-    res: Res,
-    next: () => void,
-  ) => {
-    const requestUrl = req.url;
-    if (requestUrl === undefined || !requestUrl.startsWith("/assets/otp/")) {
-      next();
-      return;
-    }
-
-    const relativePath = requestUrl.slice("/assets/otp/".length);
-    const filePath = resolve(assetsDir, relativePath);
-    const assetRelativePath = relative(assetsDir, filePath);
-    if (assetRelativePath.startsWith("..") || isAbsolute(assetRelativePath)) {
-      res.statusCode = 403;
-      setHeaders(res);
-      res.end("Forbidden");
-      return;
-    }
-
-    try {
-      const content = await readFile(filePath);
-      setHeaders(res);
-      setContentType(res, filePath);
-      res.end(content);
-    } catch {
-      res.statusCode = 404;
-      setHeaders(res);
-      res.end("Not found");
-    }
-  };
-
-  return {
-    name: "otp",
-    configureServer(server) {
-      server.middlewares.use(serveAsset);
-    },
-    configurePreviewServer(server) {
-      server.middlewares.use(serveAsset);
-    },
-  };
-}
-
-function setHeaders(res: Res) {
-  for (const [key, value] of Object.entries(CORS_HEADERS)) {
-    res.setHeader(key, value);
-  }
-}
-
-function setContentType(res: Res, path: string) {
-  if (path.endsWith(".mjs")) {
-    res.setHeader("Content-Type", "text/javascript");
-    return;
-  }
-  if (path.endsWith(".wasm")) {
-    res.setHeader("Content-Type", "application/wasm");
-    return;
-  }
-  if (path.endsWith(".json")) {
-    res.setHeader("Content-Type", "application/json");
-    return;
-  }
-  res.setHeader("Content-Type", "application/octet-stream");
-}
-
 export default defineConfig({
   root: __dirname,
-  plugins: [otpPlugin()],
+  plugins: [
+    popcorn({
+      rootDir: resolve(__dirname, "entrypoint-app"),
+      app: "test_entrypoint",
+    }),
+  ],
   server: {
     host: "127.0.0.1",
     port: 5173,
     strictPort: true,
-    headers: CORS_HEADERS,
-    fs: {
-      allow: [otpJsRootDir],
-    },
   },
   preview: {
     host: "127.0.0.1",
     port: 5173,
     strictPort: true,
-    headers: CORS_HEADERS,
-  },
-  optimizeDeps: {
-    exclude: ["@swmansion/popcorn-otp"],
   },
 });


### PR DESCRIPTION
Drop custom code for e2e tests – we can simply use vite plugin.