### PR TITLE
otp: worker as separate entrypoint

### DIFF
--- a/otp/js/package.json
+++ b/otp/js/package.json
@@ -16,10 +16,6 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"
     },
-    "./beam": {
-      "types": "./dist/beam.d.ts",
-      "import": "./dist/beam.mjs"
-    },
     "./esbuild": {
       "types": "./dist/plugins/esbuild.d.ts",
       "import": "./dist/plugins/esbuild.mjs"

--- a/otp/js/plugins/shared.ts
+++ b/otp/js/plugins/shared.ts
@@ -18,7 +18,6 @@ const execFileAsync = promisify(execFile);
 const brotliCompressAsync = promisify(brotliCompress);
 const gzipAsync = promisify(gzip);
 const OTP_DIR = "assets/otp";
-const manifestUrl = `/${OTP_DIR}/manifest.json`;
 
 export type Options = {
   rootDir: string;
@@ -28,7 +27,6 @@ export type Options = {
 
 export type Prepared = {
   dir: string;
-  manifestUrl: string;
   notes: unknown[];
 };
 
@@ -105,7 +103,6 @@ export async function popcorn(opts: Options): Promise<Prepared> {
 
     return {
       dir: preparedDir,
-      manifestUrl,
       notes: report.notes ?? [],
     };
   } catch (error) {

--- a/otp/js/rollup.config.mjs
+++ b/otp/js/rollup.config.mjs
@@ -1,5 +1,5 @@
-import { copyFile, mkdir } from "node:fs/promises";
-import { dirname } from "node:path";
+import { copyFile, mkdir, readdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import typescript from "@rollup/plugin-typescript";
 
 function copyFiles(targets) {
@@ -16,22 +16,53 @@ function copyFiles(targets) {
   };
 }
 
-export default [
-  // Main library
-  {
-    input: {
-      index: "src/index.ts",
-      worker: "src/worker.ts",
+function cleanDir(dir) {
+  return {
+    name: "clean-dir",
+    async buildStart() {
+      await rm(dir, { recursive: true, force: true });
     },
+  };
+}
+
+function cleanModules(dir) {
+  return {
+    name: "clean-modules",
+    async buildStart() {
+      await mkdir(dir, { recursive: true });
+      const entries = await readdir(dir, { withFileTypes: true });
+      await Promise.all(
+        entries
+          .filter((entry) => entry.isFile() && entry.name.endsWith(".mjs"))
+          .map((entry) => rm(join(dir, entry.name))),
+      );
+    },
+  };
+}
+
+export default [
+  {
+    input: "src/index.ts",
     output: {
-      dir: "dist",
+      file: "dist/index.mjs",
       format: "esm",
-      entryFileNames: "[name].mjs",
-      preserveModules: true,
-      preserveModulesRoot: "src",
     },
     cache: false,
-    external: (id) => id.startsWith("node:"),
+    plugins: [
+      cleanModules("dist"),
+      typescript({ tsconfig: "./tsconfig.json", outputToFilesystem: true }),
+    ],
+  },
+  {
+    input: "src/worker.ts",
+    output: {
+      file: "dist/worker.mjs",
+      format: "esm",
+      paths: (id) =>
+        id.endsWith("/assets/beam.mjs") ? "./assets/beam.mjs" : id,
+    },
+    external: (id) => id.endsWith("/assets/beam.mjs"),
+    cache: false,
     plugins: [
       typescript({ tsconfig: "./tsconfig.json", outputToFilesystem: true }),
     ],
@@ -46,11 +77,13 @@ export default [
       dir: "dist/plugins",
       format: "esm",
       entryFileNames: "[name].mjs",
+      chunkFileNames: "[name].mjs",
     },
     external: (id) =>
-      id.startsWith("node") || ["esbuild", "rollup", "vite"].includes(id),
+      id.startsWith("node:") || ["esbuild", "rollup", "vite"].includes(id),
     cache: false,
     plugins: [
+      cleanDir("dist/plugins"),
       typescript({
         tsconfig: "./plugins/tsconfig.json",
         outputToFilesystem: true,

--- a/otp/js/src/index.ts
+++ b/otp/js/src/index.ts
@@ -1,12 +1,6 @@
-export { boot } from "./beam";
 export { PopcornError } from "./errors";
 export { Popcorn } from "./popcorn";
 export type { PopcornOpts, PopcornSendOpts } from "./popcorn";
 export type { PopcornEvent } from "./events";
-export type {
-  BeamBootOptions,
-  BeamEvent,
-  BeamTarget,
-  OtpErrorPayload,
-} from "./types";
+export type { BeamTarget, OtpErrorPayload } from "./types";
 export type { PopcornErrors, SerializedError } from "./errors";


### PR DESCRIPTION
This was needed to avoid listing files in vite plugin. This should produce two entrypoints, one for main context, one for webworker context.