### PR TITLE
otp: optimize only on link

### DIFF
--- a/scripts/build-beam.sh
+++ b/scripts/build-beam.sh
@@ -290,10 +290,6 @@ run_configure() {
         LDFLAGS+=" -sASSERTIONS=2"
     else
         LDFLAGS+=" -sASSERTIONS=0"
-        # LTO: -Oz runs binaryen's size passes and minifies the JS glue.
-        # --closure additionally Closure-minifies the glue.
-        # ref: https://emscripten.org/docs/tools_reference/emcc.html
-        LDFLAGS+=" -Oz --closure 1"
     fi
 
     # Autoconf cache variables for cross-compilation
@@ -391,8 +387,15 @@ build_beam() {
 
     # Set up JS bridge link flags if the bridge exists in the patched source
     local js_bridge_dir="${beam_dir}/erts/emulator/js_bridge"
+    export EXTRA_EMCC_LINK_FLAGS=""
     if [[ -d "${js_bridge_dir}" ]]; then
-        export EXTRA_EMCC_LINK_FLAGS="--pre-js ${js_bridge_dir}/beam-bridge.pre.js --js-library ${js_bridge_dir}/js_bridge.js"
+        EXTRA_EMCC_LINK_FLAGS="--pre-js ${js_bridge_dir}/beam-bridge.pre.js --js-library ${js_bridge_dir}/js_bridge.js"
+    fi
+    if [[ "${mode}" == "release" ]]; then
+        # LTO: -Oz runs binaryen's size passes and minifies the JS glue.
+        # --closure additionally Closure-minifies the glue.
+        # ref: https://emscripten.org/docs/tools_reference/emcc.html
+        EXTRA_EMCC_LINK_FLAGS+=" -Oz --closure 1"
     fi
 
     # erts/lib_src target dir is created on first build only


### PR DESCRIPTION
Part of OTP/BEAM size optimization series. Options were already enabled, this PR moves them in more logical place to be available only on link instead for all object files. Below table shows the change from the baseline.


| Artifact | Raw | gzip-9 | Brotli-11 | Δ Brotli-11 |
|---|---:|---:|---:|---:|
| WebAssembly | 3 200K → 3 000K | 1 130K → 1 120K | 885K → 865K | -20K; -2% |
| JavaScript glue | 300K → 80K | 70K → 25K | 55K → 25K | -30K; -60% |
| **Total** | 3 500K → 3 050K | 1 200K → 1 145K | 940K → 890K | -50K; -5% |

<details>
<summary>Accurate measurements</summary>

| Artifact | Raw | gzip-9 | Brotli-11 | Δ Brotli-11 |
|---|---:|---:|---:|---:|
| WebAssembly | 3 205,4K → 2 987,1K | 1 130,6K → 1 117,8K | 884,5K → 864,8K | -19,7K; -2,2% |
| JavaScript glue | 295,2K → 78,4K | 69,3K → 26,8K | 56,6K → 23,5K | -33,1K; -58,5% |
| **Total** | 3 500,6K → 3 065,5K | 1 199,9K → 1 144,6K | 941,1K → 888,3K | -52,8K; -5,6% |

</details>
