### PR TITLE
otp: strip packaged beam archives by default

### DIFF
--- a/otp/js/plugins/shared.ts
+++ b/otp/js/plugins/shared.ts
@@ -23,6 +23,7 @@ export type Options = {
   rootDir: string;
   app: string | null;
   brotli?: boolean;
+  strip?: boolean;
 };
 
 export type Prepared = {
@@ -46,6 +47,7 @@ type CopyOptions = {
 
 export async function popcorn(opts: Options): Promise<Prepared> {
   const useBrotli = opts.brotli ?? false;
+  const strip = opts.strip ?? true;
   const assetVariants: CopyOptions["variants"] = [
     "gzip",
     useBrotli && "brotli",
@@ -73,9 +75,6 @@ export async function popcorn(opts: Options): Promise<Prepared> {
         p`${distDir}/assets/lib/tarballs.json`,
         p`${preparedDir}/${OTP_DIR}/lib/tarballs.json`,
       ),
-      copy(coreTarballs, p`${preparedDir}/${OTP_DIR}/lib`, {
-        variants: assetVariants,
-      }),
     ]);
 
     const report = await withTmp(async (packedDir) => {
@@ -84,6 +83,8 @@ export async function popcorn(opts: Options): Promise<Prepared> {
         outDir: packedDir,
         providedAppsManifestPath: p`${distDir}/assets/manifest.json`,
         app: opts.app,
+        tarPaths: coreTarballs,
+        strip,
       });
 
       if (!report.ok) {
@@ -114,11 +115,15 @@ async function packTarballs({
   outDir,
   providedAppsManifestPath,
   app,
+  tarPaths,
+  strip,
 }: {
   rootDir: string;
   outDir: string;
   providedAppsManifestPath: string;
   app: string | null;
+  tarPaths: string[];
+  strip: boolean;
 }): Promise<Report> {
   const scriptPath = p`${dirname(fileURLToPath(import.meta.url))}/tarballs.exs`;
   const args = [
@@ -134,6 +139,12 @@ async function packTarballs({
   if (app !== null) {
     args.push("--entrypoint-app", app);
   }
+
+  if (strip) {
+    args.push("--strip");
+  }
+
+  args.push(...tarPaths);
 
   const { stdout } = await execFileAsync("elixir", args);
   return JSON.parse(stdout) as Report;

--- a/otp/js/plugins/tarballs.exs
+++ b/otp/js/plugins/tarballs.exs
@@ -8,7 +8,8 @@ defmodule Tarballs do
     root_dir: :string,
     entrypoint_app: :string,
     out_dir: :string,
-    provided_apps_manifest_path: :string
+    provided_apps_manifest_path: :string,
+    strip: :boolean
   ]
 
   @required_options [:root_dir, :out_dir, :provided_apps_manifest_path]
@@ -26,6 +27,37 @@ defmodule Tarballs do
         |> encode_json()
         |> IO.puts()
     end
+  end
+
+  defp strip_tarball(path, out_dir) do
+    {:ok, entries} = :erl_tar.extract(to_charlist(path), [:memory])
+
+    stripped =
+      entries
+      |> Enum.sort_by(fn {name, _content} -> to_string(name) end)
+      |> Enum.map(&strip_entry/1)
+
+    output = Path.join(out_dir, Path.basename(path))
+    opts = [mtime: 0, atime: 0, ctime: 0, uid: 0, gid: 0]
+
+    :ok = :erl_tar.create(to_charlist(output), stripped, opts)
+  end
+
+  defp strip_entry({name, content}) do
+    is_beam? = fn path -> Path.extname(path) == ".beam" end
+
+    with true <- is_beam?.(to_string(name)),
+         {:ok, {_module, stripped}} <- strip_beam(content) do
+      {name, stripped}
+    else
+      _ -> {name, content}
+    end
+  end
+
+  defp strip_beam(content) do
+    :beam_lib.strip(content)
+  rescue
+    _error -> :error
   end
 
   defp run(argv) do
@@ -65,6 +97,8 @@ defmodule Tarballs do
         |> Map.values()
         |> Enum.map(&Path.expand(Path.join(args.out_dir, &1.tar)))
 
+      tar_paths = maybe_strip_tarballs(tar_paths ++ args.tar_paths, args.strip, args.out_dir)
+
       manifest = %{
         entrypoint: args.entrypoint_app,
         apps: manifest_apps,
@@ -84,6 +118,15 @@ defmodule Tarballs do
          notes: notes
        }}
     end
+  end
+
+  defp maybe_strip_tarballs(paths, false, _out_dir), do: paths
+
+  defp maybe_strip_tarballs(paths, true, out_dir) do
+    Enum.map(paths, fn path ->
+      :ok = strip_tarball(path, out_dir)
+      Path.expand(Path.join(out_dir, Path.basename(path)))
+    end)
   end
 
   defp fetch_user_apps(root_dir) do
@@ -227,13 +270,20 @@ defmodule Tarballs do
   end
 
   defp parse_argv(argv) do
-    {opts, _rest, invalid} = OptionParser.parse(argv, strict: @options)
+    {opts, tar_paths, invalid} = OptionParser.parse(argv, strict: @options)
 
     missing_opts = Enum.reject(@required_options, &Keyword.has_key?(opts, &1))
 
     case {invalid, missing_opts} do
       {[], []} ->
-        {:ok, opts |> Map.new() |> Map.put_new(:entrypoint_app, nil)}
+        args =
+          opts
+          |> Map.new()
+          |> Map.put_new(:entrypoint_app, nil)
+          |> Map.put_new(:strip, false)
+          |> Map.put(:tar_paths, tar_paths)
+
+        {:ok, args}
 
       _ ->
         err(:bad_args, {invalid, missing_opts})


### PR DESCRIPTION
Part of OTP/BEAM size optimization series. Stripping modules from debug info and docs improved sizes a lot.



| Archive | Raw | gzip-9 | Brotli-11 | Δ Brotli-11 |
|---|---:|---:|---:|---:|
| `compiler.tar` | 3 150K → 700K | 2 500K → 650K | 2 300K → 600K | -1 700K; -75% |
| `elixir.tar` | 7 300K → 1 500K | 4 750K → 1 250K | 4 100K → 1 250K | -2 850K; -70% |
| `kernel.tar` | 3 100K → 700K | 2 500K → 600K | 2 300K → 600K | -1 700K; -75% |
| `logger.tar` | 205K → 50K | 130K → 40K | 120K → 40K | -80K; -65% |
| `stdlib.tar` | 6 800K → 1 300K | 5 250K → 1 200K | 4 750K → 1 200K | -3 550K; -75% |
| **Total** | 20 550K → 4 250K | 15 150K → 3 750K | 13 550K → 3 700K | -9 850K; -75% |

<details>
<summary>Accurate measurements</summary>

| Archive | Raw | gzip-9 | Brotli-11 | Δ Brotli-11 |
|---|---:|---:|---:|---:|
| `compiler.tar` | 3 160,1K → 676,4K | 2 524,2K → 627,0K | 2 306,7K → 624,5K | -1 682,2K; -72,9% |
| `elixir.tar` | 7 307,3K → 1 518,1K | 4 734,1K → 1 263,0K | 4 085,7K → 1 250,2K | -2 835,5K; -69,4% |
| `kernel.tar` | 3 084,8K → 694,3K | 2 510,8K → 612,8K | 2 293,9K → 609,4K | -1 684,5K; -73,4% |
| `logger.tar` | 204,8K → 51,7K | 132,3K → 41,9K | 119,4K → 41,7K | -77,7K; -65,1% |
| `stdlib.tar` | 6 780,4K → 1 305,1K | 5 269,3K → 1 188,3K | 4 749,6K → 1 178,3K | -3 571,3K; -75,2% |
| **Total** | 20 537,3K → 4 245,5K | 15 170,8K → 3 733,1K | 13 555,2K → 3 704,1K | -9 851,1K; -72,7% |

</details>

