### PR TITLE
otp: save bytes on unsupported features

### DIFF
--- a/otp/patches/stripped/0001-without-zstd.patch
+++ b/otp/patches/stripped/0001-without-zstd.patch
@@ -1,0 +1,95 @@
+diff --git a/erts/emulator/Makefile.in b/erts/emulator/Makefile.in
+--- a/erts/emulator/Makefile.in
++++ b/erts/emulator/Makefile.in
+@@ -397,17 +397,6 @@ else
+ LIBS += $(OPENSSL_LIB)
+ endif
+ 
+-ZSTD_DIR = $(ERL_TOP)/erts/emulator/zstd/obj/$(TARGET)/$(TYPE)
+-ZSTD_LIB = $(ZSTD_DIR)/$(LIB_PREFIX)zstd$(LIB_SUFFIX)
+-DEPLIBS += $(ZSTD_LIB)
+- 
+-ifeq ($(TARGET),win32)
+-LIBS    += -L$(ZSTD_DIR) -lzstd
+-else
+-# Build on darwin fails if -l$(ZSTD_LIB) is used
+-LIBS    += $(ZSTD_LIB)
+-endif
+-
+ LIBSCTP = @LIBSCTP@
+ 
+ ORG_THR_LIBS=@EMU_THR_LIBS@
+@@ -451,8 +440,7 @@ CREATE_DIRS += $(OBJDIR) \
+ 	pcre/obj/$(TARGET)/$(TYPE) \
+ 	$(ZLIB_OBJDIR) \
+ 	$(RYU_OBJDIR) \
+-	$(OPENSSL_OBJDIR) \
+-        $(ZSTD_OBJDIR)
++	$(OPENSSL_OBJDIR)
+ 
+ ifeq ($(FLAVOR),jit)
+ CREATE_DIRS+=$(OBJDIR)/asmjit/ $(OBJDIR)/asmjit/core $(OBJDIR)/asmjit/$(JIT_ARCH)
+@@ -523,7 +511,6 @@ include zlib/zlib.mk
+ include pcre/pcre.mk
+ include ryu/ryu.mk
+ include openssl/openssl.mk
+-include zstd/zstd.mk
+ 
+ $(ERTS_LIB):
+ 	$(V_at)cd $(ERTS_LIB_DIR) && $(MAKE) $(TYPE)
+@@ -827,7 +814,7 @@ COMMON_INCLUDES = -Ibeam -Isys/$(ERLANG_OSTYPE) -Isys/common -I$(TARGET)
+ ifndef Z_LIB
+ COMMON_INCLUDES += -Izlib 
+ endif
+-COMMON_INCLUDES += -Ipcre -Iryu -Iopenssl/include -Izstd
++COMMON_INCLUDES += -Ipcre -Iryu -Iopenssl/include
+ COMMON_INCLUDES += -I../include -I../include/$(TARGET)
+ COMMON_INCLUDES += -I../include/internal -I../include/internal/$(TARGET)
+ 
+@@ -1172,3 +1159,2 @@ NIF_OBJS = \
+ 	$(OBJDIR)/zlib_nif.o \
+-	$(OBJDIR)/zstd_nif.o \
+ 	$(ESOCK_NIF_OBJS)
+@@ -1427,6 +1413,6 @@ $(TARGET)/gen_git_version.mk:
+ 	$(V_at)if utils/gen_git_version $@; then touch beam/erl_bif_info.c; fi
+ 
+-DEPEND_DEPS=jit src drv nif sys target zlib ryu zstd
++DEPEND_DEPS=jit src drv nif sys target zlib ryu
+ 
+ $(TTF_DIR)/src.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC)
+ 	$(gen_verbose)
+@@ -1458,10 +1444,6 @@ $(TTF_DIR)/ryu.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC)
+ 	$(gen_verbose)
+ 	$(V_at)$(DEP_CC) $(DEP_FLAGS) $(RYU_SRC) > $@.tmp
+ 	$(V_at)$(SED_DEPEND_ZLIB) $@.tmp  > $@
+-$(TTF_DIR)/zstd.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC)
+-	$(gen_verbose)
+-	$(V_at)$(DEP_CC) $(DEP_FLAGS) $(ZSTD_SRC) > $@.tmp
+-	$(V_at)$(SED_DEPEND_ZLIB) $@.tmp  > $@
+ $(TTF_DIR)/jit.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC)
+ 	$(gen_verbose)
+ 	@touch $@
+diff --git a/lib/stdlib/src/Makefile b/lib/stdlib/src/Makefile
+--- a/lib/stdlib/src/Makefile
++++ b/lib/stdlib/src/Makefile
+@@ -138,8 +138,7 @@ MODULES= \
+ 	unicode_util \
+ 	uri_string \
+ 	win32reg \
+-	zip \
+-	zstd
++	zip
+ 
+ HRL_FILES= \
+ 	../include/assert.hrl \
+diff --git a/lib/stdlib/src/stdlib.app.src b/lib/stdlib/src/stdlib.app.src
+--- a/lib/stdlib/src/stdlib.app.src
++++ b/lib/stdlib/src/stdlib.app.src
+@@ -118,6 +118,5 @@
+ 	     uri_string,
+ 	     win32reg,
+-	     zip,
+-             zstd]},
++	     zip]},
+   {registered,[timer_server,rsh_starter,take_over_monitor,pool_master,
+                dets]},

--- a/otp/patches/stripped/0002-without-native-sockets.patch
+++ b/otp/patches/stripped/0002-without-native-sockets.patch
@@ -1,0 +1,65 @@
+diff --git a/erts/emulator/Makefile.in b/erts/emulator/Makefile.in
+--- a/erts/emulator/Makefile.in
++++ b/erts/emulator/Makefile.in
+@@ -1178,6 +1178,5 @@ ifeq ($(TARGET),win32)
+ DRV_OBJS = \
+ 	$(OBJDIR)/registry_drv.o \
+-	$(OBJDIR)/inet_drv.o \
+ 	$(OBJDIR)/ram_file_drv.o
+ OS_OBJS = \
+ 	$(OBJDIR)/dll_sys.o \
+@@ -1205,6 +1204,5 @@ OS_OBJS = \
+ 	$(OBJDIR)/unix_socket_syncio.o
+ 
+ DRV_OBJS = \
+-	$(OBJDIR)/inet_drv.o \
+ 	$(OBJDIR)/ram_file_drv.o
+ endif
+ 
+diff --git a/erts/preloaded/src/prim_inet.erl b/erts/preloaded/src/prim_inet.erl
+--- a/erts/preloaded/src/prim_inet.erl
++++ b/erts/preloaded/src/prim_inet.erl
+@@ -97,26 +97,3 @@ fdopen(Protocol, Family, Type, Fd, Bound)
+-open(Protocol, Family, Type, Opts, Req, Data) ->
+-    Drv = protocol2drv(Protocol),
+-    AF = enc_family(Family),
+-    T = enc_type(Type),
+-    try erlang:open_port({spawn_driver,Drv}, [binary]) of
+-	S ->
+-	    case setopts(S, Opts) of
+-		ok ->
+-		    case ctl_cmd(S, Req, [AF,T,Data]) of
+-			{ok,_} -> {ok,S};
+-			{error,_}=E1 ->
+-			    close(S),
+-			    E1
+-		    end;
+-		{error,_}=E2 ->
+-		    close(S),
+-		    E2
+-	    end
+-    catch
+-	%% The only (?) way to get here is to try to open
+-	%% the sctp driver when it does not exist (badarg)
+-	error:badarg       -> {error, eprotonosupport};
+-	%% system_limit if out of port slots
+-	error:system_limit -> {error, system_limit}
+-    end.
++open(_Protocol, _Family, _Type, _Opts, _Req, _Data) ->
++    {error, eprotonosupport}.
+ 
+@@ -123,14 +100,1 @@ open(Protocol, Family, Type, Opts, Req, Data) ->
+-enc_family(inet)  -> ?INET_AF_INET;
+-enc_family(inet6) -> ?INET_AF_INET6;
+-enc_family(local) -> ?INET_AF_LOCAL.
+-
+-enc_type(stream) -> ?INET_TYPE_STREAM;
+-enc_type(dgram) -> ?INET_TYPE_DGRAM;
+-enc_type(seqpacket) -> ?INET_TYPE_SEQPACKET.
+-
+-protocol2drv(tcp)   -> "tcp_inet";
+-protocol2drv(udp)   -> "udp_inet";
+-protocol2drv(sctp)  -> "sctp_inet";
+-protocol2drv(mptcp) -> "tcp_inet".
+-
+ drv2protocol("tcp_inet")  -> tcp;

--- a/otp/patches/stripped/0003-without-distribution.patch
+++ b/otp/patches/stripped/0003-without-distribution.patch
@@ -1,0 +1,281 @@
+diff --git a/lib/kernel/src/Makefile b/lib/kernel/src/Makefile
+--- a/lib/kernel/src/Makefile
++++ b/lib/kernel/src/Makefile
+@@ -66,14 +66,11 @@ MODULES = \
+ 	disk_log_server \
+ 	disk_log_sup \
+ 	dist_ac \
+-	dist_util \
+ 	erl_boot_server \
+ 	erl_compile_server \
+ 	erl_ddll \
+ 	erl_debugger \
+-	erl_distribution \
+ 	erl_erts_errors \
+-	erl_epmd \
+ 	erl_kernel_errors \
+ 	erl_reply \
+ 	erl_signal_handler \
+@@ -97,21 +94,17 @@ MODULES = \
+ 	heart \
+ 	inet \
+ 	inet6_tcp \
+-	inet6_tcp_dist \
+ 	inet6_udp \
+ 	inet6_sctp \
+ 	inet_config \
+ 	inet_db \
+ 	inet_dns \
+ 	inet_dns_tsig \
+-	inet_epmd_dist \
+-	inet_epmd_socket \
+ 	inet_gethost_native \
+ 	inet_hosts \
+ 	inet_parse \
+ 	inet_res \
+ 	inet_tcp \
+-	inet_tcp_dist \
+ 	inet_udp \
+ 	inet_sctp \
+ 	kernel \
+diff --git a/lib/kernel/src/kernel.app.src b/lib/kernel/src/kernel.app.src
+--- a/lib/kernel/src/kernel.app.src
++++ b/lib/kernel/src/kernel.app.src
+@@ -32,11 +32,9 @@
+ 	     auth,
+ 	     code,
+ 	     code_server,
+-	     dist_util,
+ 	     erl_boot_server,
+ 	     erl_compile_server,
+ 	     erl_debugger,
+-	     erl_distribution,
+              erl_erts_errors,
+ 	     erl_reply,
+              erl_kernel_errors,
+@@ -54,15 +52,11 @@
+ 	     group_history,
+ 	     heart,
+ 	     inet6_tcp,
+-	     inet6_tcp_dist,
+ 	     inet6_udp,
+ 	     inet6_sctp,
+ 	     inet_config,
+-             inet_epmd_dist,
+-             inet_epmd_socket,
+ 	     inet_hosts,
+ 	     inet_gethost_native,
+-	     inet_tcp_dist,
+ 	     kernel,
+ 	     kernel_config,
+ 	     kernel_refc,
+@@ -99,7 +93,6 @@
+              disk_log_sup,
+              dist_ac,
+              erl_ddll,
+-             erl_epmd,
+ 	     erts_debug,
+              gen_tcp,
+ 	     gen_tcp_socket,
+diff --git a/lib/kernel/src/kernel.erl b/lib/kernel/src/kernel.erl
+--- a/lib/kernel/src/kernel.erl
++++ b/lib/kernel/src/kernel.erl
+@@ -260,13 +260,6 @@ start_distribution() ->
+ 
+     DistAC = start_dist_ac(),
+ 
+-    NetSup = #{id => net_sup,
+-               start => {erl_distribution, start_link, []},
+-               restart => permanent,
+-               shutdown => infinity,
+-               type => supervisor,
+-               modules => [erl_distribution]},
+-
+     GlGroup = #{id => global_group,
+                 start => {global_group,start_link,[]},
+                 restart => permanent,
+@@ -274,7 +267,7 @@ start_distribution() ->
+                 type => worker,
+                 modules => [global_group]},
+ 
+-    [Rpc, Global | DistAC] ++ [NetSup, GlGroup].
++    [Rpc, Global | DistAC] ++ [GlGroup].
+ 
+ start_dist_ac() ->
+     Spec = [#{id => dist_ac,
+diff --git a/lib/kernel/src/net_kernel.erl b/lib/kernel/src/net_kernel.erl
+--- a/lib/kernel/src/net_kernel.erl
++++ b/lib/kernel/src/net_kernel.erl
+@@ -345,10 +345,9 @@ Only possible when the net kernel was started using `start/2`, otherwise
+ `{error, not_allowed}` is returned. Returns `{error, not_found}` if the local
+ node is not alive.
+ """.
+--spec stop() -> ok | {error, Reason} when
+-      Reason :: not_allowed | not_found.
++-spec stop() -> {error, enotsup}.
+ stop() ->
+-    erl_distribution:stop().
++    {error, enotsup}.
+ 
+ -type node_info() ::
+     {address, #net_address{}} |
+@@ -834,28 +833,8 @@ Currently supported options:
+       Reason :: {already_started, pid()} | term().
+ 
+ start(Name, Options) when is_atom(Name), is_map(Options) ->
+-    try
+-        maps:foreach(fun (name_domain, Val) when Val == shortnames;
+-                                                 Val == longnames ->
+-                             ok;
+-                         (net_ticktime, Val) when is_integer(Val),
+-                                                  Val > 0 ->
+-                             ok;
+-                         (net_tickintensity, Val) when is_integer(Val),
+-                                                       4 =< Val,
+-                                                       Val =< 1000 ->
+-                             ok;
+-                         (dist_listen, Val) when is_boolean(Val) ->
+-                             ok;
+-                         (hidden, Val) when is_boolean(Val) ->
+-                             ok;
+-                         (Opt, Val) ->
+-                             error({invalid_option, Opt, Val})
+-                     end, Options)
+-    catch error:Reason ->
+-            error(Reason, [Name, Options])
+-    end,
+-    erl_distribution:start(Options#{name => Name});
++    _ = {Name, Options},
++    {error, enotsup};
+ start(Name, Options) when is_map(Options) ->
+     error(invalid_name, [Name, Options]);
+ start(Name, Options) ->
+diff --git a/erts/emulator/beam/dist.c b/erts/emulator/beam/dist.c
+--- a/erts/emulator/beam/dist.c
++++ b/erts/emulator/beam/dist.c
+@@ -2020,6 +2020,8 @@ int erts_net_message(Port *prt,
+ 		     const byte *buf,
+ 		     ErlDrvSizeT len)
+ {
++    return -1;
++
+     ErtsDistExternal ede, *edep = &ede;
+     ErtsDistExternalData ede_data;
+     ErlHeapFragment *ede_hfrag = NULL;
+@@ -3220,6 +3222,8 @@ erts_dsig_prepare(ErtsDSigSendContext *ctx,
+                   int no_trap,
+ 		  int connect)
+ {
++    return ERTS_DSIG_PREP_NOT_CONNECTED;
++
+     /*
+      * No process imply that we should force data through. That
+      * is, ignore busy state of dist entry and allow enqueue
+@@ -4271,6 +4275,8 @@ erts_dist_command(Port *prt, int initial_reds)
+ BIF_RETTYPE
+ dist_ctrl_get_data_notification_1(BIF_ALIST_1)
+ {
++    BIF_RET(am_notsup);
++
+     DistEntry *dep = ERTS_PROC_GET_DIST_ENTRY(BIF_P);
+     erts_aint32_t notify;
+     erts_aint_t qsize;
+@@ -4331,6 +4337,8 @@ dist_ctrl_get_data_notification_1(BIF_ALIST_1)
+ BIF_RETTYPE
+ dist_ctrl_put_data_2(BIF_ALIST_2)
+ {
++    BIF_RET(am_notsup);
++
+     DistEntry *dep;
+     Eterm input_handler;
+     Uint32 conn_id;
+@@ -4407,6 +4415,8 @@ dist_ctrl_put_data_2(BIF_ALIST_2)
+ BIF_RETTYPE
+ dist_ctrl_set_opt_3(BIF_ALIST_3)
+ {
++    BIF_RET(am_notsup);
++
+     DistEntry *dep = ERTS_PROC_GET_DIST_ENTRY(BIF_P);
+     Uint32 conn_id;
+     BIF_RETTYPE ret;
+@@ -4450,6 +4460,8 @@ dist_ctrl_set_opt_3(BIF_ALIST_3)
+ BIF_RETTYPE
+ dist_ctrl_get_opt_2(BIF_ALIST_2)
+ {
++    BIF_RET(am_notsup);
++
+     DistEntry *dep = ERTS_PROC_GET_DIST_ENTRY(BIF_P);
+     Uint32 conn_id;
+     BIF_RETTYPE ret;
+@@ -4487,6 +4499,8 @@ dist_ctrl_get_opt_2(BIF_ALIST_2)
+ BIF_RETTYPE
+ dist_get_stat_1(BIF_ALIST_1)
+ {
++    BIF_RET(am_notsup);
++
+     Sint64 read, write, pend;
+     Eterm res, *hp, **hpp;
+     Uint sz, *szp;
+@@ -4531,6 +4545,8 @@ dist_get_stat_1(BIF_ALIST_1)
+ BIF_RETTYPE
+ dist_ctrl_input_handler_2(BIF_ALIST_2)
+ {
++    BIF_RET(am_notsup);
++
+     Uint32 conn_id;
+     DistEntry *dep = erts_dhandle_to_dist_entry(BIF_ARG_1, &conn_id);
+ 
+@@ -4557,6 +4573,8 @@ dist_ctrl_input_handler_2(BIF_ALIST_2)
+ BIF_RETTYPE
+ dist_ctrl_get_data_1(BIF_ALIST_1)
+ {
++    BIF_RET(am_notsup);
++
+     DistEntry *dep = ERTS_PROC_GET_DIST_ENTRY(BIF_P);
+     const Sint initial_reds = ERTS_BIF_REDS_LEFT(BIF_P);
+     Sint reds = initial_reds, ix, vlen;
+@@ -4977,6 +4995,8 @@ int distribution_info(fmtfn_t to, void *arg)
+ 
+ BIF_RETTYPE setnode_2(BIF_ALIST_2)
+ {
++    BIF_RET(am_notsup);
++
+     Process *net_kernel = NULL;
+     Uint32 creation;
+     int success;
+@@ -5126,6 +5146,8 @@ setup_connection_distctrl(Process *c_p, void *arg,
+ 
+ BIF_RETTYPE erts_internal_create_dist_channel_3(BIF_ALIST_3)
+ {
++    BIF_RET(am_notsup);
++
+     BIF_RETTYPE ret;
+     Uint64 flags;
+     Uint32 creation;
+@@ -5587,6 +5609,8 @@ BIF_RETTYPE erts_internal_get_creation_0(BIF_ALIST_0)
+ 
+ BIF_RETTYPE erts_internal_new_connection_1(BIF_ALIST_1)
+ {
++    BIF_RET(am_notsup);
++
+     DistEntry* dep;
+     Uint32 conn_id;
+     Eterm* hp;
+@@ -5692,6 +5716,8 @@ static Sint abort_pending_connection(DistEntry *dep, Uint32 conn_id,
+ 
+ BIF_RETTYPE erts_internal_abort_pending_connection_2(BIF_ALIST_2)
+ {
++    BIF_RET(am_notsup);
++
+     DistEntry* dep;
+     Uint32 conn_id;
+     Sint reds;
+@@ -5712,6 +5738,8 @@ BIF_RETTYPE erts_internal_abort_pending_connection_2(BIF_ALIST_2)
+ 
+ int erts_auto_connect(DistEntry* dep, Process *proc, ErtsProcLocks proc_locks)
+ {
++    return 0;
++
+     erts_de_rwlock(dep);
+     if (dep->state != ERTS_DE_STATE_IDLE) {
+         erts_de_rwunlock(dep);

--- a/otp/patches/stripped/0004-without-crash-dumps.patch
+++ b/otp/patches/stripped/0004-without-crash-dumps.patch
@@ -1,0 +1,26 @@
+diff --git a/erts/emulator/beam/break.c b/erts/emulator/beam/break.c
+--- a/erts/emulator/beam/break.c
++++ b/erts/emulator/beam/break.c
+@@ -797,4 +797,15 @@ erl_crash_dump_v(char *file, int line, const char* fmt, va_list args)
+ {
++#ifdef __EMSCRIPTEN__
++    erts_fprintf(stderr, "\nBEAM fatal error");
++    if (file != NULL)
++        erts_fprintf(stderr, " in %s:%d", file, line);
++    if (fmt != NULL && *fmt != '\0') {
++        erts_fprintf(stderr, ": ");
++        erts_vfprintf(stderr, fmt, args);
++    }
++    erts_fprintf(stderr, "\n");
++    return;
++#else
+     ErtsThrPrgrData tpd_buf; /* in case we aren't a managed thread... */
+     int fd;
+     size_t envsz;
+@@ -1048,5 +1059,6 @@ erl_crash_dump_v(char *file, int line, const char* fmt, va_list args)
+ 
+     erts_fprintf(stderr,"done\n");
++#endif
+ }
+ 
+ void

--- a/otp/patches/stripped/0005-without-dynamic-loading.patch
+++ b/otp/patches/stripped/0005-without-dynamic-loading.patch
@@ -1,0 +1,79 @@
+diff --git a/erts/emulator/beam/erl_bif_ddll.c b/erts/emulator/beam/erl_bif_ddll.c
+--- a/erts/emulator/beam/erl_bif_ddll.c
++++ b/erts/emulator/beam/erl_bif_ddll.c
+@@ -178,4 +178,10 @@ BIF_RETTYPE erl_ddll_try_load_3(BIF_ALIST_3)
+ {
++#ifdef __EMSCRIPTEN__
++    Eterm *hp = HAlloc(BIF_P, 3);
++    Eterm error = build_load_error_hp(NULL, ERL_DE_ERROR_NO_DDLL_FUNCTIONALITY);
++
++    BIF_RET(TUPLE2(hp, am_error, error));
++#else
+     Eterm path_term = BIF_ARG_1;
+     Eterm name_term = BIF_ARG_2;
+     Eterm options = BIF_ARG_3;
+@@ -465,5 +471,6 @@ BIF_RETTYPE erl_ddll_try_load_3(BIF_ALIST_3)
+     }
+     BIF_ERROR(BIF_P, BADARG);
++#endif
+ }
+ 
+ /*
+diff --git a/erts/emulator/beam/erl_nif.c b/erts/emulator/beam/erl_nif.c
+--- a/erts/emulator/beam/erl_nif.c
++++ b/erts/emulator/beam/erl_nif.c
+@@ -3276,6 +3276,13 @@ int enif_dynamic_resource_call(ErlNifEnv* caller_env, ERL_NIF_TERM resource_ter
+ void* enif_dlopen(const char* lib,
+ 		  void (*err_handler)(void*,const char*), void* err_arg)
+ {
++#ifdef __EMSCRIPTEN__
++    (void)lib;
++    if (err_handler != NULL) {
++        (*err_handler)(err_arg, "Dynamic loading is not supported in browser");
++    }
++    return NULL;
++#else
+     ErtsSysDdllError errdesc = ERTS_SYS_DDLL_ERROR_INIT;
+     void* handle;
+     void* init_func;
+@@ -3292,10 +3299,19 @@ void* enif_dlopen(const char* lib,
+     erts_sys_ddll_free_error(&errdesc);
+     return handle;
++#endif
+ }
+ 
+ void* enif_dlsym(void* handle, const char* symbol,
+ 		 void (*err_handler)(void*,const char*), void* err_arg)
+ {
++#ifdef __EMSCRIPTEN__
++    (void)handle;
++    (void)symbol;
++    if (err_handler != NULL) {
++        (*err_handler)(err_arg, "Dynamic loading is not supported in browser");
++    }
++    return NULL;
++#else
+     ErtsSysDdllError errdesc = ERTS_SYS_DDLL_ERROR_INIT;
+     void* ret;
+     if (erts_sys_ddll_sym2(handle, symbol, &ret, &errdesc) != ERL_DE_NO_ERROR) {
+@@ -3308,5 +3324,6 @@ void* enif_dlsym(void* handle, const char* symbol,
+     }
+     return ret;
++#endif
+ }
+ 
+ int enif_consume_timeslice(ErlNifEnv* env, int percent)
+@@ -4725,6 +4742,13 @@ Eterm erts_load_nif(Process *c_p, ErtsCodePtr I, Eterm filename, Eterm args)
+             is_static = 1;
+         }
+     }
++#ifdef __EMSCRIPTEN__
++    if (!is_static) {
++        ret = load_nif_error(c_p, "load_failed",
++                             "Dynamic loading is not supported in browser");
++        goto error;
++    }
++#endif
+     this_mi = &module_p->curr;
+     prev_mi = &module_p->old;
+     if (in_area(caller, module_p->old.code_hdr, module_p->old.code_length)) {

--- a/scripts/build-beam.sh
+++ b/scripts/build-beam.sh
@@ -11,6 +11,8 @@
 # Options:
 #   --with-crypto         Include static OpenSSL + crypto/asn1 NIFs
 #   --without-zstd        Exclude Zstandard support
+#   --without-native-sockets
+#                         Exclude the native inet driver
 #   --otp-tag <TAG>       OTP git tag to clone (default: OTP-28.3.1)
 #   --source <path>       Use local OTP source instead of cloning
 #   --outdir <dir>        Output directory (default: ./out)
@@ -58,6 +60,8 @@ Build modes (positional):
 Options:
   --with-crypto         Include static OpenSSL + crypto/asn1 NIFs
   --without-zstd        Exclude Zstandard support
+  --without-native-sockets
+                        Exclude the native inet driver
   --otp-tag <TAG>       OTP git tag to clone (default: ${DEFAULT_OTP_TAG})
   --source <path>       Use local OTP source instead of cloning
   --outdir <dir>        Output directory (default: ./out)
@@ -180,9 +184,14 @@ build_bootstrap() {
 compile_preloaded_modules() {
     local beam_dir="$1"
     local force="${2:-false}"
+    local compile_prim_inet="${3:-false}"
     local ebin="${beam_dir}/erts/preloaded/ebin"
     local erlc="${beam_dir}/bootstrap/bin/erlc"
-    local module
+    local modules=(wasm erl_init)
+
+    if [[ "${compile_prim_inet}" == "true" ]]; then
+        modules+=(prim_inet)
+    fi
 
     if [[ ! -x "${erlc}" ]]; then
         erlc="$(command -v erlc || true)"
@@ -192,7 +201,7 @@ compile_preloaded_modules() {
     fi
 
     mkdir -p "${ebin}"
-    for module in wasm erl_init; do
+    for module in "${modules[@]}"; do
         local src="${beam_dir}/erts/preloaded/src/${module}.erl"
         local beam="${ebin}/${module}.beam"
 
@@ -208,7 +217,10 @@ compile_preloaded_modules() {
 
         log "Compiling preloaded ${module}.beam with ${erlc}..."
         # +deterministic matches how the committed preloaded beams are produced.
-        run "${erlc}" +deterministic -o "${ebin}" "${src}"
+        run "${erlc}" +deterministic \
+            -I "${beam_dir}/lib/kernel/src" \
+            -I "${beam_dir}/lib/kernel/include" \
+            -o "${ebin}" "${src}"
     done
     success "Preloaded modules compiled."
 }
@@ -456,6 +468,7 @@ main() {
     local outdir=""
     local with_crypto=false
     local without_zstd=false
+    local without_native_sockets=false
     local clean=false
     local jobs=""
     local mode=""
@@ -471,6 +484,10 @@ main() {
                 ;;
             --without-zstd)
                 without_zstd=true
+                shift
+                ;;
+            --without-native-sockets)
+                without_native_sockets=true
                 shift
                 ;;
             --otp-tag)
@@ -513,6 +530,7 @@ main() {
 
     if [[ "${mode}" == "release" ]]; then
         without_zstd=true
+        without_native_sockets=true
     fi
 
     # Use single-threaded build in CI to avoid OOM (unless explicitly set)
@@ -541,17 +559,18 @@ main() {
 
     local patch_args=()
     [[ "${without_zstd}" == "true" ]] && patch_args+=(--without-zstd)
+    [[ "${without_native_sockets}" == "true" ]] && patch_args+=(--without-native-sockets)
     patch_otp "${patch_args[@]}"
 
     run_autoconf "${beam_dir}"
 
     # The native bootstrap emulator embeds erts/preloaded/ebin/*.beam while
     # building preload.c, before bootstrap/bin/erlc has been created.
-    compile_preloaded_modules "${beam_dir}" true
+    compile_preloaded_modules "${beam_dir}" true "${without_native_sockets}"
 
     build_bootstrap "${beam_dir}" "${jobs}"
 
-    compile_preloaded_modules "${beam_dir}" true
+    compile_preloaded_modules "${beam_dir}" true "${without_native_sockets}"
 
     local openssl_prefix=""
     if [[ "${with_crypto}" == "true" ]]; then

--- a/scripts/build-beam.sh
+++ b/scripts/build-beam.sh
@@ -13,6 +13,8 @@
 #   --without-zstd        Exclude Zstandard support
 #   --without-native-sockets
 #                         Exclude the native inet driver
+#   --without-distribution
+#                         Exclude remote distribution
 #   --otp-tag <TAG>       OTP git tag to clone (default: OTP-28.3.1)
 #   --source <path>       Use local OTP source instead of cloning
 #   --outdir <dir>        Output directory (default: ./out)
@@ -62,6 +64,8 @@ Options:
   --without-zstd        Exclude Zstandard support
   --without-native-sockets
                         Exclude the native inet driver
+  --without-distribution
+                        Exclude remote distribution
   --otp-tag <TAG>       OTP git tag to clone (default: ${DEFAULT_OTP_TAG})
   --source <path>       Use local OTP source instead of cloning
   --outdir <dir>        Output directory (default: ./out)
@@ -469,6 +473,7 @@ main() {
     local with_crypto=false
     local without_zstd=false
     local without_native_sockets=false
+    local without_distribution=false
     local clean=false
     local jobs=""
     local mode=""
@@ -488,6 +493,10 @@ main() {
                 ;;
             --without-native-sockets)
                 without_native_sockets=true
+                shift
+                ;;
+            --without-distribution)
+                without_distribution=true
                 shift
                 ;;
             --otp-tag)
@@ -531,6 +540,7 @@ main() {
     if [[ "${mode}" == "release" ]]; then
         without_zstd=true
         without_native_sockets=true
+        without_distribution=true
     fi
 
     # Use single-threaded build in CI to avoid OOM (unless explicitly set)
@@ -560,6 +570,7 @@ main() {
     local patch_args=()
     [[ "${without_zstd}" == "true" ]] && patch_args+=(--without-zstd)
     [[ "${without_native_sockets}" == "true" ]] && patch_args+=(--without-native-sockets)
+    [[ "${without_distribution}" == "true" ]] && patch_args+=(--without-distribution)
     patch_otp "${patch_args[@]}"
 
     run_autoconf "${beam_dir}"

--- a/scripts/build-beam.sh
+++ b/scripts/build-beam.sh
@@ -10,14 +10,6 @@
 #
 # Options:
 #   --with-crypto         Include static OpenSSL + crypto/asn1 NIFs
-#   --without-zstd        Exclude Zstandard support
-#   --without-native-sockets
-#                         Exclude the native inet driver
-#   --without-distribution
-#                         Exclude remote distribution
-#   --without-crash-dumps Exclude filesystem crash dump generation
-#   --without-dynamic-loading
-#                         Exclude filesystem-backed driver and NIF loading
 #   --otp-tag <TAG>       OTP git tag to clone (default: OTP-28.3.1)
 #   --source <path>       Use local OTP source instead of cloning
 #   --outdir <dir>        Output directory (default: ./out)
@@ -64,14 +56,6 @@ Build modes (positional):
 
 Options:
   --with-crypto         Include static OpenSSL + crypto/asn1 NIFs
-  --without-zstd        Exclude Zstandard support
-  --without-native-sockets
-                        Exclude the native inet driver
-  --without-distribution
-                        Exclude remote distribution
-  --without-crash-dumps Exclude filesystem crash dump generation
-  --without-dynamic-loading
-                        Exclude filesystem-backed driver and NIF loading
   --otp-tag <TAG>       OTP git tag to clone (default: ${DEFAULT_OTP_TAG})
   --source <path>       Use local OTP source instead of cloning
   --outdir <dir>        Output directory (default: ./out)
@@ -477,11 +461,6 @@ main() {
     local otp_tag="${DEFAULT_OTP_TAG}"
     local outdir=""
     local with_crypto=false
-    local without_zstd=false
-    local without_native_sockets=false
-    local without_distribution=false
-    local without_crash_dumps=false
-    local without_dynamic_loading=false
     local clean=false
     local jobs=""
     local mode=""
@@ -493,26 +472,6 @@ main() {
                 ;;
             --with-crypto)
                 with_crypto=true
-                shift
-                ;;
-            --without-zstd)
-                without_zstd=true
-                shift
-                ;;
-            --without-native-sockets)
-                without_native_sockets=true
-                shift
-                ;;
-            --without-distribution)
-                without_distribution=true
-                shift
-                ;;
-            --without-crash-dumps)
-                without_crash_dumps=true
-                shift
-                ;;
-            --without-dynamic-loading)
-                without_dynamic_loading=true
                 shift
                 ;;
             --otp-tag)
@@ -553,14 +512,6 @@ main() {
         error "Build mode is required. Use: debug, release"
     fi
 
-    if [[ "${mode}" == "release" ]]; then
-        without_zstd=true
-        without_native_sockets=true
-        without_distribution=true
-        without_crash_dumps=true
-        without_dynamic_loading=true
-    fi
-
     # Use single-threaded build in CI to avoid OOM (unless explicitly set)
     if [[ -n "${CI:-}" ]] && [[ -z "${jobs}" ]]; then
         jobs="1"
@@ -585,23 +536,22 @@ main() {
 
     setup_otp_source "${source}" "${otp_tag}"
 
-    local patch_args=()
-    [[ "${without_zstd}" == "true" ]] && patch_args+=(--without-zstd)
-    [[ "${without_native_sockets}" == "true" ]] && patch_args+=(--without-native-sockets)
-    [[ "${without_distribution}" == "true" ]] && patch_args+=(--without-distribution)
-    [[ "${without_crash_dumps}" == "true" ]] && patch_args+=(--without-crash-dumps)
-    [[ "${without_dynamic_loading}" == "true" ]] && patch_args+=(--without-dynamic-loading)
-    patch_otp "${patch_args[@]}"
+    patch_otp \
+        --without-zstd \
+        --without-native-sockets \
+        --without-distribution \
+        --without-crash-dumps \
+        --without-dynamic-loading
 
     run_autoconf "${beam_dir}"
 
     # The native bootstrap emulator embeds erts/preloaded/ebin/*.beam while
     # building preload.c, before bootstrap/bin/erlc has been created.
-    compile_preloaded_modules "${beam_dir}" true "${without_native_sockets}"
+    compile_preloaded_modules "${beam_dir}" true true
 
     build_bootstrap "${beam_dir}" "${jobs}"
 
-    compile_preloaded_modules "${beam_dir}" true "${without_native_sockets}"
+    compile_preloaded_modules "${beam_dir}" true true
 
     local openssl_prefix=""
     if [[ "${with_crypto}" == "true" ]]; then

--- a/scripts/build-beam.sh
+++ b/scripts/build-beam.sh
@@ -16,6 +16,8 @@
 #   --without-distribution
 #                         Exclude remote distribution
 #   --without-crash-dumps Exclude filesystem crash dump generation
+#   --without-dynamic-loading
+#                         Exclude filesystem-backed driver and NIF loading
 #   --otp-tag <TAG>       OTP git tag to clone (default: OTP-28.3.1)
 #   --source <path>       Use local OTP source instead of cloning
 #   --outdir <dir>        Output directory (default: ./out)
@@ -68,6 +70,8 @@ Options:
   --without-distribution
                         Exclude remote distribution
   --without-crash-dumps Exclude filesystem crash dump generation
+  --without-dynamic-loading
+                        Exclude filesystem-backed driver and NIF loading
   --otp-tag <TAG>       OTP git tag to clone (default: ${DEFAULT_OTP_TAG})
   --source <path>       Use local OTP source instead of cloning
   --outdir <dir>        Output directory (default: ./out)
@@ -477,6 +481,7 @@ main() {
     local without_native_sockets=false
     local without_distribution=false
     local without_crash_dumps=false
+    local without_dynamic_loading=false
     local clean=false
     local jobs=""
     local mode=""
@@ -504,6 +509,10 @@ main() {
                 ;;
             --without-crash-dumps)
                 without_crash_dumps=true
+                shift
+                ;;
+            --without-dynamic-loading)
+                without_dynamic_loading=true
                 shift
                 ;;
             --otp-tag)
@@ -549,6 +558,7 @@ main() {
         without_native_sockets=true
         without_distribution=true
         without_crash_dumps=true
+        without_dynamic_loading=true
     fi
 
     # Use single-threaded build in CI to avoid OOM (unless explicitly set)
@@ -580,6 +590,7 @@ main() {
     [[ "${without_native_sockets}" == "true" ]] && patch_args+=(--without-native-sockets)
     [[ "${without_distribution}" == "true" ]] && patch_args+=(--without-distribution)
     [[ "${without_crash_dumps}" == "true" ]] && patch_args+=(--without-crash-dumps)
+    [[ "${without_dynamic_loading}" == "true" ]] && patch_args+=(--without-dynamic-loading)
     patch_otp "${patch_args[@]}"
 
     run_autoconf "${beam_dir}"

--- a/scripts/build-beam.sh
+++ b/scripts/build-beam.sh
@@ -15,6 +15,7 @@
 #                         Exclude the native inet driver
 #   --without-distribution
 #                         Exclude remote distribution
+#   --without-crash-dumps Exclude filesystem crash dump generation
 #   --otp-tag <TAG>       OTP git tag to clone (default: OTP-28.3.1)
 #   --source <path>       Use local OTP source instead of cloning
 #   --outdir <dir>        Output directory (default: ./out)
@@ -66,6 +67,7 @@ Options:
                         Exclude the native inet driver
   --without-distribution
                         Exclude remote distribution
+  --without-crash-dumps Exclude filesystem crash dump generation
   --otp-tag <TAG>       OTP git tag to clone (default: ${DEFAULT_OTP_TAG})
   --source <path>       Use local OTP source instead of cloning
   --outdir <dir>        Output directory (default: ./out)
@@ -474,6 +476,7 @@ main() {
     local without_zstd=false
     local without_native_sockets=false
     local without_distribution=false
+    local without_crash_dumps=false
     local clean=false
     local jobs=""
     local mode=""
@@ -497,6 +500,10 @@ main() {
                 ;;
             --without-distribution)
                 without_distribution=true
+                shift
+                ;;
+            --without-crash-dumps)
+                without_crash_dumps=true
                 shift
                 ;;
             --otp-tag)
@@ -541,6 +548,7 @@ main() {
         without_zstd=true
         without_native_sockets=true
         without_distribution=true
+        without_crash_dumps=true
     fi
 
     # Use single-threaded build in CI to avoid OOM (unless explicitly set)
@@ -571,6 +579,7 @@ main() {
     [[ "${without_zstd}" == "true" ]] && patch_args+=(--without-zstd)
     [[ "${without_native_sockets}" == "true" ]] && patch_args+=(--without-native-sockets)
     [[ "${without_distribution}" == "true" ]] && patch_args+=(--without-distribution)
+    [[ "${without_crash_dumps}" == "true" ]] && patch_args+=(--without-crash-dumps)
     patch_otp "${patch_args[@]}"
 
     run_autoconf "${beam_dir}"

--- a/scripts/build-beam.sh
+++ b/scripts/build-beam.sh
@@ -10,6 +10,7 @@
 #
 # Options:
 #   --with-crypto         Include static OpenSSL + crypto/asn1 NIFs
+#   --without-zstd        Exclude Zstandard support
 #   --otp-tag <TAG>       OTP git tag to clone (default: OTP-28.3.1)
 #   --source <path>       Use local OTP source instead of cloning
 #   --outdir <dir>        Output directory (default: ./out)
@@ -56,6 +57,7 @@ Build modes (positional):
 
 Options:
   --with-crypto         Include static OpenSSL + crypto/asn1 NIFs
+  --without-zstd        Exclude Zstandard support
   --otp-tag <TAG>       OTP git tag to clone (default: ${DEFAULT_OTP_TAG})
   --source <path>       Use local OTP source instead of cloning
   --outdir <dir>        Output directory (default: ./out)
@@ -133,7 +135,7 @@ setup_otp_source() {
 
 patch_otp() {
     log "Patching OTP sources..."
-    run "${PROJECT_ROOT}/scripts/patch-beam.sh"
+    run "${PROJECT_ROOT}/scripts/patch-beam.sh" "$@"
 }
 
 
@@ -453,6 +455,7 @@ main() {
     local otp_tag="${DEFAULT_OTP_TAG}"
     local outdir=""
     local with_crypto=false
+    local without_zstd=false
     local clean=false
     local jobs=""
     local mode=""
@@ -464,6 +467,10 @@ main() {
                 ;;
             --with-crypto)
                 with_crypto=true
+                shift
+                ;;
+            --without-zstd)
+                without_zstd=true
                 shift
                 ;;
             --otp-tag)
@@ -504,6 +511,10 @@ main() {
         error "Build mode is required. Use: debug, release"
     fi
 
+    if [[ "${mode}" == "release" ]]; then
+        without_zstd=true
+    fi
+
     # Use single-threaded build in CI to avoid OOM (unless explicitly set)
     if [[ -n "${CI:-}" ]] && [[ -z "${jobs}" ]]; then
         jobs="1"
@@ -528,7 +539,9 @@ main() {
 
     setup_otp_source "${source}" "${otp_tag}"
 
-    patch_otp
+    local patch_args=()
+    [[ "${without_zstd}" == "true" ]] && patch_args+=(--without-zstd)
+    patch_otp "${patch_args[@]}"
 
     run_autoconf "${beam_dir}"
 

--- a/scripts/patch-beam.sh
+++ b/scripts/patch-beam.sh
@@ -11,6 +11,7 @@
 # Options:
 #   --without-zstd
 #   --without-native-sockets
+#   --without-distribution
 #   -h, --help    Show this help
 #
 # Requires otp/sources/otp to exist (created by build-beam.sh).
@@ -100,6 +101,7 @@ apply_patches() {
     local -a patches=("${PATCHES_DIR}/0001-emscripten-support.patch")
     [[ "${WITHOUT_ZSTD}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0001-without-zstd.patch")
     [[ "${WITHOUT_NATIVE_SOCKETS}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0002-without-native-sockets.patch")
+    [[ "${WITHOUT_DISTRIBUTION}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0003-without-distribution.patch")
 
     local patches_list
     patches_list=$(printf '%s\n' "${patches[@]}")
@@ -190,6 +192,7 @@ main() {
     local regen=false
     WITHOUT_ZSTD=false
     WITHOUT_NATIVE_SOCKETS=false
+    WITHOUT_DISTRIBUTION=false
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -206,6 +209,10 @@ main() {
                 ;;
             --without-native-sockets)
                 WITHOUT_NATIVE_SOCKETS=true
+                shift
+                ;;
+            --without-distribution)
+                WITHOUT_DISTRIBUTION=true
                 shift
                 ;;
             *)

--- a/scripts/patch-beam.sh
+++ b/scripts/patch-beam.sh
@@ -13,6 +13,7 @@
 #   --without-native-sockets
 #   --without-distribution
 #   --without-crash-dumps
+#   --without-dynamic-loading
 #   -h, --help    Show this help
 #
 # Requires otp/sources/otp to exist (created by build-beam.sh).
@@ -104,6 +105,7 @@ apply_patches() {
     [[ "${WITHOUT_NATIVE_SOCKETS}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0002-without-native-sockets.patch")
     [[ "${WITHOUT_DISTRIBUTION}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0003-without-distribution.patch")
     [[ "${WITHOUT_CRASH_DUMPS}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0004-without-crash-dumps.patch")
+    [[ "${WITHOUT_DYNAMIC_LOADING}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0005-without-dynamic-loading.patch")
 
     local patches_list
     patches_list=$(printf '%s\n' "${patches[@]}")
@@ -196,6 +198,7 @@ main() {
     WITHOUT_NATIVE_SOCKETS=false
     WITHOUT_DISTRIBUTION=false
     WITHOUT_CRASH_DUMPS=false
+    WITHOUT_DYNAMIC_LOADING=false
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -220,6 +223,10 @@ main() {
                 ;;
             --without-crash-dumps)
                 WITHOUT_CRASH_DUMPS=true
+                shift
+                ;;
+            --without-dynamic-loading)
+                WITHOUT_DYNAMIC_LOADING=true
                 shift
                 ;;
             *)

--- a/scripts/patch-beam.sh
+++ b/scripts/patch-beam.sh
@@ -12,6 +12,7 @@
 #   --without-zstd
 #   --without-native-sockets
 #   --without-distribution
+#   --without-crash-dumps
 #   -h, --help    Show this help
 #
 # Requires otp/sources/otp to exist (created by build-beam.sh).
@@ -102,6 +103,7 @@ apply_patches() {
     [[ "${WITHOUT_ZSTD}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0001-without-zstd.patch")
     [[ "${WITHOUT_NATIVE_SOCKETS}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0002-without-native-sockets.patch")
     [[ "${WITHOUT_DISTRIBUTION}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0003-without-distribution.patch")
+    [[ "${WITHOUT_CRASH_DUMPS}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0004-without-crash-dumps.patch")
 
     local patches_list
     patches_list=$(printf '%s\n' "${patches[@]}")
@@ -193,6 +195,7 @@ main() {
     WITHOUT_ZSTD=false
     WITHOUT_NATIVE_SOCKETS=false
     WITHOUT_DISTRIBUTION=false
+    WITHOUT_CRASH_DUMPS=false
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -213,6 +216,10 @@ main() {
                 ;;
             --without-distribution)
                 WITHOUT_DISTRIBUTION=true
+                shift
+                ;;
+            --without-crash-dumps)
+                WITHOUT_CRASH_DUMPS=true
                 shift
                 ;;
             *)

--- a/scripts/patch-beam.sh
+++ b/scripts/patch-beam.sh
@@ -10,6 +10,7 @@
 #
 # Options:
 #   --without-zstd
+#   --without-native-sockets
 #   -h, --help    Show this help
 #
 # Requires otp/sources/otp to exist (created by build-beam.sh).
@@ -98,6 +99,7 @@ apply_patches() {
 
     local -a patches=("${PATCHES_DIR}/0001-emscripten-support.patch")
     [[ "${WITHOUT_ZSTD}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0001-without-zstd.patch")
+    [[ "${WITHOUT_NATIVE_SOCKETS}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0002-without-native-sockets.patch")
 
     local patches_list
     patches_list=$(printf '%s\n' "${patches[@]}")
@@ -187,6 +189,7 @@ regen_patches() {
 main() {
     local regen=false
     WITHOUT_ZSTD=false
+    WITHOUT_NATIVE_SOCKETS=false
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -199,6 +202,10 @@ main() {
                 ;;
             --without-zstd)
                 WITHOUT_ZSTD=true
+                shift
+                ;;
+            --without-native-sockets)
+                WITHOUT_NATIVE_SOCKETS=true
                 shift
                 ;;
             *)

--- a/scripts/patch-beam.sh
+++ b/scripts/patch-beam.sh
@@ -9,6 +9,7 @@
 #   --regen       Regenerate patches from current otp/sources/otp state
 #
 # Options:
+#   --without-zstd
 #   -h, --help    Show this help
 #
 # Requires otp/sources/otp to exist (created by build-beam.sh).
@@ -41,6 +42,7 @@ Options:
 Apply mode:
   Expects otp/sources/otp-original to exist (cloned OTP).
   Copies otp-original to otp/ if not present, then applies patches.
+  Stripped patches are applied only when their --without-* option is present.
 
 Regen mode:
   Expects otp/sources/otp to exist with local modifications.
@@ -94,11 +96,11 @@ apply_patches() {
         error "otp/patches/ not found. No patches to apply."
     fi
 
-    local patches
-    patches=$(find "${PATCHES_DIR}" -name "*.patch" -type f | sort)
-    if [[ -z "${patches}" ]]; then
-        error "No .patch files found in otp/patches/."
-    fi
+    local -a patches=("${PATCHES_DIR}/0001-emscripten-support.patch")
+    [[ "${WITHOUT_ZSTD}" == "true" ]] && patches+=("${PATCHES_DIR}/stripped/0001-without-zstd.patch")
+
+    local patches_list
+    patches_list=$(printf '%s\n' "${patches[@]}")
 
     # Copy otp-original to otp if not present
     if [[ ! -d "${OTP_DIR}" ]]; then
@@ -111,7 +113,7 @@ apply_patches() {
     # otherwise an edited patch is silently ignored and the built VM keeps
     # running the previous protocol.
     local patches_hash
-    patches_hash=$(echo "${patches}" | xargs cat | git hash-object --stdin)
+    patches_hash=$(cat "${patches[@]}" | git hash-object --stdin)
 
     if [[ -f "${STAMP_FILE}" ]] && [[ "$(cat "${STAMP_FILE}")" == "${patches_hash}" ]]; then
         log "Patches already applied and up to date, skipping."
@@ -141,7 +143,7 @@ apply_patches() {
         patch_name=$(basename "${patch}")
         log "  Applying ${patch_name}..."
         (cd "${OTP_DIR}" && git apply "${patch}")
-    done <<< "${patches}"
+    done <<< "${patches_list}"
 
     echo "${patches_hash}" > "${STAMP_FILE}"
     success "Patches applied."
@@ -184,6 +186,7 @@ regen_patches() {
 
 main() {
     local regen=false
+    WITHOUT_ZSTD=false
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -192,6 +195,10 @@ main() {
                 ;;
             --regen)
                 regen=true
+                shift
+                ;;
+            --without-zstd)
+                WITHOUT_ZSTD=true
                 shift
                 ;;
             *)


### PR DESCRIPTION
This PR, along with #692 and #691 improves the .wasm binary size and shipped tarballs size. We drop the things that aren't supported in browser version anyway. Final binary sizes dropped from ~1M to 750K.

| Runtime cut | Raw | gzip-9 | Brotli-11 | Δ Brotli-11 |
|---|---:|---:|---:|---:|
| Zstandard | 3 000K → 2 650K | 1 120K → 1 010K | 865K → 785K | -80K; -10% |
| Native sockets | 3 000K → 2 900K | 1 120K → 1 090K | 865K → 840K | -25K; -3% |
| Distribution | 3 010K → 2 980K | 1 115K → 1 100K | 880K → 870K | -10K; -1% |
| Crash dumps | 3 010K → 2 980K | 1 115K → 1 105K | 880K → 875K | -8K; -1% |
| Dynamic loading | 3 010K → 3 007K | 1 113K → 1 112K | 881K → 879K | -1,5K; -0,2% |

<details>
<summary>Accurate measurements</summary>

| Runtime cut | Raw | gzip-9 | Brotli-11 | Δ Brotli-11 |
|---|---:|---:|---:|---:|
| Zstandard | 2 987,1K → 2 643,6K | 1 117,8K → 1 006,2K | 864,8K → 785,0K | -79,8K; -9,2% |
| Native sockets | 2 987,1K → 2 897,7K | 1 117,8K → 1 085,8K | 864,8K → 839,8K | -25,0K; -2,9% |
| Distribution | 3 010,3K → 2 976,3K | 1 113,1K → 1 098,8K | 880,8K → 870,1K | -10,7K; -1,2% |
| Crash dumps | 3 012,9K → 2 977,8K | 1 113,5K → 1 102,7K | 881,1K → 873,0K | -8,1K; -0,9% |
| Dynamic loading | 3 010,3K → 3 006,7K | 1 113,1K → 1 111,7K | 880,8K → 879,4K | -1,5K; -0,2% |

</details>