### PR TITLE
otp: drop meta from wasm messages

### DIFF
--- a/otp/elixir/lib/popcorn/wasm.ex
+++ b/otp/elixir/lib/popcorn/wasm.ex
@@ -41,9 +41,7 @@ defmodule Popcorn.Wasm do
 
   ## Receiving messages
 
-  Messages from JS have `{:wasm, payload, meta}` shape. `payload` is fully controlled by user,
-  `meta` contains user-controlled metadata (can be specific in JS options object).
-  <!-- TODO: remove `meta` -->
+  Messages from JS have `{:wasm, payload}` shape. `payload` is fully controlled by user.
 
   You can use `is_message/1` guard for filtering this type of messages.
 
@@ -84,7 +82,7 @@ defmodule Popcorn.Wasm do
   The payload is already decoded into Elixir terms. Only value serializable to JSON are supported.
   TrackedValues and PID handles are special-cased in communication.
   """
-  @type message :: {:wasm, payload :: term(), metadata :: term()}
+  @type message :: {:wasm, payload :: term()}
 
   @type run_js_opts :: [{:timeout, timeout()}]
 
@@ -92,7 +90,7 @@ defmodule Popcorn.Wasm do
   Matches a `t:message/0` sent from JavaScript.
   """
   defguard is_message(message)
-           when is_tuple(message) and tuple_size(message) == 3 and elem(message, 0) == :wasm
+           when is_tuple(message) and tuple_size(message) == 2 and elem(message, 0) == :wasm
 
   @doc """
   Returns true when running inside the Popcorn OTP runtime.

--- a/otp/elixir/test/popcorn/wasm_test.exs
+++ b/otp/elixir/test/popcorn/wasm_test.exs
@@ -18,18 +18,18 @@ defmodule Popcorn.WasmTest do
 
   describe "is_message/1" do
     test "matches messages from JS" do
-      assert Wasm.is_message({:wasm, %{"a" => 1}, %{}})
+      assert Wasm.is_message({:wasm, %{"a" => 1}})
     end
 
     test "rejects other terms" do
-      refute Wasm.is_message({:wasm, :payload})
+      refute Wasm.is_message({:wasm, :payload, :meta})
       refute Wasm.is_message({:other, :payload, :meta})
       refute Wasm.is_message(:wasm)
       refute Wasm.is_message("wasm")
     end
 
     test "is usable in a guard" do
-      assert match?(msg when Wasm.is_message(msg), {:wasm, :payload, :meta})
+      assert match?(msg when Wasm.is_message(msg), {:wasm, :payload})
     end
   end
 

--- a/otp/js/e2e/bridge.spec.ts
+++ b/otp/js/e2e/bridge.spec.ts
@@ -1,5 +1,5 @@
 import { assert, evalOpts, expect, test, trimLeft } from "./helpers";
-import { tuple2 } from "../src/etf";
+import { encode } from "../src/etf";
 
 const PAYLOAD = {
   text: "zażółć",
@@ -24,15 +24,13 @@ const PAYLOAD = {
   nested: [{ value: "ok" }],
 };
 
-const META = { requestId: "req-1" };
-
 test("ETF sorts map keys", () => {
   assert.equal(hex({ b: 2, a: 1 }), hex({ a: 1, b: 2 }));
 });
 
 test("ETF accepts null-prototype plain objects", () => {
   const value = Object.assign(Object.create(null), { key: "value" });
-  assert(tuple2(value, {}).ok);
+  assert(encode(value).ok);
 });
 
 for (const [name, value, reason] of [
@@ -46,7 +44,7 @@ for (const [name, value, reason] of [
   ["non-plain object", new Date(), "non-plain-object"],
 ] as const) {
   test(`ETF reports ${name}`, () => {
-    const result = tuple2(value, {});
+    const result = encode(value);
     assert(!result.ok);
     assert.equal(result.error.t, "bridge:unserializable");
     assert.equal(result.error.data.data, value);
@@ -58,7 +56,7 @@ for (const [name, value, reason] of [
 test("ETF reports cyclic values", () => {
   const value: unknown[] = [];
   value.push(value);
-  const result = tuple2(value, {});
+  const result = encode(value);
   assert(!result.ok);
   assert.equal(result.error.data.data, value);
   assert.equal(result.error.data.part, value);
@@ -79,7 +77,7 @@ test("ETF encodes enumerable string properties", () => {
   assert.equal(hex(accessor), hex({ value: true }));
   assert.equal(hex(extendedArray), hex([]));
   const sparse = new Array(1);
-  const result = tuple2(sparse, {});
+  const result = encode(sparse);
   assert(!result.ok);
   assert.equal(result.error.data.data, sparse);
   assert.equal(result.error.data.part, undefined);
@@ -94,22 +92,12 @@ test("ETF reports unsupported nested values", () => {
     [[fn], fn],
     [{ value: symbol }, symbol],
   ] as const) {
-    const result = tuple2(value, {});
+    const result = encode(value);
     assert(!result.ok);
     assert.equal(result.error.data.data, value);
     assert.equal(result.error.data.part, part);
     assert.equal(result.error.data.reason, "unsupported");
   }
-});
-
-test("ETF reports the failing metadata part with the full payload", () => {
-  const data = { value: "ok" };
-  const part = new Date();
-  const result = tuple2(data, { part });
-  assert(!result.ok);
-  assert.equal(result.error.data.data, data);
-  assert.equal(result.error.data.part, part);
-  assert.equal(result.error.data.reason, "non-plain-object");
 });
 
 test("handles events in both directions", async ({ otp }) => {
@@ -137,20 +125,19 @@ test("handles events in both directions", async ({ otp }) => {
         <<"emptyMap">> => #{},
         <<"nested">> => [#{<<"value">> => <<"ok">>}]
       },
-      ExpectedMeta = #{<<"requestId">> => <<"req-1">>},
-      ExpectedEtf = base64:encode(term_to_binary({ExpectedPayload, ExpectedMeta})),
+      ExpectedEtf = base64:encode(term_to_binary(ExpectedPayload)),
       ok = wasm:send(#{etf_expected => ExpectedEtf}),
       ok = wasm:send(#{direct => true, nested => #{count => 1}}),
       true = register(bridge, self()),
       Loop = fun(F) ->
         ok = wasm:send(#{bridge_ready => true}),
         receive
-          {wasm, Payload, Meta} ->
-            Shape = case {Payload, Meta} of
-              {ExpectedPayload, ExpectedMeta} -> decoded;
+          {wasm, Payload} ->
+            Shape = case Payload of
+              ExpectedPayload -> decoded;
               _ -> unexpected
             end,
-            ok = wasm:send(#{reply => Payload, meta => Meta, shape => Shape})
+            ok = wasm:send(#{reply => Payload, shape => Shape})
         after 100 ->
             F(F)
         end
@@ -163,7 +150,7 @@ test("handles events in both directions", async ({ otp }) => {
   assert(boot.ok);
   const expectedEtf = await otp.waitForEvent("etf_expected");
   expect(expectedEtf).toEqual({
-    etf_expected: Buffer.from(encode(PAYLOAD, META)).toString("base64"),
+    etf_expected: Buffer.from(encodePayload(PAYLOAD)).toString("base64"),
   });
   await otp.waitForEvent("direct");
   expect(otp.events).toContainEqual({
@@ -173,15 +160,12 @@ test("handles events in both directions", async ({ otp }) => {
 
   await otp.waitForEvent("bridge_ready");
 
-  const send = await otp.send("bridge", structuredClone(PAYLOAD), {
-    meta: structuredClone(META),
-  });
+  const send = await otp.send("bridge", structuredClone(PAYLOAD));
   assert(send.ok);
 
   await otp.waitForEvent("reply");
   expect(otp.events).toContainEqual({
     reply: { ...PAYLOAD, nullValue: "nil" },
-    meta: META,
     shape: "decoded",
   });
 });
@@ -360,12 +344,12 @@ test("send() timeout", async ({ otp }) => {
   });
 });
 
-function hex(payload: unknown, meta: unknown = {}): string {
-  return Buffer.from(encode(payload, meta)).toString("hex");
+function hex(payload: unknown): string {
+  return Buffer.from(encodePayload(payload)).toString("hex");
 }
 
-function encode(payload: unknown, meta: unknown): Uint8Array<ArrayBuffer> {
-  const result = tuple2(payload, meta);
+function encodePayload(payload: unknown): Uint8Array<ArrayBuffer> {
+  const result = encode(payload);
   assert(result.ok);
   return result.data;
 }

--- a/otp/js/e2e/helpers.ts
+++ b/otp/js/e2e/helpers.ts
@@ -11,7 +11,6 @@ import type {
   Popcorn,
   PopcornOpts,
   PopcornEvent,
-  PopcornSendOpts,
   OtpErrorPayload,
   Pid,
   SerializedError,
@@ -36,7 +35,6 @@ type Otp = {
   send(
     target: string | Pid,
     payload?: unknown,
-    opts?: PopcornSendOpts,
   ): Promise<BootResult>;
   waitForEvent(name: string): Promise<PopcornEvent>;
   deinit(): void;
@@ -195,11 +193,10 @@ export class OtpHandle {
   public async send(
     target: string,
     payload?: unknown,
-    opts?: PopcornSendOpts,
   ): Promise<BootResult> {
     const result = await this.otp.evaluate(
-      (otp, args) => otp.send(args.target, args.payload, args.opts),
-      { target, payload, opts },
+      (otp, args) => otp.send(args.target, args.payload),
+      { target, payload },
     );
     await this.syncEvents();
     return result;
@@ -338,9 +335,8 @@ function createOtp(id: string): Otp {
     public async send(
       target: string | Pid,
       payload?: unknown,
-      opts?: PopcornSendOpts,
     ): Promise<BootResult> {
-      const result = await this.popcorn.send(target, payload, opts);
+      const result = await this.popcorn.send(target, payload);
       if (result.ok) return { ok: true, data: null };
       return { ok: false, error: result.error.serialize() };
     }

--- a/otp/js/e2e/pid.spec.ts
+++ b/otp/js/e2e/pid.spec.ts
@@ -8,7 +8,7 @@ test("injected send delivers to a named process (sync)", async ({ otp }) => {
       #{}
     ),
     receive
-      {wasm, Payload, _} ->
+      {wasm, Payload} ->
         #{<<"from_js">> := true} = Payload,
         ok = wasm:send(#{named_send_ok => true})
     end.
@@ -28,7 +28,7 @@ test("injected send works from a later timer callback", async ({ otp }) => {
       #{}
     ),
     receive
-      {wasm, Payload, _} ->
+      {wasm, Payload} ->
         #{<<"delayed">> := true} = Payload,
         ok = wasm:send(#{delayed_send_ok => true})
     end.
@@ -48,7 +48,7 @@ test("injected send addresses a pid passed via args", async ({ otp }) => {
       #{target => Self}
     ),
     receive
-      {wasm, Payload, _} ->
+      {wasm, Payload} ->
         #{<<"via_pid">> := true} = Payload,
         ok = wasm:send(#{pid_send_ok => true})
     end.
@@ -85,7 +85,7 @@ test("pid forwarded inside a send payload revives to a real pid", async ({
     Parent = self(),
     Receiver = spawn(fun() ->
       receive
-        {wasm, Payload, _} ->
+        {wasm, Payload} ->
           #{<<"forwarded">> := Pid} = Payload,
           Parent ! {forwarded_pid, Pid}
       end

--- a/otp/js/e2e/tracked-values.spec.ts
+++ b/otp/js/e2e/tracked-values.spec.ts
@@ -152,7 +152,7 @@ test("tracked argument cleanup waits for async run_js to finish", async ({
       ok = wasm:send(#{async_runner_ready => true})
     end),
     receive
-      {wasm, #{<<"collect">> := true}, _} ->
+      {wasm, #{<<"collect">> := true}} ->
         % Force collection while Runner is blocked inside wasm:run_js/3.
         erlang:garbage_collect(Runner),
         ok = wasm:send(#{async_runner_collected => true})
@@ -234,7 +234,7 @@ test("tracked values isolated cleanup", async ({ createOtp, page }) => {
     HB = wasm:run_js(<<"() => new TrackedValue({v: 42})">>, #{}),
     ok = wasm:send(#{live_ready => true}),
     receive
-      {wasm, _, _} ->
+      {wasm, _} ->
         ok = wasm:send(HB)
     end.
   `);

--- a/otp/js/src/etf.ts
+++ b/otp/js/src/etf.ts
@@ -9,7 +9,6 @@ const VERSION = 0x83;
 const NEW_FLOAT_EXT = 0x46;
 const SMALL_INTEGER_EXT = 0x61;
 const INTEGER_EXT = 0x62;
-const SMALL_TUPLE_EXT = 0x68;
 const NIL_EXT = 0x6a;
 const LIST_EXT = 0x6c;
 const BINARY_EXT = 0x6d;
@@ -39,13 +38,12 @@ export class RawTerm {
 
 export type Mapper = (value: object) => object;
 
-export function tuple2(
+export function encode(
   data: unknown,
-  meta: unknown,
   mapper?: Mapper,
 ): Result<Uint8Array<ArrayBuffer>, "bridge:unserializable"> {
   try {
-    return { ok: true, data: new Encoder(mapper).tuple2(data, meta) };
+    return { ok: true, data: new Encoder(mapper).encode(data) };
   } catch (error) {
     let reason: UnserializableReason = "unsupported";
     let part = data;
@@ -68,12 +66,9 @@ class Encoder {
 
   public constructor(private readonly mapper: Mapper = (value) => value) {}
 
-  tuple2(left: unknown, right: unknown): Uint8Array<ArrayBuffer> {
+  encode(value: unknown): Uint8Array<ArrayBuffer> {
     this.byte(VERSION);
-    this.byte(SMALL_TUPLE_EXT);
-    this.byte(2);
-    this.value(left);
-    this.value(right);
+    this.value(value);
     return new Uint8Array(this.output);
   }
 

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -1,5 +1,5 @@
 import { type Result, type SerializedError } from "./errors";
-import { tuple2, type Mapper } from "./etf";
+import { encode, type Mapper } from "./etf";
 import type {
   AnyValue,
   BeamBootOptions,
@@ -117,7 +117,6 @@ export function readWorkerEvent(value: unknown): VmToMainEvent | null {
 export function serializeSendPayload(
   target: BeamTarget,
   payload: AnyValue,
-  meta: AnyValue,
   mapper?: Mapper,
 ): Result<BeamSendPayload, "bridge:unserializable"> {
   if (isNameTarget(target)) {
@@ -126,7 +125,7 @@ export function serializeSendPayload(
     check(target.pid.byteLength > 0);
   }
 
-  const etf = tuple2(payload, meta, mapper);
+  const etf = encode(payload, mapper);
   if (!etf.ok) return etf;
   return { ok: true, data: { target, etf: etf.data } };
 }

--- a/otp/js/src/index.ts
+++ b/otp/js/src/index.ts
@@ -1,6 +1,6 @@
 export { PopcornError } from "./errors";
 export { Popcorn } from "./popcorn";
-export type { PopcornOpts, PopcornSendOpts } from "./popcorn";
+export type { PopcornOpts } from "./popcorn";
 export type { PopcornEvent } from "./events";
 export type { Pid, OtpErrorPayload } from "./types";
 export type { PopcornErrors, SerializedError } from "./errors";

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -36,10 +36,6 @@ export type PopcornOpts = {
   workerUrl?: string | URL;
 };
 
-export type PopcornSendOpts = {
-  meta?: AnyValue;
-};
-
 type ResolvedTimeouts = Required<NonNullable<PopcornOpts["timeoutsMs"]>>;
 const DEFAULT_TIMEOUTS_MS: ResolvedTimeouts = {
   boot: 10_000,
@@ -63,7 +59,6 @@ type PendingSend = (result: Result<null>) => void;
 type SendFn = (
   target: string | Pid,
   payload?: AnyValue,
-  opts?: PopcornSendOpts,
 ) => Promise<Result<null>>;
 type RunJsFn = (args: AnyValue, send: SendFn) => AnyValue;
 
@@ -234,7 +229,6 @@ export class Popcorn {
   public async send(
     rawTarget: string | Pid,
     payload?: AnyValue,
-    opts?: PopcornSendOpts,
   ): Promise<Result<null>> {
     if (this.state.status !== "booted") {
       if (this.state.status === "closed") {
@@ -256,7 +250,6 @@ export class Popcorn {
     const command = serializeSendPayload(
       target,
       payload ?? {},
-      opts?.meta ?? {},
       this.handleMapper(tracked),
     );
     if (!command.ok) {
@@ -342,8 +335,8 @@ export class Popcorn {
       const fn = this.jsWithCurrentEnv(request.code);
       assertRunJsFn(fn);
       const args = this.reviveHandles(request.args);
-      const send: SendFn = (target, sendPayload, sendOpts) =>
-        this.send(target, sendPayload, sendOpts);
+      const send: SendFn = (target, sendPayload) =>
+        this.send(target, sendPayload);
       const result = await fn(args, send);
       const value = request.return === "ref" ? this.asRef(result) : result;
       payload = { ok: true, value: value ?? null };
@@ -357,7 +350,6 @@ export class Popcorn {
     const command = serializeSendPayload(
       target,
       payload,
-      {},
       this.handleMapper(tracked),
     );
     if (command.ok) {
@@ -371,7 +363,6 @@ export class Popcorn {
     const failure = serializeSendPayload(
       target,
       { ok: false, error: { unserializable: command.error.data.reason } },
-      {},
     );
     check(failure.ok);
     this.sendRunJsReply(failure.data);

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -191,10 +191,10 @@ index 0000000000000000000000000000000000000000..ed09e8dd4ff11df4fe5e8b9adcb4dc70
 +});
 diff --git a/erts/emulator/nifs/common/wasm_nif.c b/erts/emulator/nifs/common/wasm_nif.c
 new file mode 100644
-index 0000000000000000000000000000000000000000..730183d503d8b85a95083be2b9b7719ed99cd009
+index 0000000000000000000000000000000000000000..e39af2a963bdf9697de3e9f61d18d17629a7228d
 --- /dev/null
 +++ b/erts/emulator/nifs/common/wasm_nif.c
-@@ -0,0 +1,651 @@
+@@ -0,0 +1,644 @@
 +/*
 + * %CopyrightBegin%
 + *
@@ -772,14 +772,10 @@ index 0000000000000000000000000000000000000000..730183d503d8b85a95083be2b9b7719e
 +  ErlNifEnv *env;
 +  ERL_NIF_TERM atom;
 +  ErlNifPid pid;
-+  ERL_NIF_TERM pair;
 +  ERL_NIF_TERM payload_term;
 +  ERL_NIF_TERM message_payload;
-+  ERL_NIF_TERM meta_term;
 +  ERL_NIF_TERM message;
 +  ERL_NIF_TERM token;
-+  const ERL_NIF_TERM *pair_elems;
-+  int pair_arity;
 +  int decoded_size;
 +  bool has_token = false;
 +
@@ -791,14 +787,11 @@ index 0000000000000000000000000000000000000000..730183d503d8b85a95083be2b9b7719e
 +    abort();
 +  }
 +
-+  decoded_size = enif_binary_to_term(env, etf, (size_t)etf_len, &pair,
++  decoded_size = enif_binary_to_term(env, etf, (size_t)etf_len, &payload_term,
 +                                     ERL_NIF_BIN2TERM_SAFE);
-+  if (decoded_size != etf_len ||
-+      !enif_get_tuple(env, pair, &pair_arity, &pair_elems) || pair_arity != 2) {
++  if (decoded_size != etf_len) {
 +    abort();
 +  }
-+  payload_term = pair_elems[0];
-+  meta_term = pair_elems[1];
 +
 +  if (target_kind == WASM_TARGET_PID_BYTES) {
 +    if (!decode_pid_target(env, target_name, target_name_len, &pid, &has_token,
@@ -825,7 +818,7 @@ index 0000000000000000000000000000000000000000..730183d503d8b85a95083be2b9b7719e
 +
 +  message_payload =
 +      has_token ? enif_make_tuple2(env, token, payload_term) : payload_term;
-+  message = enif_make_tuple3(env, am_wasm, message_payload, meta_term);
++  message = enif_make_tuple2(env, am_wasm, message_payload);
 +
 +  if (!enif_send(NULL, &pid, env, message)) {
 +    enif_free_env(env);
@@ -1025,7 +1018,7 @@ index 3b672dc41a554cf7d5440ccfd94e85bd44b61d35..4e5efb04e7eb04556ff14dc3ba8e0d83
  	    ]},
 diff --git a/erts/preloaded/src/wasm.erl b/erts/preloaded/src/wasm.erl
 new file mode 100644
-index 0000000000000000000000000000000000000000..76a13760969bd11829dd4a9df4d48269da4197ae
+index 0000000000000000000000000000000000000000..cd6de3257fcf336f481167e83ee4e5cf3b6baad7
 --- /dev/null
 +++ b/erts/preloaded/src/wasm.erl
 @@ -0,0 +1,122 @@
@@ -1084,7 +1077,7 @@ index 0000000000000000000000000000000000000000..76a13760969bd11829dd4a9df4d48269
 +                 reply_to => ReplyTo, return => Return},
 +    ok = send_raw(iolist_to_binary(json:encode(Envelope, fun encode_arg/2))),
 +    Reply = receive
-+                {wasm, {Token, Payload}, _Meta} -> Payload
++                {wasm, {Token, Payload}} -> Payload
 +            after Timeout ->
 +                timeout
 +            end,


### PR DESCRIPTION
Unused, was meant to keep data independent from payload to match on it more easily. With current value/ref semantics, which are recursive, it's easy enough to provide a map with ref and data that would land in meta.