### PR TITLE
otp: add pid handles

### DIFF
--- a/otp/js/e2e/helpers.ts
+++ b/otp/js/e2e/helpers.ts
@@ -12,8 +12,8 @@ import type {
   PopcornOpts,
   PopcornEvent,
   PopcornSendOpts,
-  BeamTarget,
   OtpErrorPayload,
+  Pid,
   SerializedError,
 } from "@swmansion/popcorn-otp";
 
@@ -32,8 +32,9 @@ type Otp = {
   id: string;
   events: PopcornEvent[];
   boot(options: InitOptions): Promise<BootResult>;
+  reboot(): Promise<BootResult>;
   send(
-    target: string | BeamTarget,
+    target: string | Pid,
     payload?: unknown,
     opts?: PopcornSendOpts,
   ): Promise<BootResult>;
@@ -53,6 +54,15 @@ export function evalOpts(code: string): PopcornOpts {
       extraArgs: ["-eval", code],
     },
   };
+}
+
+function pidCaptureEval(): PopcornOpts {
+  return evalOpts(
+    trimLeft(`
+      ok = wasm:send(#{pid_captured => self()}),
+      receive _ -> ok end.
+    `),
+  );
 }
 
 type PopcornHooksGlobal = typeof globalThis & {
@@ -176,8 +186,14 @@ export class OtpHandle {
     return result;
   }
 
+  public async reboot(): Promise<BootResult> {
+    const result = await this.otp.evaluate((otp) => otp.reboot());
+    await this.syncEvents();
+    return result;
+  }
+
   public async send(
-    target: string | BeamTarget,
+    target: string,
     payload?: unknown,
     opts?: PopcornSendOpts,
   ): Promise<BootResult> {
@@ -196,6 +212,35 @@ export class OtpHandle {
     );
     await this.syncEvents();
     return event;
+  }
+
+  /**
+   * Boots the instance and captures its main process as a JS `Pid` (the way the
+   * feature delivers one — a `run_js` closure receiving it in args). Returns a
+   * handle usable with `sendToPid`.
+   */
+  public async captureOwnPid(): Promise<JSHandle<Pid>> {
+    const boot = await this.boot(pidCaptureEval());
+    assert(boot.ok, "pid-capture boot failed");
+    await this.waitForEvent("pid_captured");
+
+    return this.otp.evaluateHandle((otp) => {
+      const event = otp.events.find(
+        (value): value is { pid_captured: Pid } =>
+          typeof value === "object" &&
+          value !== null &&
+          Object.hasOwn(value, "pid_captured"),
+      );
+      if (event === undefined) throw new Error("no captured pid");
+      return event.pid_captured;
+    });
+  }
+
+  /** Sends to a captured pid through this instance. */
+  public async sendToPid(pid: JSHandle<Pid>): Promise<BootResult> {
+    const result = await this.otp.evaluate((otp, p) => otp.send(p, {}), pid);
+    await this.syncEvents();
+    return result;
   }
 
   public async waitForStderr(text: string): Promise<ConsoleMessage> {
@@ -282,8 +327,16 @@ function createOtp(id: string): Otp {
       return result;
     }
 
+    public async reboot(): Promise<BootResult> {
+      const popcorn = this.popcorn;
+      popcorn.deinit();
+      const boot = await popcorn.boot();
+      if (boot.ok) return { ok: true, data: null };
+      return { ok: false, error: boot.error.serialize() };
+    }
+
     public async send(
-      target: string | BeamTarget,
+      target: string | Pid,
       payload?: unknown,
       opts?: PopcornSendOpts,
     ): Promise<BootResult> {

--- a/otp/js/e2e/pid.spec.ts
+++ b/otp/js/e2e/pid.spec.ts
@@ -1,0 +1,158 @@
+import { assert, evalOpts, expect, test, trimLeft } from "./helpers";
+
+test("injected send delivers to a named process (sync)", async ({ otp }) => {
+  const BOOT_EVAL = trimLeft(`
+    true = register(controller, self()),
+    wasm:run_js(
+      <<"(args, send) => { send('controller', {from_js: true}); return null; }">>,
+      #{}
+    ),
+    receive
+      {wasm, Payload, _} ->
+        #{<<"from_js">> := true} = Payload,
+        ok = wasm:send(#{named_send_ok => true})
+    end.
+  `);
+  const boot = await otp.boot(evalOpts(BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("named_send_ok");
+  expect(otp.events).toContainEqual({ named_send_ok: true });
+});
+
+test("injected send works from a later timer callback", async ({ otp }) => {
+  const BOOT_EVAL = trimLeft(`
+    true = register(controller, self()),
+    wasm:run_js(
+      <<"(args, send) => { setTimeout(() => send('controller', {delayed: true}), 10); return null; }">>,
+      #{}
+    ),
+    receive
+      {wasm, Payload, _} ->
+        #{<<"delayed">> := true} = Payload,
+        ok = wasm:send(#{delayed_send_ok => true})
+    end.
+  `);
+  const boot = await otp.boot(evalOpts(BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("delayed_send_ok");
+  expect(otp.events).toContainEqual({ delayed_send_ok: true });
+});
+
+test("injected send addresses a pid passed via args", async ({ otp }) => {
+  const BOOT_EVAL = trimLeft(`
+    Self = self(),
+    wasm:run_js(
+      <<"(args, send) => { send(args.target, {via_pid: true}); return null; }">>,
+      #{target => Self}
+    ),
+    receive
+      {wasm, Payload, _} ->
+        #{<<"via_pid">> := true} = Payload,
+        ok = wasm:send(#{pid_send_ok => true})
+    end.
+  `);
+  const boot = await otp.boot(evalOpts(BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("pid_send_ok");
+  expect(otp.events).toContainEqual({ pid_send_ok: true });
+});
+
+test("pid round-trips through run_js args and result", async ({ otp }) => {
+  const BOOT_EVAL = trimLeft(`
+    Self = self(),
+    Self = wasm:run_js(<<"(args) => args.target">>, #{target => Self}),
+    #{<<"nested">> := #{<<"p">> := Self}, <<"list">> := [Self]} =
+      wasm:run_js(
+        <<"(args) => ({nested: {p: args.target}, list: [args.target]})">>,
+        #{target => Self}
+      ),
+    ok = wasm:send(#{pid_roundtrip_ok => true}).
+  `);
+  const boot = await otp.boot(evalOpts(BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("pid_roundtrip_ok");
+  expect(otp.events).toContainEqual({ pid_roundtrip_ok: true });
+});
+
+test("pid forwarded inside a send payload revives to a real pid", async ({
+  otp,
+}) => {
+  const BOOT_EVAL = trimLeft(`
+    Parent = self(),
+    Receiver = spawn(fun() ->
+      receive
+        {wasm, Payload, _} ->
+          #{<<"forwarded">> := Pid} = Payload,
+          Parent ! {forwarded_pid, Pid}
+      end
+    end),
+    true = register(pidreceiver, Receiver),
+    wasm:run_js(
+      <<"(args, send) => { send('pidreceiver', {forwarded: args.target}); return null; }">>,
+      #{target => Parent}
+    ),
+    receive
+      {forwarded_pid, Got} ->
+        ok = wasm:send(#{payload_pid_ok => Got =:= Parent})
+    end.
+  `);
+  const boot = await otp.boot(evalOpts(BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("payload_pid_ok");
+  expect(otp.events).toContainEqual({ payload_pid_ok: true });
+});
+
+test("sending to a dead process fails without crashing", async ({ otp }) => {
+  const BOOT_EVAL = trimLeft(`
+    Dead = spawn(fun() -> ok end),
+    Ref = erlang:monitor(process, Dead),
+    receive {'DOWN', Ref, process, Dead, _} -> ok end,
+    Ok = wasm:run_js(
+      <<"(args, send) => send(args.target, {ping: true}).then(r => r.ok)">>,
+      #{target => Dead}
+    ),
+    ok = wasm:send(#{dead_send_ok => Ok}).
+  `);
+  const boot = await otp.boot(evalOpts(BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("dead_send_ok");
+  expect(otp.events).toContainEqual({ dead_send_ok: false });
+});
+
+test("a pid is scoped to the instance that minted it", async ({ createOtp }) => {
+  const [a, b] = await Promise.all([createOtp(), createOtp()]);
+  const [aPid] = await Promise.all([
+    a.captureOwnPid(),
+    b.boot(evalOpts("ok = wasm:send(#{ready => true}).")),
+  ]);
+
+  // The minting instance recognizes its own pid and delivers to it.
+  const own = await a.sendToPid(aPid);
+  expect(own.ok).toBe(true);
+
+  const foreign = await b.sendToPid(aPid);
+  expect(foreign).toEqual({
+    ok: false,
+    error: { t: "bridge:invalid-target", data: {} },
+  });
+});
+
+test("a pid is invalid after its instance reboots", async ({ createOtp }) => {
+  const otp = await createOtp();
+  const stalePid = await otp.captureOwnPid();
+
+  const reboot = await otp.reboot();
+  expect(reboot.ok).toBe(true);
+
+  const stale = await otp.sendToPid(stalePid);
+  expect(stale).toEqual({
+    ok: false,
+    error: { t: "bridge:invalid-target", data: {} },
+  });
+});

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -205,7 +205,12 @@ async function loadFsData(manifestUrl: string): Promise<Result<LoadedFsData>> {
 
   return {
     ok: true,
-    data: { appNames, entrypoint: manifest.entrypoint ?? null, bootFile, tarballs },
+    data: {
+      appNames,
+      entrypoint: manifest.entrypoint ?? null,
+      bootFile,
+      tarballs,
+    },
   };
 }
 
@@ -249,10 +254,9 @@ export function send(
     return { ok: false, error: err("bridge:not-started", {}) };
   }
 
-  let targetName: string;
   let target: PreparedTarget;
   if (isNameTarget(message.target)) {
-    targetName = message.target.name;
+    const targetName = message.target.name;
     target = {
       kind: TARGET_REGISTERED_NAME,
       argType: "string",
@@ -260,8 +264,7 @@ export function send(
       length: utf8Length(targetName),
     };
   } else {
-    targetName = message.target.pid;
-    const bytes = base64ToBytes(targetName);
+    const bytes = message.target.pid;
     target = {
       kind: TARGET_PID_BYTES,
       argType: "array",
@@ -273,13 +276,7 @@ export function send(
   const status = module.ccall(
     "sendVmMessage",
     "number",
-    [
-      "number",
-      target.argType,
-      "number",
-      "array",
-      "number",
-    ],
+    ["number", target.argType, "number", "array", "number"],
     [
       target.kind,
       target.value,
@@ -294,9 +291,10 @@ export function send(
   }
 
   if (status === 1) {
+    const t = isNameTarget(message.target) ? message.target.name : "<pid>";
     return {
       ok: false,
-      error: err("bridge:listener-not-found", { targetName }),
+      error: err("bridge:listener-not-found", { targetName: t }),
     };
   }
   unreachable();
@@ -327,13 +325,4 @@ function isNameTarget(
 
 function utf8Length(text: string): number {
   return UTF8.encode(text).length;
-}
-
-function base64ToBytes(b64: string): Uint8Array {
-  const binary = atob(b64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
 }

--- a/otp/js/src/errors.ts
+++ b/otp/js/src/errors.ts
@@ -106,7 +106,7 @@ function message(error: SerializedError): string {
     case "bridge:not-started":
       return "Bridge did not start";
     case "bridge:invalid-target":
-      return "Target name must not be empty";
+      return "Target must be a non-empty name or a PID from this VM boot";
     case "bridge:unserializable":
       return "Message can't be serialized to ETF";
     case "bridge:listener-not-found":

--- a/otp/js/src/etf.ts
+++ b/otp/js/src/etf.ts
@@ -21,6 +21,22 @@ const UTF8 = new TextEncoder();
 
 type Atom = "true" | "false" | "nil";
 
+/** Pre-encoded ETF sub-term bytes (no version prefix), spliced verbatim. */
+export class RawTerm {
+  public constructor(public readonly bytes: Uint8Array) {}
+
+  /**
+   * Wraps a full external term (`term_to_binary` output) as a spliceable
+   * sub-term by dropping its leading version byte.
+   */
+  public static fromExternal(external: Uint8Array): RawTerm {
+    if (external[0] !== VERSION) {
+      throw new TypeError("expected a version-prefixed ETF external term");
+    }
+    return new RawTerm(external.subarray(1));
+  }
+}
+
 export function tuple2(
   data: unknown,
   meta: unknown,
@@ -121,6 +137,10 @@ class Encoder {
   }
 
   private object(value: object): void {
+    if (value instanceof RawTerm) {
+      this.bytes(value.bytes);
+      return;
+    }
     if (this.ancestors.has(value)) {
       throw err("cyclic-object", value);
     }

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -7,7 +7,7 @@ import type {
   BeamSendPayload,
   BeamTarget,
 } from "./types";
-import { check, objectWithKeys } from "./utils";
+import { base64ToBytes, check, objectWithKeys } from "./utils";
 
 type BootEvent = {
   type: "popcorn:boot";
@@ -121,7 +121,7 @@ export function serializeSendPayload(
   if (isNameTarget(target)) {
     check(target.name.length > 0);
   } else {
-    check(target.pid.length > 0);
+    check(target.pid.byteLength > 0);
   }
 
   const etf = tuple2(payload, meta);
@@ -159,7 +159,7 @@ export function deserializeBridgeMessage(
           payload: {
             code: parsed.code,
             args: parsed.args,
-            replyTo: parsed.reply_to,
+            replyTo: base64ToBytes(parsed.reply_to),
           },
         };
       default:

--- a/otp/js/src/index.ts
+++ b/otp/js/src/index.ts
@@ -2,5 +2,5 @@ export { PopcornError } from "./errors";
 export { Popcorn } from "./popcorn";
 export type { PopcornOpts, PopcornSendOpts } from "./popcorn";
 export type { PopcornEvent } from "./events";
-export type { BeamTarget, OtpErrorPayload } from "./types";
+export type { Pid, OtpErrorPayload } from "./types";
 export type { PopcornErrors, SerializedError } from "./errors";

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -1,4 +1,5 @@
 import { PopcornError, err, type Result } from "./errors";
+import { RawTerm } from "./etf";
 import {
   readWorkerEvent,
   serializeSendPayload,
@@ -11,13 +12,15 @@ import type {
   BeamBootOptions,
   BeamTarget,
   OtpErrorPayload,
+  Pid,
   RunJsRequest,
 } from "./types";
-import { check, objectWithKeys, unreachable } from "./utils";
+import { base64ToBytes, check, objectWithKeys, unreachable } from "./utils";
 
 type TrackedEntry = { value: unknown; cleanup?: () => void };
 
 const TRACKED_REF_KEY = "popcorn_ref";
+const PID_REF_KEY = "popcorn_pid";
 
 export type PopcornOpts = {
   beam: Pick<BeamBootOptions, "manifestUrl" | "extraArgs">;
@@ -55,7 +58,18 @@ type PopcornState =
   | { status: "booted" }
   | { status: "closed"; error: PopcornError<"vm:exited"> };
 type PendingSend = (result: Result<null>) => void;
-type RunJsFn = (args: AnyValue) => AnyValue;
+type SendFn = (
+  target: string | Pid,
+  payload?: AnyValue,
+  opts?: PopcornSendOpts,
+) => Promise<Result<null>>;
+type RunJsFn = (args: AnyValue, send: SendFn) => AnyValue;
+
+function createPidClass() {
+  return class {
+    public constructor(public readonly bytes: Uint8Array) {}
+  };
+}
 
 function assertRunJsFn(value: unknown): asserts value is RunJsFn {
   check(typeof value === "function");
@@ -78,6 +92,8 @@ export class Popcorn {
       public readonly cleanup?: () => void,
     ) {}
   };
+
+  private Pid = createPidClass();
   private readonly onWorkerMessage = (event: MessageEvent<unknown>) => {
     const data = readWorkerEvent(event.data);
     check(data !== null);
@@ -87,7 +103,7 @@ export class Popcorn {
       case "popcorn:boot-fail":
         return;
       case "otp:message":
-        this.emit(this.reviveTrackedValues(data.payload));
+        this.emit(this.reviveHandles(data.payload));
         return;
       case "otp:run_js":
         this.runJs(data.payload);
@@ -158,6 +174,7 @@ export class Popcorn {
       this.spawnWorker();
     }
 
+    this.Pid = createPidClass();
     this.state = { status: "booting" };
 
     return await new Promise<Result<Popcorn>>((resolve) => {
@@ -213,7 +230,7 @@ export class Popcorn {
    * Resolves after VM sent message to registered process.
    */
   public async send(
-    target: string | BeamTarget,
+    rawTarget: string | Pid,
     payload?: AnyValue,
     opts?: PopcornSendOpts,
   ): Promise<Result<null>> {
@@ -224,9 +241,18 @@ export class Popcorn {
       return { ok: false, error: err("bridge:not-started", {}) };
     }
 
+    let target: BeamTarget;
+    if (typeof rawTarget === "string" && rawTarget.length > 0) {
+      target = { name: rawTarget };
+    } else if (rawTarget instanceof this.Pid) {
+      target = { pid: rawTarget.bytes };
+    } else {
+      return { ok: false, error: err("bridge:invalid-target", {}) };
+    }
+
     const command = serializeSendPayload(
-      typeof target === "string" ? { name: target } : target,
-      payload ?? {},
+      target,
+      this.serializeHandles(payload ?? {}),
       opts?.meta ?? {},
     );
     if (!command.ok) {
@@ -308,9 +334,11 @@ export class Popcorn {
     try {
       const fn = this.jsWithCurrentEnv(request.code);
       assertRunJsFn(fn);
-      const args = this.reviveTrackedValues(request.args);
-      const result = await fn(args);
-      payload = { ok: true, value: this.serializeResult(result) ?? null };
+      const args = this.reviveHandles(request.args);
+      const send: SendFn = (target, sendPayload, sendOpts) =>
+        this.send(target, sendPayload, sendOpts);
+      const result = await fn(args, send);
+      payload = { ok: true, value: this.serializeHandles(result) ?? null };
     } catch (error) {
       check(error instanceof Error);
       payload = { ok: false, error: error.toString() };
@@ -336,28 +364,36 @@ export class Popcorn {
     return make(this.TrackedValue);
   }
 
-  private reviveTrackedValues(value: unknown): unknown {
+  private reviveHandles(value: unknown): unknown {
     const key = trackedRefKey(value);
     if (key !== null) {
       const entry = this.trackedValues.get(key);
       check(entry !== undefined);
       return entry.value;
     }
+    const pidToken = pidRefToken(value);
+    if (pidToken !== null) {
+      return new this.Pid(base64ToBytes(pidToken));
+    }
     if (Array.isArray(value)) {
-      return value.map((item) => this.reviveTrackedValues(item));
+      return value.map((item) => this.reviveHandles(item));
     }
     const obj = objectWithKeys(value, []);
     if (obj !== null) {
       const revived: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(obj)) {
-        revived[k] = this.reviveTrackedValues(v);
+        revived[k] = this.reviveHandles(v);
       }
       return revived;
     }
     return value;
   }
 
-  private serializeResult(value: unknown): unknown {
+  private serializeHandles(value: unknown): unknown {
+    if (value instanceof this.Pid) {
+      // Splice the pid's own ETF bytes so binary_to_term revives a real pid.
+      return RawTerm.fromExternal(value.bytes);
+    }
     if (value instanceof this.TrackedValue) {
       this.trackedKeySeq += 1;
       const key = this.trackedKeySeq;
@@ -368,13 +404,13 @@ export class Popcorn {
       return { [TRACKED_REF_KEY]: key };
     }
     if (Array.isArray(value)) {
-      return value.map((item) => this.serializeResult(item));
+      return value.map((item) => this.serializeHandles(item));
     }
     const obj = objectWithKeys(value, []);
     if (obj !== null) {
       const serialized: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(obj)) {
-        serialized[k] = this.serializeResult(v);
+        serialized[k] = this.serializeHandles(v);
       }
       return serialized;
     }
@@ -463,6 +499,17 @@ function trackedRefKey(value: unknown): number | null {
   const key = marker[TRACKED_REF_KEY];
   check(typeof key === "number");
   return key;
+}
+
+function pidRefToken(value: unknown): string | null {
+  const marker = objectWithKeys(value, [PID_REF_KEY]);
+  const hasOnlyMarker = marker !== null && Object.keys(marker).length === 1;
+  if (!hasOnlyMarker) {
+    return null;
+  }
+  const token = marker[PID_REF_KEY];
+  check(typeof token === "string");
+  return token;
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#direct_and_indirect_eval

--- a/otp/js/src/types.ts
+++ b/otp/js/src/types.ts
@@ -2,7 +2,11 @@ type CreateModuleFn<Mod> = (overrides?: Partial<Mod>) => Promise<Mod>;
 
 export type AnyValue = unknown;
 
-export type BeamTarget = { name: string } | { pid: string };
+declare const pidBrand: unique symbol;
+export type Pid = { readonly [pidBrand]: true };
+
+/** Internal wire target. The public `send` accepts `string | Pid` instead. */
+export type BeamTarget = { name: string } | { pid: Uint8Array };
 
 export type BeamSendPayload = {
   target: BeamTarget;
@@ -27,7 +31,7 @@ export type BeamEvent =
 export type RunJsRequest = {
   code: string;
   args: AnyValue;
-  replyTo: string;
+  replyTo: Uint8Array;
 };
 
 export type OtpErrorPayload =

--- a/otp/js/src/utils.ts
+++ b/otp/js/src/utils.ts
@@ -36,6 +36,15 @@ export async function fetchJson<T>(url: string): Promise<T | null> {
   }
 }
 
+export function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
 export function check(ok: boolean, msg?: string): asserts ok {
   if (!ok) throw err("internal:check", { detail: msg });
 }

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -1025,10 +1025,10 @@ index 3b672dc41a554cf7d5440ccfd94e85bd44b61d35..4e5efb04e7eb04556ff14dc3ba8e0d83
  	    ]},
 diff --git a/erts/preloaded/src/wasm.erl b/erts/preloaded/src/wasm.erl
 new file mode 100644
-index 0000000000000000000000000000000000000000..4f9ce99cd9273e45ae4e3a296392d3570e9ebaec
+index 0000000000000000000000000000000000000000..289c344682d7ac40fcc71c45c77736a79f440efc
 --- /dev/null
 +++ b/erts/preloaded/src/wasm.erl
-@@ -0,0 +1,99 @@
+@@ -0,0 +1,101 @@
 +%%
 +%% %CopyrightBegin%
 +%%
@@ -1103,6 +1103,8 @@ index 0000000000000000000000000000000000000000..4f9ce99cd9273e45ae4e3a296392d357
 +
 +encode_arg({wasm_tracked_value, Resource}, Encoder) ->
 +    json:encode_value(#{popcorn_ref => ref_key(Resource)}, Encoder);
++encode_arg(Pid, Encoder) when is_pid(Pid) ->
++    json:encode_value(#{popcorn_pid => base64:encode(term_to_binary(Pid))}, Encoder);
 +encode_arg(Other, Encoder) ->
 +    json:encode_value(Other, Encoder).
 +


### PR DESCRIPTION
Allow `run_js` to send messages to named processes and PIDs passed from VM.
Represents pids as opaque handles backed by external-term bytes.