### PR TITLE
otp: support :ref in run_js

### DIFF
--- a/otp/js/e2e/bridge.spec.ts
+++ b/otp/js/e2e/bridge.spec.ts
@@ -242,6 +242,94 @@ test("throwing run_js raises in VM", async ({ otp }) => {
   expect(otp.events).toContainEqual({ run_js_error: "Error: boom" });
 });
 
+test("run_js: return nested value", async ({ otp }) => {
+  const RUN_JS_BOOT_EVAL = trimLeft(`
+    V = wasm:run_js(
+      <<"() => ({a: 1, s: 'x', nested: {b: [2, 3]}, flag: true})">>,
+      #{},
+      [{return, value}]
+    ),
+    ok = wasm:send(#{value_mode => V}).
+  `);
+  const boot = await otp.boot(evalOpts(RUN_JS_BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("value_mode");
+  expect(otp.events).toContainEqual({
+    value_mode: { a: 1, s: "x", nested: { b: [2, 3] }, flag: true },
+  });
+});
+
+test("run_js: throws when returning unserializable value", async ({ otp }) => {
+  // One case per codec reason (unsupported/non_finite_float/lossy_int/
+  // non_plain_object/cyclic_object).
+  const REJECTIONS = [
+    ["func", "() => () => 1", "unsupported"],
+    ["symbol", "() => Symbol('x')", "unsupported"],
+    ["bigint", "() => 1n", "unsupported"],
+    ["pos_inf", "() => Infinity", "non_finite_float"],
+    ["neg_inf", "() => -Infinity", "non_finite_float"],
+    ["nan", "() => NaN", "non_finite_float"],
+    ["unsafe_int", "() => Number.MAX_SAFE_INTEGER + 1", "lossy_int"],
+    ["non_plain", "() => new Date()", "non_plain_object"],
+    ["cyclic", "() => { const a = []; a.push(a); return a; }", "cyclic_object"],
+  ] as const;
+  const cases = REJECTIONS.map(
+    ([name, code]) => `{${name}, <<"${code}">>}`,
+  ).join(",\n      ");
+  const RUN_JS_BOOT_EVAL = trimLeft(`
+    Cases = [
+      ${cases}
+    ],
+    lists:foreach(fun({Name, Code}) ->
+      Result = try wasm:run_js(Code, #{}) of
+        _ -> #{outcome => no_error}
+      catch
+        error:{run_js, {unserializable, Reason}} ->
+          #{outcome => rejected, reason => Reason};
+        error:run_js_timeout -> #{outcome => timeout}
+      end,
+      ok = wasm:send(#{reject => Name, result => Result})
+    end, Cases).
+  `);
+  const boot = await otp.boot(evalOpts(RUN_JS_BOOT_EVAL));
+  assert(boot.ok);
+
+  for (const [name, , reason] of REJECTIONS) {
+    await otp.waitForEvent("reject");
+    expect(otp.events).toContainEqual({
+      reject: name,
+      result: { outcome: "rejected", reason },
+    });
+  }
+});
+
+test("run_js: options validation", async ({ otp }) => {
+  const RUN_JS_BOOT_EVAL = trimLeft(`
+    Value = wasm:run_js(<<"() => 1">>, #{}, [{return, value}]),
+    Ref = wasm:run_js(<<"() => 1">>, #{}, [{return, ref}]),
+    Invalid = try wasm:run_js(<<"() => 1">>, #{}, [{return, bogus}]) of
+      _ -> ok
+    catch
+      error:function_clause -> invalid_option
+    end,
+    ok = wasm:send(#{
+      value_ok => Value =:= 1,
+      ref_ok => is_tuple(Ref) andalso element(1, Ref) =:= wasm_tracked_value,
+      invalid_return => Invalid
+    }).
+  `);
+  const boot = await otp.boot(evalOpts(RUN_JS_BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("invalid_return");
+  expect(otp.events).toContainEqual({
+    value_ok: true,
+    ref_ok: true,
+    invalid_return: "invalid_option",
+  });
+});
+
 test("send() to unregistered process", async ({ otp }) => {
   const READY_BOOT_EVAL = "ok = wasm:send(#{ready => true}).";
   const boot = await otp.boot(evalOpts(READY_BOOT_EVAL));

--- a/otp/js/e2e/tracked-values.spec.ts
+++ b/otp/js/e2e/tracked-values.spec.ts
@@ -23,6 +23,49 @@ test("tracked values keep identity", async ({ otp }) => {
   expect(otp.events).toContainEqual({ roundtrip: 2 });
 });
 
+test("run_js: refs refer to the same value", async ({ otp }) => {
+  const RUN_JS_BOOT_EVAL = trimLeft(`
+    % initial
+    H = wasm:run_js(<<"() => ({n: 0})">>, #{}, [{return, ref}]),
+    % update
+    wasm:run_js(<<"({h}) => { h.n = 100; }">>, #{h => H}),
+    % read
+    V = wasm:run_js(<<"({h}) => h.n">>, #{h => H}),
+    ok = wasm:send(#{var_value => V}).
+  `);
+  const boot = await otp.boot(evalOpts(RUN_JS_BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("var_value");
+  expect(otp.events).toContainEqual({ var_value: 100 });
+});
+
+test("run_js: refs work with unserializable values", async ({ otp }) => {
+  const RUN_JS_BOOT_EVAL = trimLeft(`
+    H = wasm:run_js(<<"() => document.createElement('div')">>, #{}, [{return, ref}]),
+    V = wasm:run_js(<<"({h}) => h.tagName">>, #{h => H}),
+    ok = wasm:send(#{ref_unsupported => V}).
+  `);
+  const boot = await otp.boot(evalOpts(RUN_JS_BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("ref_unsupported");
+  expect(otp.events).toContainEqual({ ref_unsupported: "DIV" });
+});
+
+test("run_js: refs don't nest TrackedValues", async ({ otp }) => {
+  const RUN_JS_BOOT_EVAL = trimLeft(`
+    H = wasm:run_js(<<"() => new TrackedValue({n: 1})">>, #{}, [{return, ref}]),
+    V = wasm:run_js(<<"({h}) => h.n">>, #{h => H}),
+    ok = wasm:send(#{ref_no_nest => V}).
+  `);
+  const boot = await otp.boot(evalOpts(RUN_JS_BOOT_EVAL));
+  assert(boot.ok);
+
+  await otp.waitForEvent("ref_no_nest");
+  expect(otp.events).toContainEqual({ ref_no_nest: 1 });
+});
+
 test("nested tracked values", async ({ otp }) => {
   const RUN_JS_BOOT_EVAL = trimLeft(`
     H = wasm:run_js(<<"() => new TrackedValue({n: 5})">>, #{}),
@@ -215,4 +258,3 @@ test("tracked values isolated cleanup", async ({ createOtp, page }) => {
   expect(liveEvent).toEqual({ v: 42 });
   expect(cleanupCalls).toBe(1);
 });
-

--- a/otp/js/src/etf.ts
+++ b/otp/js/src/etf.ts
@@ -37,12 +37,15 @@ export class RawTerm {
   }
 }
 
+export type Mapper = (value: object) => object;
+
 export function tuple2(
   data: unknown,
   meta: unknown,
+  mapper?: Mapper,
 ): Result<Uint8Array<ArrayBuffer>, "bridge:unserializable"> {
   try {
-    return { ok: true, data: new Encoder().tuple2(data, meta) };
+    return { ok: true, data: new Encoder(mapper).tuple2(data, meta) };
   } catch (error) {
     let reason: UnserializableReason = "unsupported";
     let part = data;
@@ -62,6 +65,8 @@ class Encoder {
   private readonly output: number[] = [];
   private readonly buffer = new ArrayBuffer(8);
   private readonly view = new DataView(this.buffer);
+
+  public constructor(private readonly mapper: Mapper = (value) => value) {}
 
   tuple2(left: unknown, right: unknown): Uint8Array<ArrayBuffer> {
     this.byte(VERSION);
@@ -136,7 +141,8 @@ class Encoder {
     this.bytes(digits);
   }
 
-  private object(value: object): void {
+  private object(rawValue: object): void {
+    const value = this.mapper(rawValue);
     if (value instanceof RawTerm) {
       this.bytes(value.bytes);
       return;

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -1,5 +1,5 @@
 import { type Result, type SerializedError } from "./errors";
-import { tuple2 } from "./etf";
+import { tuple2, type Mapper } from "./etf";
 import type {
   AnyValue,
   BeamBootOptions,
@@ -73,6 +73,7 @@ type BridgeEnvelope =
       code: string;
       args: AnyValue;
       reply_to: string;
+      return: "value" | "ref";
     };
 
 export function readMainEvent(value: unknown): MainToVmEvent | null {
@@ -117,14 +118,15 @@ export function serializeSendPayload(
   target: BeamTarget,
   payload: AnyValue,
   meta: AnyValue,
-): Result<BeamSendPayload> {
+  mapper?: Mapper,
+): Result<BeamSendPayload, "bridge:unserializable"> {
   if (isNameTarget(target)) {
     check(target.name.length > 0);
   } else {
     check(target.pid.byteLength > 0);
   }
 
-  const etf = tuple2(payload, meta);
+  const etf = tuple2(payload, meta, mapper);
   if (!etf.ok) return etf;
   return { ok: true, data: { target, etf: etf.data } };
 }
@@ -160,6 +162,7 @@ export function deserializeBridgeMessage(
             code: parsed.code,
             args: parsed.args,
             replyTo: base64ToBytes(parsed.reply_to),
+            return: parsed.return,
           },
         };
       default:

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -1,5 +1,5 @@
 import { PopcornError, err, type Result } from "./errors";
-import { RawTerm } from "./etf";
+import { RawTerm, type Mapper } from "./etf";
 import {
   readWorkerEvent,
   serializeSendPayload,
@@ -10,6 +10,7 @@ import {
 import type {
   AnyValue,
   BeamBootOptions,
+  BeamSendPayload,
   BeamTarget,
   OtpErrorPayload,
   Pid,
@@ -18,6 +19,7 @@ import type {
 import { base64ToBytes, check, objectWithKeys, unreachable } from "./utils";
 
 type TrackedEntry = { value: unknown; cleanup?: () => void };
+type PendingTracked = TrackedEntry & { key: number };
 
 const TRACKED_REF_KEY = "popcorn_ref";
 const PID_REF_KEY = "popcorn_pid";
@@ -250,13 +252,18 @@ export class Popcorn {
       return { ok: false, error: err("bridge:invalid-target", {}) };
     }
 
+    const tracked: PendingTracked[] = [];
     const command = serializeSendPayload(
       target,
-      this.serializeHandles(payload ?? {}),
+      payload ?? {},
       opts?.meta ?? {},
+      this.handleMapper(tracked),
     );
     if (!command.ok) {
       return command;
+    }
+    for (const { key, value, cleanup } of tracked) {
+      this.trackedValues.set(key, { value, cleanup });
     }
 
     const requestId = this.nextRequestId();
@@ -338,21 +345,48 @@ export class Popcorn {
       const send: SendFn = (target, sendPayload, sendOpts) =>
         this.send(target, sendPayload, sendOpts);
       const result = await fn(args, send);
-      payload = { ok: true, value: this.serializeHandles(result) ?? null };
+      const value = request.return === "ref" ? this.asRef(result) : result;
+      payload = { ok: true, value: value ?? null };
     } catch (error) {
       check(error instanceof Error);
       payload = { ok: false, error: error.toString() };
     }
 
-    const command = serializeSendPayload({ pid: request.replyTo }, payload, {});
-    check(command.ok);
+    const target = { pid: request.replyTo };
+    const tracked: PendingTracked[] = [];
+    const command = serializeSendPayload(
+      target,
+      payload,
+      {},
+      this.handleMapper(tracked),
+    );
+    if (command.ok) {
+      for (const { key, value, cleanup } of tracked) {
+        this.trackedValues.set(key, { value, cleanup });
+      }
+      this.sendRunJsReply(command.data);
+      return;
+    }
+
+    const failure = serializeSendPayload(
+      target,
+      { ok: false, error: { unserializable: command.error.data.reason } },
+      {},
+    );
+    check(failure.ok);
+    this.sendRunJsReply(failure.data);
+  }
+
+  private asRef(value: unknown): unknown {
+    if (value instanceof this.TrackedValue) return value;
+    return new this.TrackedValue(value);
+  }
+
+  private sendRunJsReply(message: BeamSendPayload): void {
     toVm(
       this.vmWorker,
-      {
-        type: "popcorn:run-js-reply",
-        payload: { message: command.data },
-      },
-      [command.data.etf.buffer],
+      { type: "popcorn:run-js-reply", payload: { message } },
+      [message.etf.buffer],
     );
   }
 
@@ -389,32 +423,20 @@ export class Popcorn {
     return value;
   }
 
-  private serializeHandles(value: unknown): unknown {
-    if (value instanceof this.Pid) {
-      // Splice the pid's own ETF bytes so binary_to_term revives a real pid.
-      return RawTerm.fromExternal(value.bytes);
-    }
-    if (value instanceof this.TrackedValue) {
-      this.trackedKeySeq += 1;
-      const key = this.trackedKeySeq;
-      this.trackedValues.set(key, {
-        value: value.value,
-        cleanup: value.cleanup,
-      });
-      return { [TRACKED_REF_KEY]: key };
-    }
-    if (Array.isArray(value)) {
-      return value.map((item) => this.serializeHandles(item));
-    }
-    const obj = objectWithKeys(value, []);
-    if (obj !== null) {
-      const serialized: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(obj)) {
-        serialized[k] = this.serializeHandles(v);
+  /** Maps pids and `TrackedValue`s during encoding, collecting handles into
+   * `tracked` for the caller to register once encoding succeeds. */
+  private handleMapper(tracked: PendingTracked[]): Mapper {
+    return (value) => {
+      if (value instanceof this.Pid) {
+        return RawTerm.fromExternal(value.bytes);
       }
-      return serialized;
-    }
-    return value;
+      if (value instanceof this.TrackedValue) {
+        const key = (this.trackedKeySeq += 1);
+        tracked.push({ key, value: value.value, cleanup: value.cleanup });
+        return { [TRACKED_REF_KEY]: key };
+      }
+      return value;
+    };
   }
 
   private deleteTrackedValue(key: number): void {

--- a/otp/js/src/types.ts
+++ b/otp/js/src/types.ts
@@ -32,6 +32,7 @@ export type RunJsRequest = {
   code: string;
   args: AnyValue;
   replyTo: Uint8Array;
+  return: "value" | "ref";
 };
 
 export type OtpErrorPayload =

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -1025,10 +1025,10 @@ index 3b672dc41a554cf7d5440ccfd94e85bd44b61d35..4e5efb04e7eb04556ff14dc3ba8e0d83
  	    ]},
 diff --git a/erts/preloaded/src/wasm.erl b/erts/preloaded/src/wasm.erl
 new file mode 100644
-index 0000000000000000000000000000000000000000..289c344682d7ac40fcc71c45c77736a79f440efc
+index 0000000000000000000000000000000000000000..76a13760969bd11829dd4a9df4d48269da4197ae
 --- /dev/null
 +++ b/erts/preloaded/src/wasm.erl
-@@ -0,0 +1,101 @@
+@@ -0,0 +1,122 @@
 +%%
 +%% %CopyrightBegin%
 +%%
@@ -1068,16 +1068,20 @@ index 0000000000000000000000000000000000000000..289c344682d7ac40fcc71c45c77736a7
 +    ?MODULE:keep_alive(Envelope),
 +    ok.
 +
-+-spec run_js(binary(), map()) -> json:decode_value().
++%% Returns the decoded result, which may contain pids and, in `ref` mode, a
++%% `{wasm_tracked_value, _}` handle — so not strictly a json:decode_value().
++-spec run_js(binary(), map()) -> term().
 +run_js(Code, Args) when is_binary(Code), is_map(Args) ->
 +    run_js(Code, Args, []).
 +
-+-spec run_js(binary(), map(), proplists:proplist()) -> json:decode_value().
++-spec run_js(binary(), map(), proplists:proplist()) -> term().
 +run_js(Code, Args, Opts) when is_binary(Code), is_map(Args), is_list(Opts) ->
 +    Timeout = proplists:get_value(timeout, Opts, ?RUN_JS_TIMEOUT),
++    Return = validate_return(proplists:get_value(return, Opts, value)),
 +    Token = erlang:unique_integer(),
 +    ReplyTo = base64:encode(term_to_binary({self(), Token})),
-+    Envelope = #{type => run_js, code => Code, args => Args, reply_to => ReplyTo},
++    Envelope = #{type => run_js, code => Code, args => Args,
++                 reply_to => ReplyTo, return => Return},
 +    ok = send_raw(iolist_to_binary(json:encode(Envelope, fun encode_arg/2))),
 +    Reply = receive
 +                {wasm, {Token, Payload}, _Meta} -> Payload
@@ -1094,12 +1098,29 @@ index 0000000000000000000000000000000000000000..289c344682d7ac40fcc71c45c77736a7
 +keep_alive(Term) ->
 +    Term.
 +
++%% `value` transports the decoded result; `ref` tracks the whole result and
++%% returns one opaque handle. Invalid options are programmer errors and fail loud.
++validate_return(value) -> value;
++validate_return(ref) -> ref.
++
 +handle_run_js_reply(#{<<"ok">> := true, <<"value">> := Value}) ->
 +    revive_refs(Value);
 +handle_run_js_reply(#{<<"ok">> := true}) ->
 +    null;
-+handle_run_js_reply(#{<<"ok">> := false, <<"error">> := Reason}) ->
++handle_run_js_reply(#{<<"ok">> := false,
++                      <<"error">> := #{<<"unserializable">> := Reason}}) ->
++    error({run_js, {unserializable, unserializable_reason(Reason)}});
++handle_run_js_reply(#{<<"ok">> := false, <<"error">> := Reason})
++  when is_binary(Reason) ->
 +    error({run_js, Reason}).
++
++%% Map the codec's stable reasons to known atoms; never build atoms from
++%% arbitrary JavaScript strings.
++unserializable_reason(<<"cyclic-object">>) -> cyclic_object;
++unserializable_reason(<<"non-plain-object">>) -> non_plain_object;
++unserializable_reason(<<"lossy-int">>) -> lossy_int;
++unserializable_reason(<<"non-finite-float">>) -> non_finite_float;
++unserializable_reason(<<"unsupported">>) -> unsupported.
 +
 +encode_arg({wasm_tracked_value, Resource}, Encoder) ->
 +    json:encode_value(#{popcorn_ref => ref_key(Resource)}, Encoder);


### PR DESCRIPTION
This allows for interacting with JS values that can't be serialized to Beam native data types.