### PR TITLE
otp: use ETF for VM communication

### DIFF
--- a/otp/js/e2e/bridge.spec.ts
+++ b/otp/js/e2e/bridge.spec.ts
@@ -1,17 +1,156 @@
 import { assert, evalOpts, expect, test, trimLeft } from "./helpers";
+import { tuple2 } from "../src/etf";
+
+const PAYLOAD = {
+  text: "zażółć",
+  nullValue: null,
+  boolTrue: true,
+  boolFalse: false,
+  numbers: [
+    0,
+    2 ** 8 - 1,
+    2 ** 8,
+    -1,
+    2 ** 31 - 1,
+    -(2 ** 31),
+    2 ** 31,
+    -(2 ** 31) - 1,
+    Number.MAX_SAFE_INTEGER,
+    Number.MIN_SAFE_INTEGER,
+    1.5,
+  ],
+  emptyList: [],
+  emptyMap: {},
+  nested: [{ value: "ok" }],
+};
+
+const META = { requestId: "req-1" };
+
+test("ETF sorts map keys", () => {
+  assert.equal(hex({ b: 2, a: 1 }), hex({ a: 1, b: 2 }));
+});
+
+test("ETF accepts null-prototype plain objects", () => {
+  const value = Object.assign(Object.create(null), { key: "value" });
+  assert(tuple2(value, {}).ok);
+});
+
+for (const [name, value, reason] of [
+  ["unsafe integer", Number.MAX_SAFE_INTEGER + 1, "lossy-int"],
+  ["positive infinity", Infinity, "non-finite-float"],
+  ["negative infinity", -Infinity, "non-finite-float"],
+  ["NaN", NaN, "non-finite-float"],
+  ["undefined", undefined, "unsupported"],
+  ["function", () => null, "unsupported"],
+  ["symbol", Symbol("value"), "unsupported"],
+  ["non-plain object", new Date(), "non-plain-object"],
+] as const) {
+  test(`ETF reports ${name}`, () => {
+    const result = tuple2(value, {});
+    assert(!result.ok);
+    assert.equal(result.error.t, "bridge:unserializable");
+    assert.equal(result.error.data.data, value);
+    assert.equal(result.error.data.part, value);
+    assert.equal(result.error.data.reason, reason);
+  });
+}
+
+test("ETF reports cyclic values", () => {
+  const value: unknown[] = [];
+  value.push(value);
+  const result = tuple2(value, {});
+  assert(!result.ok);
+  assert.equal(result.error.data.data, value);
+  assert.equal(result.error.data.part, value);
+  assert.equal(result.error.data.reason, "cyclic-object");
+});
+
+test("ETF encodes enumerable string properties", () => {
+  const symbolKey = { visible: true, [Symbol("key")]: true };
+  const hidden = Object.defineProperty({}, "hidden", { value: true });
+  const accessor = Object.defineProperty({}, "value", {
+    enumerable: true,
+    get: () => true,
+  });
+  const extendedArray = Object.assign([], { extra: true });
+
+  assert.equal(hex(symbolKey), hex({ visible: true }));
+  assert.equal(hex(hidden), hex({}));
+  assert.equal(hex(accessor), hex({ value: true }));
+  assert.equal(hex(extendedArray), hex([]));
+  const sparse = new Array(1);
+  const result = tuple2(sparse, {});
+  assert(!result.ok);
+  assert.equal(result.error.data.data, sparse);
+  assert.equal(result.error.data.part, undefined);
+  assert.equal(result.error.data.reason, "unsupported");
+});
+
+test("ETF reports unsupported nested values", () => {
+  const fn = () => null;
+  const symbol = Symbol();
+  for (const [value, part] of [
+    [{ value: undefined }, undefined],
+    [[fn], fn],
+    [{ value: symbol }, symbol],
+  ] as const) {
+    const result = tuple2(value, {});
+    assert(!result.ok);
+    assert.equal(result.error.data.data, value);
+    assert.equal(result.error.data.part, part);
+    assert.equal(result.error.data.reason, "unsupported");
+  }
+});
+
+test("ETF reports the failing metadata part with the full payload", () => {
+  const data = { value: "ok" };
+  const part = new Date();
+  const result = tuple2(data, { part });
+  assert(!result.ok);
+  assert.equal(result.error.data.data, data);
+  assert.equal(result.error.data.part, part);
+  assert.equal(result.error.data.reason, "non-plain-object");
+});
 
 test("handles events in both directions", async ({ otp }) => {
   const BRIDGE_BOOT_EVAL = trimLeft(`
     spawn(fun() ->
+      ExpectedPayload = #{
+        <<"text">> => <<"zażółć"/utf8>>,
+        <<"nullValue">> => nil,
+        <<"boolTrue">> => true,
+        <<"boolFalse">> => false,
+        <<"numbers">> => [
+          0,
+          (1 bsl 8) - 1,
+          1 bsl 8,
+          -1,
+          (1 bsl 31) - 1,
+          -(1 bsl 31),
+          1 bsl 31,
+          -(1 bsl 31) - 1,
+          (1 bsl 53) - 1,
+          -((1 bsl 53) - 1),
+          1.5
+        ],
+        <<"emptyList">> => [],
+        <<"emptyMap">> => #{},
+        <<"nested">> => [#{<<"value">> => <<"ok">>}]
+      },
+      ExpectedMeta = #{<<"requestId">> => <<"req-1">>},
+      ExpectedEtf = base64:encode(term_to_binary({ExpectedPayload, ExpectedMeta})),
+      ok = wasm:send(#{etf_expected => ExpectedEtf}),
       ok = wasm:send(#{direct => true, nested => #{count => 1}}),
       true = register(bridge, self()),
       Loop = fun(F) ->
         ok = wasm:send(#{bridge_ready => true}),
         receive
-          {wasm, PayloadJson, MetaJson} ->
-            Payload = json:decode(PayloadJson),
-            Meta = json:decode(MetaJson),
-            ok = wasm:send(#{reply => Payload, meta => Meta})
+          {wasm, Payload, Meta} ->
+            Shape = case {Payload, Meta} of
+              {ExpectedPayload, ExpectedMeta} -> decoded;
+              _ -> unexpected
+            end,
+            ok = wasm:send(#{reply => Payload, meta => Meta, shape => Shape})
         after 100 ->
             F(F)
         end
@@ -22,6 +161,10 @@ test("handles events in both directions", async ({ otp }) => {
   const boot = await otp.boot(evalOpts(BRIDGE_BOOT_EVAL));
 
   assert(boot.ok);
+  const expectedEtf = await otp.waitForEvent("etf_expected");
+  expect(expectedEtf).toEqual({
+    etf_expected: Buffer.from(encode(PAYLOAD, META)).toString("base64"),
+  });
   await otp.waitForEvent("direct");
   expect(otp.events).toContainEqual({
     direct: true,
@@ -30,20 +173,18 @@ test("handles events in both directions", async ({ otp }) => {
 
   await otp.waitForEvent("bridge_ready");
 
-  const send = await otp.send(
-    "bridge",
-    { ping: true },
-    { meta: { requestId: "req-1" } },
-  );
+  const send = await otp.send("bridge", structuredClone(PAYLOAD), {
+    meta: structuredClone(META),
+  });
   assert(send.ok);
 
   await otp.waitForEvent("reply");
   expect(otp.events).toContainEqual({
-    reply: { ping: true },
-    meta: { requestId: "req-1" },
+    reply: { ...PAYLOAD, nullValue: "nil" },
+    meta: META,
+    shape: "decoded",
   });
 });
-
 
 test("run_js -> send", async ({ otp }) => {
   const RUN_JS_BOOT_EVAL = trimLeft(`
@@ -101,7 +242,6 @@ test("throwing run_js raises in VM", async ({ otp }) => {
   expect(otp.events).toContainEqual({ run_js_error: "Error: boom" });
 });
 
-
 test("send() to unregistered process", async ({ otp }) => {
   const READY_BOOT_EVAL = "ok = wasm:send(#{ready => true}).";
   const boot = await otp.boot(evalOpts(READY_BOOT_EVAL));
@@ -132,3 +272,12 @@ test("send() timeout", async ({ otp }) => {
   });
 });
 
+function hex(payload: unknown, meta: unknown = {}): string {
+  return Buffer.from(encode(payload, meta)).toString("hex");
+}
+
+function encode(payload: unknown, meta: unknown): Uint8Array<ArrayBuffer> {
+  const result = tuple2(payload, meta);
+  assert(result.ok);
+  return result.data;
+}

--- a/otp/js/e2e/tracked-values.spec.ts
+++ b/otp/js/e2e/tracked-values.spec.ts
@@ -109,8 +109,7 @@ test("tracked argument cleanup waits for async run_js to finish", async ({
       ok = wasm:send(#{async_runner_ready => true})
     end),
     receive
-      {wasm, PayloadJson, _} ->
-        #{<<"collect">> := true} = json:decode(PayloadJson),
+      {wasm, #{<<"collect">> := true}, _} ->
         % Force collection while Runner is blocked inside wasm:run_js/3.
         erlang:garbage_collect(Runner),
         ok = wasm:send(#{async_runner_collected => true})
@@ -216,5 +215,4 @@ test("tracked values isolated cleanup", async ({ createOtp, page }) => {
   expect(liveEvent).toEqual({ v: 42 });
   expect(cleanupCalls).toBe(1);
 });
-
 

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -277,19 +277,15 @@ export function send(
       "number",
       target.argType,
       "number",
-      "string",
-      "number",
-      "string",
+      "array",
       "number",
     ],
     [
       target.kind,
       target.value,
       target.length,
-      message.payloadJson,
-      utf8Length(message.payloadJson),
-      message.metaJson,
-      utf8Length(message.metaJson),
+      message.etf,
+      message.etf.byteLength,
     ],
   );
 

--- a/otp/js/src/errors.ts
+++ b/otp/js/src/errors.ts
@@ -10,7 +10,7 @@ export type PopcornErrors = {
   "vm:exited": VmExitedData;
   "bridge:not-started": EmptyData;
   "bridge:invalid-target": EmptyData;
-  "bridge:unserializable": EmptyData;
+  "bridge:unserializable": UnserializableData;
   "bridge:listener-not-found": { targetName: string };
   "beam:missing-boot-script": { url: string };
   "beam:missing-manifest": { url: string };
@@ -25,6 +25,17 @@ export type SerializedError<T extends Tag = Tag> = {
 }[T];
 
 type EmptyData = Record<never, never>;
+export type UnserializableReason =
+  | "cyclic-object"
+  | "non-plain-object"
+  | "lossy-int"
+  | "non-finite-float"
+  | "unsupported";
+type UnserializableData = {
+  data: unknown;
+  part: unknown;
+  reason: UnserializableReason;
+};
 type VmExitedData =
   | { reason: "deinit" }
   | { reason: "abort"; data: string }
@@ -50,13 +61,14 @@ export function isErr<T extends Tag = Tag>(
 }
 
 export class PopcornError<T extends Tag = Tag> extends Error {
-  declare readonly cause: SerializedError<T>;
+  override readonly cause: SerializedError<T>;
   private readonly serialized: SerializedError<T>;
 
   constructor(cause: SerializedError<T>) {
     super(message(cause), { cause });
     this.name = "PopcornError";
     Object.setPrototypeOf(this, new.target.prototype);
+    this.cause = cause;
     this.serialized = cause;
   }
 
@@ -96,7 +108,7 @@ function message(error: SerializedError): string {
     case "bridge:invalid-target":
       return "Target name must not be empty";
     case "bridge:unserializable":
-      return "Message can't be serialized to string";
+      return "Message can't be serialized to ETF";
     case "bridge:listener-not-found":
       return `Target listener not found: '${error.data.targetName}'`;
     case "beam:missing-boot-script":
@@ -138,7 +150,7 @@ function parse(value: unknown): SerializedError {
       check(isEmptyData(value.data));
       return { t: value.t, data: value.data };
     case "bridge:unserializable":
-      check(isEmptyData(value.data));
+      check(isUnserializableData(value.data));
       return { t: value.t, data: value.data };
     case "bridge:listener-not-found":
       check(isListenerNotFoundData(value.data));
@@ -182,6 +194,27 @@ function isListenerNotFoundData(
   value: unknown,
 ): value is PopcornErrors["bridge:listener-not-found"] {
   return objectWithKeys(value, ["targetName"]) !== null;
+}
+
+function isUnserializableData(
+  value: unknown,
+): value is PopcornErrors["bridge:unserializable"] {
+  return (
+    objectWithKeys(value, ["data", "part", "reason"]) &&
+    isUnserializableReason(value.reason)
+  );
+}
+
+export function isUnserializableReason(
+  value: unknown,
+): value is UnserializableReason {
+  return (
+    value === "cyclic-object" ||
+    value === "non-plain-object" ||
+    value === "lossy-int" ||
+    value === "non-finite-float" ||
+    value === "unsupported"
+  );
 }
 
 function isUrlData(

--- a/otp/js/src/etf.ts
+++ b/otp/js/src/etf.ts
@@ -1,0 +1,211 @@
+import {
+  err as popcornError,
+  isUnserializableReason,
+  type Result,
+  type UnserializableReason,
+} from "./errors";
+
+const VERSION = 0x83;
+const NEW_FLOAT_EXT = 0x46;
+const SMALL_INTEGER_EXT = 0x61;
+const INTEGER_EXT = 0x62;
+const SMALL_TUPLE_EXT = 0x68;
+const NIL_EXT = 0x6a;
+const LIST_EXT = 0x6c;
+const BINARY_EXT = 0x6d;
+const SMALL_BIG_EXT = 0x6e;
+const MAP_EXT = 0x74;
+const SMALL_ATOM_UTF8_EXT = 0x77;
+
+const UTF8 = new TextEncoder();
+
+type Atom = "true" | "false" | "nil";
+
+export function tuple2(
+  data: unknown,
+  meta: unknown,
+): Result<Uint8Array<ArrayBuffer>, "bridge:unserializable"> {
+  try {
+    return { ok: true, data: new Encoder().tuple2(data, meta) };
+  } catch (error) {
+    let reason: UnserializableReason = "unsupported";
+    let part = data;
+    if (error instanceof TypeError && isUnserializableReason(error.message)) {
+      reason = error.message;
+      part = error.cause;
+    }
+    return {
+      ok: false,
+      error: popcornError("bridge:unserializable", { data, part, reason }),
+    };
+  }
+}
+
+class Encoder {
+  private readonly ancestors = new Set<object>();
+  private readonly output: number[] = [];
+  private readonly buffer = new ArrayBuffer(8);
+  private readonly view = new DataView(this.buffer);
+
+  tuple2(left: unknown, right: unknown): Uint8Array<ArrayBuffer> {
+    this.byte(VERSION);
+    this.byte(SMALL_TUPLE_EXT);
+    this.byte(2);
+    this.value(left);
+    this.value(right);
+    return new Uint8Array(this.output);
+  }
+
+  private value(value: unknown): void {
+    if (value === null) {
+      this.atom("nil");
+      return;
+    }
+
+    switch (typeof value) {
+      case "boolean":
+        this.atom(value ? "true" : "false");
+        return;
+      case "string":
+        this.binary(value);
+        return;
+      case "number":
+        this.number(value);
+        return;
+      case "object":
+        this.object(value);
+        return;
+      default:
+        throw err("unsupported", value);
+    }
+  }
+
+  private number(value: number): void {
+    if (!Number.isFinite(value)) {
+      throw err("non-finite-float", value);
+    }
+    if (!Number.isInteger(value)) {
+      this.byte(NEW_FLOAT_EXT);
+      this.float64(value);
+      return;
+    }
+    if (!Number.isSafeInteger(value)) {
+      throw err("lossy-int", value);
+    }
+    if (value >= 0 && value < 2 ** 8) {
+      this.byte(SMALL_INTEGER_EXT);
+      this.byte(value);
+      return;
+    }
+    if (value >= -(2 ** 31) && value < 2 ** 31) {
+      this.byte(INTEGER_EXT);
+      this.int32(value);
+      return;
+    }
+
+    this.smallBigInt(value);
+  }
+
+  // https://www.erlang.org/doc/apps/erts/erl_ext_dist.html#small_big_ext
+  private smallBigInt(value: number): void {
+    let magnitude = BigInt(Math.abs(value));
+    const digits: number[] = [];
+    while (magnitude > 0n) {
+      digits.push(Number(magnitude & 0xffn));
+      magnitude >>= 8n;
+    }
+    this.byte(SMALL_BIG_EXT);
+    this.byte(digits.length);
+    this.byte(value < 0 ? 1 : 0);
+    this.bytes(digits);
+  }
+
+  private object(value: object): void {
+    if (this.ancestors.has(value)) {
+      throw err("cyclic-object", value);
+    }
+    this.ancestors.add(value);
+    try {
+      if (Array.isArray(value)) {
+        this.array(value);
+        return;
+      }
+
+      const prototype = Object.getPrototypeOf(value);
+      const isObject = prototype === Object.prototype || prototype === null;
+      if (!isObject) {
+        throw err("non-plain-object", value);
+      }
+      this.map(value);
+    } finally {
+      this.ancestors.delete(value);
+    }
+  }
+
+  private array(value: unknown[]): void {
+    if (value.length === 0) {
+      this.byte(NIL_EXT);
+      return;
+    }
+
+    this.byte(LIST_EXT);
+    this.uint32(value.length);
+    for (const item of value) {
+      this.value(item);
+    }
+    this.byte(NIL_EXT);
+  }
+
+  private map(value: object): void {
+    const keys = Object.keys(value).sort();
+    this.byte(MAP_EXT);
+    this.uint32(keys.length);
+    for (const key of keys) {
+      this.binary(key);
+      this.value((value as Record<string, unknown>)[key]);
+    }
+  }
+
+  private atom(atom: Atom): void {
+    const bytes = UTF8.encode(atom);
+    this.byte(SMALL_ATOM_UTF8_EXT);
+    this.byte(bytes.length);
+    this.bytes(bytes);
+  }
+
+  private binary(value: string): void {
+    const bytes = UTF8.encode(value);
+    this.byte(BINARY_EXT);
+    this.uint32(bytes.length);
+    this.bytes(bytes);
+  }
+
+  private byte(value: number): void {
+    this.output.push(value);
+  }
+
+  private bytes(values: ArrayLike<number>): void {
+    for (let index = 0; index < values.length; index++) {
+      this.output.push(values[index]);
+    }
+  }
+
+  private uint32(value: number): void {
+    this.view.setUint32(0, value);
+    this.bytes(new Uint8Array(this.buffer, 0, 4));
+  }
+
+  private int32(value: number): void {
+    this.view.setInt32(0, value);
+    this.bytes(new Uint8Array(this.buffer, 0, 4));
+  }
+
+  private float64(value: number): void {
+    this.view.setFloat64(0, value);
+    this.bytes(new Uint8Array(this.buffer));
+  }
+}
+
+function err(reason: UnserializableReason, part: unknown): TypeError {
+  return new TypeError(reason, { cause: part });
+}

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -1,4 +1,5 @@
 import { type Result, type SerializedError } from "./errors";
+import { tuple2 } from "./etf";
 import type {
   AnyValue,
   BeamBootOptions,
@@ -123,14 +124,9 @@ export function serializeSendPayload(
     check(target.pid.length > 0);
   }
 
-  return {
-    ok: true,
-    data: {
-      target,
-      payloadJson: serializeJson(payload),
-      metaJson: serializeJson(meta),
-    },
-  };
+  const etf = tuple2(payload, meta);
+  if (!etf.ok) return etf;
+  return { ok: true, data: { target, etf: etf.data } };
 }
 
 function isNameTarget(
@@ -175,8 +171,12 @@ export function deserializeBridgeMessage(
 }
 
 /** Usable only from main context. */
-export function toVm(worker: Worker, event: MainToVmEvent): void {
-  worker.postMessage(event);
+export function toVm(
+  worker: Worker,
+  event: MainToVmEvent,
+  transfer?: Transferable[],
+): void {
+  worker.postMessage(event, transfer ?? []);
 }
 
 /** Usable only from webworkers. */
@@ -188,10 +188,4 @@ function isBridgeEnvelope(value: unknown): value is BridgeEnvelope {
   const KNOWN_MESSAGE_TYPES: unknown[] = ["vm_message", "vm_error", "run_js"];
   const data = objectWithKeys(value, ["type"]);
   return data !== null && KNOWN_MESSAGE_TYPES.includes(data.type);
-}
-
-function serializeJson(value: AnyValue): string {
-  const serialized = JSON.stringify(value);
-  check(serialized !== undefined);
-  return serialized;
 }

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -248,10 +248,14 @@ export class Popcorn {
         clearTimeout(timer);
         resolve(result);
       });
-      toVm(this.vmWorker, {
-        type: "popcorn:send",
-        payload: { id: requestId, message: command.data },
-      });
+      toVm(
+        this.vmWorker,
+        {
+          type: "popcorn:send",
+          payload: { id: requestId, message: command.data },
+        },
+        [command.data.etf.buffer],
+      );
     });
   }
 
@@ -314,10 +318,14 @@ export class Popcorn {
 
     const command = serializeSendPayload({ pid: request.replyTo }, payload, {});
     check(command.ok);
-    toVm(this.vmWorker, {
-      type: "popcorn:run-js-reply",
-      payload: { message: command.data },
-    });
+    toVm(
+      this.vmWorker,
+      {
+        type: "popcorn:run-js-reply",
+        payload: { message: command.data },
+      },
+      [command.data.etf.buffer],
+    );
   }
 
   private jsWithCurrentEnv(code: string): unknown {

--- a/otp/js/src/types.ts
+++ b/otp/js/src/types.ts
@@ -6,8 +6,7 @@ export type BeamTarget = { name: string } | { pid: string };
 
 export type BeamSendPayload = {
   target: BeamTarget;
-  payloadJson: string;
-  metaJson: string;
+  etf: Uint8Array<ArrayBuffer>;
 };
 
 export type BeamBootOptions = {

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -191,10 +191,10 @@ index 0000000000000000000000000000000000000000..ed09e8dd4ff11df4fe5e8b9adcb4dc70
 +});
 diff --git a/erts/emulator/nifs/common/wasm_nif.c b/erts/emulator/nifs/common/wasm_nif.c
 new file mode 100644
-index 0000000000000000000000000000000000000000..59f98e78d8c00ce54afc7525937acf2e640b20a5
+index 0000000000000000000000000000000000000000..730183d503d8b85a95083be2b9b7719ed99cd009
 --- /dev/null
 +++ b/erts/emulator/nifs/common/wasm_nif.c
-@@ -0,0 +1,655 @@
+@@ -0,0 +1,651 @@
 +/*
 + * %CopyrightBegin%
 + *
@@ -308,8 +308,7 @@ index 0000000000000000000000000000000000000000..59f98e78d8c00ce54afc7525937acf2e
 +
 +#ifdef ERTS_EMSCRIPTEN
 +int sendVmMessage(int target_kind, const char *target_name, int target_name_len,
-+                  const char *payload_json, int payload_len,
-+                  const char *meta_json, int meta_len);
++                  const unsigned char *etf, int etf_len);
 +#endif
 +
 +static void init_atoms(ErlNifEnv *env) {
@@ -769,28 +768,37 @@ index 0000000000000000000000000000000000000000..59f98e78d8c00ce54afc7525937acf2e
 +
 +EMSCRIPTEN_KEEPALIVE
 +int sendVmMessage(int target_kind, const char *target_name, int target_name_len,
-+                  const char *payload_json, int payload_len,
-+                  const char *meta_json, int meta_len) {
++                  const unsigned char *etf, int etf_len) {
 +  ErlNifEnv *env;
 +  ERL_NIF_TERM atom;
 +  ErlNifPid pid;
++  ERL_NIF_TERM pair;
 +  ERL_NIF_TERM payload_term;
 +  ERL_NIF_TERM message_payload;
 +  ERL_NIF_TERM meta_term;
 +  ERL_NIF_TERM message;
 +  ERL_NIF_TERM token;
++  const ERL_NIF_TERM *pair_elems;
++  int pair_arity;
++  int decoded_size;
 +  bool has_token = false;
 +
-+  if (target_name == NULL || target_name_len <= 0 || payload_len < 0 ||
-+      meta_len < 0 || (payload_json == NULL && payload_len > 0) ||
-+      (meta_json == NULL && meta_len > 0)) {
-+    return 2;
-+  }
++  ASSERT(target_name != NULL && target_name_len > 0 && etf != NULL &&
++         etf_len > 0);
 +
 +  env = enif_alloc_env();
 +  if (env == NULL) {
-+    return 2;
++    abort();
 +  }
++
++  decoded_size = enif_binary_to_term(env, etf, (size_t)etf_len, &pair,
++                                     ERL_NIF_BIN2TERM_SAFE);
++  if (decoded_size != etf_len ||
++      !enif_get_tuple(env, pair, &pair_arity, &pair_elems) || pair_arity != 2) {
++    abort();
++  }
++  payload_term = pair_elems[0];
++  meta_term = pair_elems[1];
 +
 +  if (target_kind == WASM_TARGET_PID_BYTES) {
 +    if (!decode_pid_target(env, target_name, target_name_len, &pid, &has_token,
@@ -812,16 +820,7 @@ index 0000000000000000000000000000000000000000..59f98e78d8c00ce54afc7525937acf2e
 +      return 1;
 +    }
 +  } else {
-+    enif_free_env(env);
-+    return 2;
-+  }
-+
-+  if (!make_binary_copy(env, payload_json != NULL ? payload_json : "",
-+                        (size_t)payload_len, &payload_term) ||
-+      !make_binary_copy(env, meta_json != NULL ? meta_json : "",
-+                        (size_t)meta_len, &meta_term)) {
-+    enif_free_env(env);
-+    return 2;
++    abort();
 +  }
 +
 +  message_payload =
@@ -838,16 +837,13 @@ index 0000000000000000000000000000000000000000..59f98e78d8c00ce54afc7525937acf2e
 +}
 +#else
 +int sendVmMessage(int target_kind, const char *target_name, int target_name_len,
-+                  const char *payload_json, int payload_len,
-+                  const char *meta_json, int meta_len) {
++                  const unsigned char *etf, int etf_len) {
 +  (void)target_kind;
 +  (void)target_name;
 +  (void)target_name_len;
-+  (void)payload_json;
-+  (void)payload_len;
-+  (void)meta_json;
-+  (void)meta_len;
-+  return 2;
++  (void)etf;
++  (void)etf_len;
++  abort();
 +}
 +#endif
 diff --git a/erts/emulator/sys/unix/sys.c b/erts/emulator/sys/unix/sys.c
@@ -1029,7 +1025,7 @@ index 3b672dc41a554cf7d5440ccfd94e85bd44b61d35..4e5efb04e7eb04556ff14dc3ba8e0d83
  	    ]},
 diff --git a/erts/preloaded/src/wasm.erl b/erts/preloaded/src/wasm.erl
 new file mode 100644
-index 0000000000000000000000000000000000000000..0e99092004c681b76ab1fe42831cf74197c06ee3
+index 0000000000000000000000000000000000000000..4f9ce99cd9273e45ae4e3a296392d3570e9ebaec
 --- /dev/null
 +++ b/erts/preloaded/src/wasm.erl
 @@ -0,0 +1,99 @@
@@ -1084,26 +1080,26 @@ index 0000000000000000000000000000000000000000..0e99092004c681b76ab1fe42831cf741
 +    Envelope = #{type => run_js, code => Code, args => Args, reply_to => ReplyTo},
 +    ok = send_raw(iolist_to_binary(json:encode(Envelope, fun encode_arg/2))),
 +    Reply = receive
-+                {wasm, {Token, PayloadJson}, _MetaJson} -> PayloadJson
++                {wasm, {Token, Payload}, _Meta} -> Payload
 +            after Timeout ->
 +                timeout
 +            end,
 +    ?MODULE:keep_alive(Envelope),
 +    case Reply of
 +        timeout -> error(run_js_timeout);
-+        ReplyJson -> handle_run_js_reply(ReplyJson)
++        ReplyPayload -> handle_run_js_reply(ReplyPayload)
 +    end.
 +
 +-spec keep_alive(Term) -> Term when Term :: term().
 +keep_alive(Term) ->
 +    Term.
 +
-+handle_run_js_reply(PayloadJson) ->
-+    case json:decode(PayloadJson) of
-+        #{<<"ok">> := true, <<"value">> := Value} -> revive_refs(Value);
-+        #{<<"ok">> := true} -> null;
-+        #{<<"ok">> := false, <<"error">> := Reason} -> error({run_js, Reason})
-+    end.
++handle_run_js_reply(#{<<"ok">> := true, <<"value">> := Value}) ->
++    revive_refs(Value);
++handle_run_js_reply(#{<<"ok">> := true}) ->
++    null;
++handle_run_js_reply(#{<<"ok">> := false, <<"error">> := Reason}) ->
++    error({run_js, Reason}).
 +
 +encode_arg({wasm_tracked_value, Resource}, Encoder) ->
 +    json:encode_value(#{popcorn_ref => ref_key(Resource)}, Encoder);


### PR DESCRIPTION
Until now, communication for both directions (VM <> JS) was done via JSON encoding. Main problem we had is that we send messages to processes in C which doesn't have json -> term API, so we stored strings in the message queue.

We have few options for fixing that:
- add decoder process (which implies managing its lifecycle and potentially being another bottleneck point)
- require to use Popcorn APIs to decode messages (which prevents us from pattern matching on data)
- parse JSON in C, create objects using `enif_make_*` functions (could work, I avoided doing it in C though)
- encode messages in External Term Format in JS, do `enif_binary_to_term()` in C (this approach, C is kept simple).

We still use JSON for communication VM -> JS.