### PR TITLE
[LLV] Figure out how to assign IDs to LLVs

### DIFF
--- a/examples/local-lv-burrito/lib/burrito/application.ex
+++ b/examples/local-lv-burrito/lib/burrito/application.ex
@@ -9,7 +9,6 @@ defmodule Burrito.Application do
       BurritoWeb.Telemetry,
       {DNSCluster, query: Application.get_env(:burrito, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Burrito.PubSub},
-      {Registry, keys: :unique, name: LocalLiveView.ChannelRegistry},
       BurritoWeb.Endpoint
     ]
 

--- a/examples/local-lv-burrito/lib/burrito_web/live/order_live.ex
+++ b/examples/local-lv-burrito/lib/burrito_web/live/order_live.ex
@@ -4,7 +4,7 @@ defmodule BurritoWeb.OrderLive do
   import BurritoWeb.InfoModal
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, llv_id: "burrito-live-#{socket.id}")}
+    {:ok, socket}
   end
 
   def render(assigns) do
@@ -108,7 +108,7 @@ defmodule BurritoWeb.OrderLive do
               </div>
               <span class="text-xs text-pop-orange-dark/60 font-medium">Loading Local LiveView…</span>
             </div>
-            <.local_live_view id={@llv_id} view="BurritoLive" />
+            <.local_live_view view="BurritoLive" />
           </div>
         </div>
       </div>
@@ -136,7 +136,7 @@ defmodule BurritoWeb.OrderLive do
             {live_render(@socket, BurritoWeb.Live.SyncTableLive,
               id: "sync-table",
               sticky: true,
-              session: %{"llv_id" => @llv_id}
+              session: %{"llv_rendering_socket_id" => @socket.id}
             )}
           </div>
         </div>

--- a/examples/local-lv-burrito/lib/burrito_web/live/order_live.ex
+++ b/examples/local-lv-burrito/lib/burrito_web/live/order_live.ex
@@ -108,7 +108,7 @@ defmodule BurritoWeb.OrderLive do
               </div>
               <span class="text-xs text-pop-orange-dark/60 font-medium">Loading Local LiveView…</span>
             </div>
-            <.local_live_view id={@llv_id} view="BurritoLive" endpoint={@socket.endpoint} />
+            <.local_live_view id={@llv_id} view="BurritoLive" />
           </div>
         </div>
       </div>
@@ -133,7 +133,11 @@ defmodule BurritoWeb.OrderLive do
         </button>
         <div id="sync-panel-content" class="collapsible-grid open">
           <div>
-            <%= live_render @socket, BurritoWeb.Live.SyncTableLive, id: "sync-table", sticky: true, session: %{"llv_id" => @llv_id} %>
+            {live_render(@socket, BurritoWeb.Live.SyncTableLive,
+              id: "sync-table",
+              sticky: true,
+              session: %{"llv_id" => @llv_id}
+            )}
           </div>
         </div>
       </div>

--- a/examples/local-lv-burrito/lib/burrito_web/live/sync_table_live.ex
+++ b/examples/local-lv-burrito/lib/burrito_web/live/sync_table_live.ex
@@ -16,12 +16,20 @@ defmodule BurritoWeb.Live.SyncTableLive do
     "guacamole" => 2.50
   }
 
-  def mount(_params, %{"llv_id" => llv_id}, socket) do
-    if connected?(socket) do
-      Phoenix.PubSub.subscribe(Burrito.PubSub, "llv_mirror:BurritoLive:#{llv_id}")
-    end
+  def mount(_params, %{"llv_rendering_socket_id" => llv_rendering_socket_id}, socket) do
+    attrs =
+      case connected?(socket) do
+        true ->
+          mirror_id =
+            LocalLiveView.Component.mirror_id(llv_rendering_socket_id, "llv-BurritoLive")
 
-    attrs = if connected?(socket), do: LocalLiveView.Channel.get_mirror_assigns(llv_id), else: %{}
+          Phoenix.PubSub.subscribe(Burrito.PubSub, "llv_mirror:BurritoLive:#{mirror_id}")
+          LocalLiveView.Channel.get_mirror_assigns(mirror_id)
+
+        false ->
+          %{}
+      end
+
     {:ok, apply_attrs(socket, attrs)}
   end
 

--- a/examples/local-lv-burrito/lib/burrito_web/live/sync_table_live.ex
+++ b/examples/local-lv-burrito/lib/burrito_web/live/sync_table_live.ex
@@ -18,16 +18,14 @@ defmodule BurritoWeb.Live.SyncTableLive do
 
   def mount(_params, %{"llv_rendering_socket_id" => llv_rendering_socket_id}, socket) do
     attrs =
-      case connected?(socket) do
-        true ->
-          mirror_id =
-            LocalLiveView.Component.mirror_id(llv_rendering_socket_id, "llv-BurritoLive")
+      if connected?(socket) do
+        mirror_id =
+          LocalLiveView.Component.mirror_id(llv_rendering_socket_id, "llv-BurritoLive")
 
-          Phoenix.PubSub.subscribe(Burrito.PubSub, "llv_mirror:BurritoLive:#{mirror_id}")
-          LocalLiveView.Channel.get_mirror_assigns(mirror_id)
-
-        false ->
-          %{}
+        Phoenix.PubSub.subscribe(Burrito.PubSub, "llv_mirror:BurritoLive:#{mirror_id}")
+        LocalLiveView.Channel.get_mirror_assigns(mirror_id)
+      else
+        %{}
       end
 
     {:ok, apply_attrs(socket, attrs)}

--- a/examples/local-lv-burrito/lib/mirror/burrito_live.ex
+++ b/examples/local-lv-burrito/lib/mirror/burrito_live.ex
@@ -2,10 +2,10 @@ defmodule Mirror.BurritoLive do
   use LocalLiveView.Mirror
 
   @impl true
-  def handle_sync(local_assigns, _mirror_assigns, %{llv_id: llv_id}) do
+  def handle_sync(local_assigns, _mirror_assigns, %{mirror_id: mirror_id}) do
     Phoenix.PubSub.broadcast(
       Burrito.PubSub,
-      "llv_mirror:BurritoLive:#{llv_id}",
+      "llv_mirror:BurritoLive:#{mirror_id}",
       {:llv_attrs, local_assigns}
     )
 

--- a/examples/local-lv-checkout/lib/local_lv_checkout_web/live/checkout_form_component.ex
+++ b/examples/local-lv-checkout/lib/local_lv_checkout_web/live/checkout_form_component.ex
@@ -4,7 +4,7 @@ defmodule LocalLvCheckoutWeb.Live.CheckoutFormComponent do
   def render(assigns) do
     ~H"""
     <div>
-      <.local_live_view id={@llv_id} view="CheckoutLive" />
+      <.local_live_view view="CheckoutLive" />
     </div>
     """
   end

--- a/examples/local-lv-checkout/lib/local_lv_checkout_web/live/checkout_live.ex
+++ b/examples/local-lv-checkout/lib/local_lv_checkout_web/live/checkout_live.ex
@@ -4,8 +4,6 @@ defmodule LocalLvCheckoutWeb.CheckoutLive do
   def mount(_params, _session, socket) do
     {:ok,
      assign(socket,
-       llv_id: "checkout-#{socket.id}",
-       nav_llv_id: "nav-#{socket.id}",
        current_step: 1
      )}
   end

--- a/examples/local-lv-forms/lib/form_demo_web/live/form_demo_live.ex
+++ b/examples/local-lv-forms/lib/form_demo_web/live/form_demo_live.ex
@@ -4,7 +4,7 @@ defmodule FormDemoWeb.FormDemoLive do
   def render(assigns) do
     ~H"""
     <div class="centered-div">
-      <.local_live_view id={"form-demo-local-#{@socket.id}"} view="FormDemoLocal" endpoint={@socket.endpoint} />
+      <.local_live_view view="FormDemoLocal" endpoint={@socket.endpoint} />
       <div class="bordered">
         <h1>[Server Runtime] User List:</h1>
         <ul>
@@ -19,9 +19,9 @@ defmodule FormDemoWeb.FormDemoLive do
 
   def mount(_params, _session, socket) do
     if connected?(socket) do
-      llv_id = "form-demo-local-#{socket.id}"
-      Phoenix.PubSub.subscribe(FormDemo.PubSub, "llv_mirror:FormDemoLocal:#{llv_id}")
-      users = LocalLiveView.Channel.get_mirror_assigns(llv_id) |> Map.get("users", [])
+      mirror_id = LocalLiveView.Component.mirror_id(socket, "FormDemoLocal")
+      Phoenix.PubSub.subscribe(FormDemo.PubSub, "llv_mirror:FormDemoLocal:#{mirror_id}")
+      users = LocalLiveView.Channel.get_mirror_assigns(mirror_id) |> Map.get("users", [])
       {:ok, assign(socket, users: users)}
     else
       {:ok, assign(socket, users: [])}

--- a/examples/local-lv-forms/lib/form_demo_web/live/form_demo_live.ex
+++ b/examples/local-lv-forms/lib/form_demo_web/live/form_demo_live.ex
@@ -19,7 +19,7 @@ defmodule FormDemoWeb.FormDemoLive do
 
   def mount(_params, _session, socket) do
     if connected?(socket) do
-      mirror_id = LocalLiveView.Component.mirror_id(socket, "FormDemoLocal")
+      mirror_id = LocalLiveView.Component.mirror_id(socket, "llv-FormDemoLocal")
       Phoenix.PubSub.subscribe(FormDemo.PubSub, "llv_mirror:FormDemoLocal:#{mirror_id}")
       users = LocalLiveView.Channel.get_mirror_assigns(mirror_id) |> Map.get("users", [])
       {:ok, assign(socket, users: users)}

--- a/examples/local-lv-forms/lib/form_demo_web/live/form_demo_live.ex
+++ b/examples/local-lv-forms/lib/form_demo_web/live/form_demo_live.ex
@@ -4,7 +4,7 @@ defmodule FormDemoWeb.FormDemoLive do
   def render(assigns) do
     ~H"""
     <div class="centered-div">
-      <.local_live_view view="FormDemoLocal" endpoint={@socket.endpoint} />
+      <.local_live_view view="FormDemoLocal" />
       <div class="bordered">
         <h1>[Server Runtime] User List:</h1>
         <ul>

--- a/examples/local-lv-forms/lib/mirror/form_demo_local.ex
+++ b/examples/local-lv-forms/lib/mirror/form_demo_local.ex
@@ -2,10 +2,10 @@ defmodule Mirror.FormDemoLocal do
   use LocalLiveView.Mirror
 
   @impl true
-  def handle_sync(%{"users" => _} = local_assigns, _mirror_assigns, %{llv_id: llv_id}) do
+  def handle_sync(%{"users" => _} = local_assigns, _mirror_assigns, %{mirror_id: mirror_id}) do
     Phoenix.PubSub.broadcast(
       FormDemo.PubSub,
-      "llv_mirror:FormDemoLocal:#{llv_id}",
+      "llv_mirror:FormDemoLocal:#{mirror_id}",
       {:llv_attrs, local_assigns}
     )
 

--- a/examples/local-lv-forms/test/form_demo_web/live/form_demo_sync_test.exs
+++ b/examples/local-lv-forms/test/form_demo_web/live/form_demo_sync_test.exs
@@ -18,15 +18,15 @@ defmodule FormDemoWeb.FormDemoSyncTest do
 
   describe "Mirror.FormDemoLocal.handle_sync/3" do
     test "broadcasts the synced assigns on the LLV mirror topic and echoes them back" do
-      llv_id = "form-demo-local-test-#{System.unique_integer([:positive])}"
-      Phoenix.PubSub.subscribe(FormDemo.PubSub, "llv_mirror:FormDemoLocal:#{llv_id}")
+      mirror_id = "form-demo-local-test-#{System.unique_integer([:positive])}"
+      Phoenix.PubSub.subscribe(FormDemo.PubSub, "llv_mirror:FormDemoLocal:#{mirror_id}")
 
       users = [%{"username" => "bob", "email" => "bob@example.com"}]
       local_assigns = %{"users" => users}
 
       # Return value becomes the mirror's stored assigns (conflict-resolution point).
       assert {:ok, ^local_assigns} =
-               Mirror.FormDemoLocal.handle_sync(local_assigns, %{}, %{llv_id: llv_id})
+               Mirror.FormDemoLocal.handle_sync(local_assigns, %{}, %{mirror_id: mirror_id})
 
       # Exactly the payload the online LiveView listens for.
       assert_receive {:llv_attrs, %{"users" => ^users}}
@@ -43,22 +43,22 @@ defmodule FormDemoWeb.FormDemoSyncTest do
 
     test "renders users synced through the mirror", %{conn: conn} do
       {:ok, view, html} = live_isolated(conn, FormDemoWeb.FormDemoLive)
-      llv_id = llv_id_from_html(html)
+      mirror_id = mirror_id_from_html(html)
 
       user = %{"username" => "alice", "email" => "alice@example.com"}
 
       # Drive the exact path a browser save triggers: the mirror broadcasts to the
       # topic this LiveView subscribed to on mount.
       assert {:ok, _} =
-               Mirror.FormDemoLocal.handle_sync(%{"users" => [user]}, %{}, %{llv_id: llv_id})
+               Mirror.FormDemoLocal.handle_sync(%{"users" => [user]}, %{}, %{mirror_id: mirror_id})
 
       assert render(view) =~ "Username: alice, Email: alice@example.com"
     end
   end
 
   # The mount-point id encodes the LiveView's socket id; the mirror topic is keyed on it.
-  defp llv_id_from_html(html) do
-    [_, llv_id] = Regex.run(~r/id="(form-demo-local-[^"]+)"/, html)
-    llv_id
+  defp mirror_id_from_html(html) do
+    [_, mirror_id] = Regex.run(~r/pop-mirror-id="([^"]+)"/, html)
+    mirror_id
   end
 end

--- a/local-live-view/assets/local_live_view/index.ts
+++ b/local-live-view/assets/local_live_view/index.ts
@@ -29,6 +29,7 @@ interface CreateArgs {
   url: string;
   urlParams: Record<string, string>;
   assigns: string;
+  mirrorId: string | undefined;
 }
 
 class PopcornClient {
@@ -58,7 +59,7 @@ class PopcornClient {
     );
   }
 
-  create({ id, view, url, urlParams, assigns }: CreateArgs): Promise<CallResult> {
+  create({ id, view, url, urlParams, assigns, mirrorId }: CreateArgs): Promise<CallResult> {
     return this.call({
       action: "create",
       id,
@@ -66,6 +67,7 @@ class PopcornClient {
       url,
       url_params: urlParams,
       assigns,
+      mirror_id: mirrorId,
     });
   }
 
@@ -75,14 +77,6 @@ class PopcornClient {
 
   reconnected(id: string): void {
     this.fire("reconnect sync", { action: "reconnected", id, payload: {} });
-  }
-
-  connectMirror(id: string, mirror_id: string): void {
-    this.fire("connect mirror", {
-      action: "connect_mirror",
-      id,
-      payload: { mirror_id: mirror_id },
-    });
   }
 
   updateAssigns(id: string, assigns: string): void {
@@ -190,6 +184,8 @@ export class LLVEngine {
   // Start a view and wire it up.
   private async mountView(pop_view_el: HTMLElement): Promise<void> {
     const llvId = pop_view_el.id;
+    const mirrorId = pop_view_el.dataset.popMirrorId;
+    this.maybeSetupMirrorChannel(pop_view_el);
     if (this.views.has(llvId)) return;
     const result = await this.pop.create({
       id: llvId,
@@ -197,6 +193,7 @@ export class LLVEngine {
       url: window.location.href,
       urlParams: Object.fromEntries(new URLSearchParams(window.location.search)),
       assigns: pop_view_el.getAttribute("data-pop-assigns")!,
+      mirrorId: mirrorId
     });
     // A rejected call resolves with ok: false (it does not throw). Bail on
     // failed or duplicate creates — wiring a fake view without a live
@@ -207,7 +204,6 @@ export class LLVEngine {
     }
     const liveEl = document.getElementById(llvId);
     if (liveEl?.matches("[data-pop-view]")) {
-      this.maybeSetupMirrorChannel(liveEl);
       setupFakeView(this.socket, this.views, this.popcornLink.socket, liveEl);
     } else {
       this.pop.destroy(llvId);
@@ -322,14 +318,15 @@ export class LLVEngine {
   private maybeSetupMirrorChannel(el: HTMLElement): void {
     const mirrorId = el.dataset.popMirrorId;
     if (!mirrorId || (mirrorId && this.channels[mirrorId])) return;
+    if (!el.dataset.popMirrorToken) return;
     const llvId = el.id;
+    console.log(el)
     const channel = this.llvMirrorSocket.channel(`llv:${mirrorId}`, {
       view: el.dataset.popView,
       token: el.dataset.popMirrorToken,
     });
     if (typeof mirrorId === "string") {
       this.channels[mirrorId] = channel;
-      this.pop.connectMirror(llvId, mirrorId);
     }
     channel
       .join()

--- a/local-live-view/assets/local_live_view/index.ts
+++ b/local-live-view/assets/local_live_view/index.ts
@@ -159,13 +159,13 @@ export class LLVEngine {
     // registerServerMessageListener / registerHooks comments).
     engine.registerServerMessageListener();
     registerNavigationHandlers(engine.socket, engine.views, engine.pop, engine.config);
+    engine.registerHooks();
     engine.bindFormsIfHostless();
     engine.connectPopcornSocket();
 
     await engine.bootPopcorn();
 
     engine.setupMirrorSync();
-    engine.registerHooks();
     engine.exposeGlobals();
     engine.patchOwner();
     registerCustomEventBindings(engine.socket);

--- a/local-live-view/assets/local_live_view/index.ts
+++ b/local-live-view/assets/local_live_view/index.ts
@@ -159,13 +159,13 @@ export class LLVEngine {
     // registerServerMessageListener / registerHooks comments).
     engine.registerServerMessageListener();
     registerNavigationHandlers(engine.socket, engine.views, engine.pop, engine.config);
-    engine.registerHooks();
     engine.bindFormsIfHostless();
     engine.connectPopcornSocket();
 
     await engine.bootPopcorn();
 
     engine.setupMirrorSync();
+    engine.registerHooks();
     engine.exposeGlobals();
     engine.patchOwner();
     registerCustomEventBindings(engine.socket);
@@ -249,9 +249,11 @@ export class LLVEngine {
     const maybeSetupMirrorChannel = (el: HTMLElement) => this.maybeSetupMirrorChannel(el);
     this.socket.hooks.LocalLiveView = {
       mounted() {
-        maybeSetupMirrorChannel(this.el);
         this.llvLastAssigns = this.el.getAttribute("data-pop-assigns")!;
-        if (pop.ready) mountView(this.el);
+        if (pop.ready) {
+          maybeSetupMirrorChannel(this.el);
+          mountView(this.el);
+        }
       },
       updated() {
         maybeSetupMirrorChannel(this.el);

--- a/local-live-view/assets/local_live_view/index.ts
+++ b/local-live-view/assets/local_live_view/index.ts
@@ -325,9 +325,7 @@ export class LLVEngine {
       view: popView,
       token: popMirrorToken,
     });
-    if (typeof mirrorId === "string") {
-      this.channels[mirrorId] = channel;
-    }
+    this.channels[mirrorId] = channel;
     channel
       .join()
       .receive("ok", () => {

--- a/local-live-view/assets/local_live_view/index.ts
+++ b/local-live-view/assets/local_live_view/index.ts
@@ -77,6 +77,14 @@ class PopcornClient {
     this.fire("reconnect sync", { action: "reconnected", id, payload: {} });
   }
 
+  connectMirror(id: string, mirror_id: string): void {
+    this.fire("connect mirror", {
+      action: "connect_mirror",
+      id,
+      payload: { mirror_id: mirror_id },
+    });
+  }
+
   updateAssigns(id: string, assigns: string): void {
     this.fire("update assigns", { action: "update_assigns", id, assigns });
   }
@@ -119,10 +127,20 @@ export class LLVEngine {
   // by __llvPushServer.
   private eventBusHooks = new Map<string, EventBusHook>();
   private popcornLink!: PopcornLink;
+  private llvMirrorSocket: PhoenixSocket;
 
   private constructor(socket: LLVSocket, config: LLVConfig) {
     this.socket = socket;
     this.config = config;
+
+    const Socket = this.socketClass();
+    const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
+
+    const llvSocket = new Socket("/llv_socket", {
+      params: { _csrf_token: csrfToken },
+    });
+    llvSocket.connect();
+    this.llvMirrorSocket = llvSocket;
   }
 
   /**
@@ -147,7 +165,7 @@ export class LLVEngine {
 
     await engine.bootPopcorn();
 
-    engine.setupMirrorChannels();
+    engine.setupMirrorSync();
     engine.exposeGlobals();
     engine.patchOwner();
     registerCustomEventBindings(engine.socket);
@@ -228,12 +246,15 @@ export class LLVEngine {
     const pop = this.pop;
     const mountView = (el: HTMLElement) => this.mountView(el);
     const unmountView = (el: HTMLElement) => this.unmountView(el);
+    const maybeSetupMirrorChannel = (el: HTMLElement) => this.maybeSetupMirrorChannel(el);
     this.socket.hooks.LocalLiveView = {
       mounted() {
+        maybeSetupMirrorChannel(this.el);
         this.llvLastAssigns = this.el.getAttribute("data-pop-assigns")!;
         if (pop.ready) mountView(this.el);
       },
       updated() {
+        maybeSetupMirrorChannel(this.el);
         const assigns = this.el.getAttribute("data-pop-assigns")!;
         if (assigns === this.llvLastAssigns) return;
         this.llvLastAssigns = assigns;
@@ -289,44 +310,35 @@ export class LLVEngine {
   }
 
   // Mirror channels: only created for views with a server-side Mirror module.
-  private setupMirrorChannels(): void {
-    const mirrorEls = document.querySelectorAll<HTMLElement>(
-      "[data-pop-view][data-pop-mirror-token]",
-    );
-    if (mirrorEls.length === 0) return;
-
-    const Socket = this.socketClass();
-    const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
-
-    const llvSocket = new Socket("/llv_socket", {
-      params: { _csrf_token: csrfToken },
-    });
-    llvSocket.connect();
-
-    mirrorEls.forEach((el) => {
-      const llvId = el.id;
-      const channel = llvSocket.channel(`llv:${llvId}`, {
-        view: el.dataset.popView,
-        token: el.dataset.popMirrorToken,
-      });
-      this.channels[llvId] = channel;
-
-      channel
-        .join()
-        .receive("ok", () => {
-          if (this.views.has(llvId)) {
-            this.pop.reconnected(llvId);
-          }
-        })
-        .receive("error", (err: unknown) => console.error("LLV channel join error", err));
-    });
-
-    window.__llvSync = (id: string, eventName: string, payload: Record<string, unknown>) => {
-      const channel = this.channels[id];
+  private setupMirrorSync(): void {
+    window.__llvSync = (mirror_id: string, eventName: string, payload: Record<string, unknown>) => {
+      const channel = this.channels[mirror_id];
       if (channel) {
         channel.push(eventName, payload);
       }
     };
+  }
+
+  private maybeSetupMirrorChannel(el: HTMLElement): void {
+    const mirrorId = el.dataset.popMirrorId;
+    if (!mirrorId || (mirrorId && this.channels[mirrorId])) return;
+    const llvId = el.id;
+    const channel = this.llvMirrorSocket.channel(`llv:${mirrorId}`, {
+      view: el.dataset.popView,
+      token: el.dataset.popMirrorToken,
+    });
+    if (typeof mirrorId === "string") {
+      this.channels[mirrorId] = channel;
+      this.pop.connectMirror(llvId, mirrorId);
+    }
+    channel
+      .join()
+      .receive("ok", () => {
+        if (this.views.has(llvId)) {
+          this.pop.reconnected(llvId);
+        }
+      })
+      .receive("error", (err: unknown) => console.error("LLV channel join error", err));
   }
 
   private exposeGlobals(): void {

--- a/local-live-view/assets/local_live_view/index.ts
+++ b/local-live-view/assets/local_live_view/index.ts
@@ -207,6 +207,7 @@ export class LLVEngine {
     }
     const liveEl = document.getElementById(llvId);
     if (liveEl?.matches("[data-pop-view]")) {
+      this.maybeSetupMirrorChannel(liveEl);
       setupFakeView(this.socket, this.views, this.popcornLink.socket, liveEl);
     } else {
       this.pop.destroy(llvId);
@@ -250,10 +251,7 @@ export class LLVEngine {
     this.socket.hooks.LocalLiveView = {
       mounted() {
         this.llvLastAssigns = this.el.getAttribute("data-pop-assigns")!;
-        if (pop.ready) {
-          maybeSetupMirrorChannel(this.el);
-          mountView(this.el);
-        }
+        if (pop.ready) mountView(this.el);
       },
       updated() {
         maybeSetupMirrorChannel(this.el);

--- a/local-live-view/assets/local_live_view/index.ts
+++ b/local-live-view/assets/local_live_view/index.ts
@@ -193,7 +193,7 @@ export class LLVEngine {
       url: window.location.href,
       urlParams: Object.fromEntries(new URLSearchParams(window.location.search)),
       assigns: pop_view_el.getAttribute("data-pop-assigns")!,
-      mirrorId: mirrorId
+      mirrorId: mirrorId,
     });
     // A rejected call resolves with ok: false (it does not throw). Bail on
     // failed or duplicate creates — wiring a fake view without a live
@@ -320,7 +320,6 @@ export class LLVEngine {
     if (!mirrorId || (mirrorId && this.channels[mirrorId])) return;
     if (!el.dataset.popMirrorToken) return;
     const llvId = el.id;
-    console.log(el)
     const channel = this.llvMirrorSocket.channel(`llv:${mirrorId}`, {
       view: el.dataset.popView,
       token: el.dataset.popMirrorToken,

--- a/local-live-view/assets/local_live_view/index.ts
+++ b/local-live-view/assets/local_live_view/index.ts
@@ -32,6 +32,13 @@ interface CreateArgs {
   mirrorId: string | undefined;
 }
 
+interface MirrorChannelOptions {
+  mirrorId?: string;
+  llvId: string;
+  popView?: string;
+  popMirrorToken?: string;
+}
+
 class PopcornClient {
   private popcorn: Popcorn | null = null;
 
@@ -121,20 +128,11 @@ export class LLVEngine {
   // by __llvPushServer.
   private eventBusHooks = new Map<string, EventBusHook>();
   private popcornLink!: PopcornLink;
-  private llvMirrorSocket: PhoenixSocket;
+  private llvMirrorSocket: PhoenixSocket | undefined = undefined;
 
   private constructor(socket: LLVSocket, config: LLVConfig) {
     this.socket = socket;
     this.config = config;
-
-    const Socket = this.socketClass();
-    const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
-
-    const llvSocket = new Socket("/llv_socket", {
-      params: { _csrf_token: csrfToken },
-    });
-    llvSocket.connect();
-    this.llvMirrorSocket = llvSocket;
   }
 
   /**
@@ -185,7 +183,9 @@ export class LLVEngine {
   private async mountView(pop_view_el: HTMLElement): Promise<void> {
     const llvId = pop_view_el.id;
     const mirrorId = pop_view_el.dataset.popMirrorId;
-    this.maybeSetupMirrorChannel(pop_view_el);
+    const popView = pop_view_el.dataset.popView;
+    const popMirrorToken = pop_view_el.dataset.popMirrorToken;
+    this.maybeSetupMirrorChannel({mirrorId, llvId, popView, popMirrorToken});
     if (this.views.has(llvId)) return;
     const result = await this.pop.create({
       id: llvId,
@@ -243,14 +243,12 @@ export class LLVEngine {
     const pop = this.pop;
     const mountView = (el: HTMLElement) => this.mountView(el);
     const unmountView = (el: HTMLElement) => this.unmountView(el);
-    const maybeSetupMirrorChannel = (el: HTMLElement) => this.maybeSetupMirrorChannel(el);
     this.socket.hooks.LocalLiveView = {
       mounted() {
         this.llvLastAssigns = this.el.getAttribute("data-pop-assigns")!;
         if (pop.ready) mountView(this.el);
       },
       updated() {
-        maybeSetupMirrorChannel(this.el);
         const assigns = this.el.getAttribute("data-pop-assigns")!;
         if (assigns === this.llvLastAssigns) return;
         this.llvLastAssigns = assigns;
@@ -315,14 +313,12 @@ export class LLVEngine {
     };
   }
 
-  private maybeSetupMirrorChannel(el: HTMLElement): void {
-    const mirrorId = el.dataset.popMirrorId;
-    if (!mirrorId || (mirrorId && this.channels[mirrorId])) return;
-    if (!el.dataset.popMirrorToken) return;
-    const llvId = el.id;
-    const channel = this.llvMirrorSocket.channel(`llv:${mirrorId}`, {
-      view: el.dataset.popView,
-      token: el.dataset.popMirrorToken,
+  private maybeSetupMirrorChannel({ mirrorId, llvId, popView, popMirrorToken }: MirrorChannelOptions): void {
+    if (!mirrorId || this.channels[mirrorId] || !popMirrorToken) return;
+    const socket = this.llvMirrorSocket ?? this.setupMirrorSocket();
+    const channel = socket.channel(`llv:${mirrorId}`, {
+      view: popView,
+      token: popMirrorToken,
     });
     if (typeof mirrorId === "string") {
       this.channels[mirrorId] = channel;
@@ -335,6 +331,18 @@ export class LLVEngine {
         }
       })
       .receive("error", (err: unknown) => console.error("LLV channel join error", err));
+  }
+
+  private setupMirrorSocket(): PhoenixSocket {
+    const Socket = this.socketClass();
+    const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
+
+    const llvSocket = new Socket("/llv_socket", {
+      params: { _csrf_token: csrfToken },
+    });
+    llvSocket.connect();
+    this.llvMirrorSocket = llvSocket;
+    return llvSocket;
   }
 
   private exposeGlobals(): void {

--- a/local-live-view/assets/local_live_view/index.ts
+++ b/local-live-view/assets/local_live_view/index.ts
@@ -185,7 +185,7 @@ export class LLVEngine {
     const mirrorId = pop_view_el.dataset.popMirrorId;
     const popView = pop_view_el.dataset.popView;
     const popMirrorToken = pop_view_el.dataset.popMirrorToken;
-    this.maybeSetupMirrorChannel({mirrorId, llvId, popView, popMirrorToken});
+    this.maybeSetupMirrorChannel({ mirrorId, llvId, popView, popMirrorToken });
     if (this.views.has(llvId)) return;
     const result = await this.pop.create({
       id: llvId,
@@ -313,7 +313,12 @@ export class LLVEngine {
     };
   }
 
-  private maybeSetupMirrorChannel({ mirrorId, llvId, popView, popMirrorToken }: MirrorChannelOptions): void {
+  private maybeSetupMirrorChannel({
+    mirrorId,
+    llvId,
+    popView,
+    popMirrorToken,
+  }: MirrorChannelOptions): void {
     if (!mirrorId || this.channels[mirrorId] || !popMirrorToken) return;
     const socket = this.llvMirrorSocket ?? this.setupMirrorSocket();
     const channel = socket.channel(`llv:${mirrorId}`, {

--- a/local-live-view/lib/local_live_view/dispatcher.ex
+++ b/local-live-view/lib/local_live_view/dispatcher.ex
@@ -59,6 +59,19 @@ defmodule LocalLiveView.Dispatcher do
     {:resolve, :ok, state}
   end
 
+  defp handle_wasm_call(
+         %{"action" => "connect_mirror", "id" => id, "payload" => payload},
+         _promise,
+         state
+       ) do
+    send_to_view(state, id, %Message{
+      event: "connect_mirror",
+      payload: payload
+    })
+
+    {:resolve, :ok, state}
+  end
+
   defp handle_wasm_call(%{"action" => "push", "id" => id, "payload" => payload}, _promise, state) do
     send_to_view(state, id, %Message{event: "js_push", payload: payload})
     {:resolve, :ok, state}

--- a/local-live-view/lib/local_live_view/dispatcher.ex
+++ b/local-live-view/lib/local_live_view/dispatcher.ex
@@ -59,19 +59,6 @@ defmodule LocalLiveView.Dispatcher do
     {:resolve, :ok, state}
   end
 
-  defp handle_wasm_call(
-         %{"action" => "connect_mirror", "id" => id, "payload" => payload},
-         _promise,
-         state
-       ) do
-    send_to_view(state, id, %Message{
-      event: "connect_mirror",
-      payload: payload
-    })
-
-    {:resolve, :ok, state}
-  end
-
   defp handle_wasm_call(%{"action" => "push", "id" => id, "payload" => payload}, _promise, state) do
     send_to_view(state, id, %Message{event: "js_push", payload: payload})
     {:resolve, :ok, state}
@@ -112,7 +99,7 @@ defmodule LocalLiveView.Dispatcher do
     view = String.to_atom("Elixir." <> Map.fetch!(msg, "view"))
 
     params =
-      Map.take(msg, ~w"id assigns url url_params")
+      Map.take(msg, ~w"id assigns url url_params mirror_id")
       |> Map.put("session", %Session{view: view})
       |> Map.update!("assigns", &parse_assigns/1)
 

--- a/local-live-view/lib/local_live_view/local_live_view.ex
+++ b/local-live-view/lib/local_live_view/local_live_view.ex
@@ -119,11 +119,11 @@ defmodule LocalLiveView do
         """
         ({ args }) => {
           if (window.__llvSync) {
-            window.__llvSync(args.id, "sync", args.payload);
+            window.__llvSync(args.mirror_id, "sync", args.payload);
           }
         }
         """,
-        %{id: socket.private[:llv_id], payload: payload}
+        %{mirror_id: socket.private[:mirror_id], payload: payload}
       )
     end
 

--- a/local-live-view/lib/local_live_view/server.ex
+++ b/local-live-view/lib/local_live_view/server.ex
@@ -86,6 +86,13 @@ defmodule LocalLiveView.Server do
     {:noreply, state}
   end
 
+  def handle_info(%Message{event: "connect_mirror", payload: %{"mirror_id" => mirror_id}}, state) do
+    new_socket_private = Map.put(state.socket.private, :mirror_id, mirror_id)
+    new_socket = Map.put(state.socket, :private, new_socket_private)
+    new_state = Map.put(state, :socket, new_socket)
+    {:noreply, new_state}
+  end
+
   def handle_info(%Message{event: "event"} = msg, state) do
     %{"value" => raw_val, "event" => event, "type" => type} = msg.payload
     val = decode_event_type(type, raw_val, msg.payload)

--- a/local-live-view/lib/local_live_view/server.ex
+++ b/local-live-view/lib/local_live_view/server.ex
@@ -86,13 +86,6 @@ defmodule LocalLiveView.Server do
     {:noreply, state}
   end
 
-  def handle_info(%Message{event: "connect_mirror", payload: %{"mirror_id" => mirror_id}}, state) do
-    new_socket_private = Map.put(state.socket.private, :mirror_id, mirror_id)
-    new_socket = Map.put(state.socket, :private, new_socket_private)
-    new_state = Map.put(state, :socket, new_socket)
-    {:noreply, new_state}
-  end
-
   def handle_info(%Message{event: "event"} = msg, state) do
     %{"value" => raw_val, "event" => event, "type" => type} = msg.payload
     val = decode_event_type(type, raw_val, msg.payload)
@@ -574,6 +567,7 @@ defmodule LocalLiveView.Server do
 
     initial_assigns = params["assigns"]
     llv_id = params["id"]
+    mirror_id = params["mirror_id"]
 
     socket = %Socket{
       view: view
@@ -583,6 +577,11 @@ defmodule LocalLiveView.Server do
 
     case mount_private(verified, params, nil, lifecycle) do
       {:ok, mount_priv} ->
+        mount_priv =
+          mount_priv
+          |> Map.put(:llv_id, llv_id)
+          |> Map.put(:mirror_id, mirror_id)
+
         socket = %{
           socket
           | id: "phx-",

--- a/local-live-view/lib/server/channel.ex
+++ b/local-live-view/lib/server/channel.ex
@@ -1,26 +1,28 @@
 defmodule LocalLiveView.Channel do
   use Phoenix.Channel
 
-  def get_mirror_assigns(llv_id) do
-    case Registry.lookup(LocalLiveView.ChannelRegistry, llv_id) do
+  def get_mirror_assigns(mirror_id) do
+    case Registry.lookup(LocalLiveView.ChannelRegistry, mirror_id) do
       [{pid, _}] -> GenServer.call(pid, :get_mirror_assigns)
       [] -> %{}
     end
   end
 
-  def set_mirror_assigns(llv_id, assigns) do
-    case Registry.lookup(LocalLiveView.ChannelRegistry, llv_id) do
+  def set_mirror_assigns(mirror_id, assigns) do
+    case Registry.lookup(LocalLiveView.ChannelRegistry, mirror_id) do
       [{pid, _}] -> GenServer.call(pid, {:set_mirror_assigns, assigns})
       [] -> {:error, :not_found}
     end
   end
 
-  def join("llv:" <> llv_id, %{"view" => view_string, "token" => token}, socket) do
+  def join("llv:" <> mirror_id, %{"view" => view_string, "token" => token}, socket) do
     case LocalLiveView.MirrorToken.verify(socket.endpoint, token, max_age: :infinity) do
-      {:ok, %{id: ^llv_id, view: ^view_string}} ->
-        Registry.register(LocalLiveView.ChannelRegistry, llv_id, view_string)
+      {:ok, %{id: ^mirror_id, view: ^view_string}} ->
+        Registry.register(LocalLiveView.ChannelRegistry, mirror_id, view_string)
         mirror_module = LocalLiveView.Mirror.find_module(view_string)
-        {:ok, assign(socket, llv_id: llv_id, mirror_assigns: %{}, mirror_module: mirror_module)}
+
+        {:ok,
+         assign(socket, mirror_id: mirror_id, mirror_assigns: %{}, mirror_module: mirror_module)}
 
       {:error, _} ->
         {:error, %{reason: "unauthorized"}}
@@ -41,7 +43,7 @@ defmodule LocalLiveView.Channel do
   end
 
   def handle_in("sync", local_assigns, socket) do
-    session = %{llv_id: socket.assigns.llv_id}
+    session = %{mirror_id: socket.assigns.mirror_id}
 
     new_mirror_assigns =
       merge_assigns(

--- a/local-live-view/lib/server/channel.ex
+++ b/local-live-view/lib/server/channel.ex
@@ -24,7 +24,7 @@ defmodule LocalLiveView.Channel do
         {:ok,
          assign(socket, mirror_id: mirror_id, mirror_assigns: %{}, mirror_module: mirror_module)}
 
-      {:error, reason} ->
+      {:error, _} ->
         {:error, %{reason: "unauthorized"}}
     end
   end

--- a/local-live-view/lib/server/channel.ex
+++ b/local-live-view/lib/server/channel.ex
@@ -24,7 +24,7 @@ defmodule LocalLiveView.Channel do
         {:ok,
          assign(socket, mirror_id: mirror_id, mirror_assigns: %{}, mirror_module: mirror_module)}
 
-      {:error, _} ->
+      {:error, reason} ->
         {:error, %{reason: "unauthorized"}}
     end
   end

--- a/local-live-view/lib/server/component.ex
+++ b/local-live-view/lib/server/component.ex
@@ -170,7 +170,7 @@ defmodule LocalLiveView.Component do
       mirror_id = LocalLiveView.Component.mirror_id(socket, "my-custom-cart")
 
       # Default ID derived from view name:
-      mirror_id = LocalLiveView.Component.mirror_id(socket, "Cart")
+      mirror_id = LocalLiveView.Component.mirror_id(socket, "llv-Cart")
   """
   @spec mirror_id(%Phoenix.LiveView.Socket{id: String.t()}, String.t()) :: String.t()
   def mirror_id(%Phoenix.LiveView.Socket{id: socket_id}, view_or_id) do

--- a/local-live-view/lib/server/component.ex
+++ b/local-live-view/lib/server/component.ex
@@ -171,7 +171,7 @@ defmodule LocalLiveView.Component do
   within a parent LiveView process.
 
   Accepts the parent `socket` (or directly its `socket.id`), and either:
-  * a view module name / string (calculates the default DOM ID)
+  * a default ID derived from view name
   * an explicit custom DOM ID provided to `<.local_live_view id="..." />`
 
   ## Examples

--- a/local-live-view/lib/server/component.ex
+++ b/local-live-view/lib/server/component.ex
@@ -119,7 +119,8 @@ defmodule LocalLiveView.Component do
   def render_markup(assigns) do
     validate_assigns!(assigns)
 
-    comp_assigns = Map.drop(assigns, [:__changed__, :view, :flash, :id, :mirror_id, :mirror_token])
+    comp_assigns =
+      Map.drop(assigns, [:__changed__, :view, :flash, :id, :mirror_id, :mirror_token])
 
     assigns =
       assign(assigns,
@@ -187,8 +188,6 @@ defmodule LocalLiveView.Component do
   defp default_id(name) when is_binary(name) do
     "llv-" <> String.replace(name, ~r/[^A-Za-z0-9_-]/, "-")
   end
-
-  defp default_id(_), do: "llv-view"
 
   defp mirror_exists?(view_name), do: LocalLiveView.Mirror.find_module(view_name) != nil
 end

--- a/local-live-view/lib/server/component.ex
+++ b/local-live-view/lib/server/component.ex
@@ -28,7 +28,6 @@ defmodule LocalLiveView.Component do
 
     * `view` (required) - the LocalLiveView module name, as a string.
     * `id` - stable element id; defaults to a server-generated random id.
-    * `endpoint` - the Phoenix endpoint module used to sign the mirror token.
 
   ## Examples
 
@@ -51,11 +50,11 @@ defmodule LocalLiveView.Component do
       <.live_component module={__MODULE__.Live} {assigns} />
       """
     else
-      render_dead(assigns)
+      render_static(assigns)
     end
   end
 
-  defp render_dead(assigns) do
+  defp render_static(assigns) do
     view = assigns[:view]
 
     unless is_binary(view) do
@@ -66,7 +65,7 @@ defmodule LocalLiveView.Component do
       raise ArgumentError, "<.local_live_view> does not accept inner content"
     end
 
-    comp_assigns = Map.drop(assigns, [:__changed__, :view, :flash, :id, :endpoint])
+    comp_assigns = Map.drop(assigns, [:__changed__, :view, :flash, :id])
     assigns = assign(assigns, comp_assigns: comp_assigns)
 
     ~H"""
@@ -98,17 +97,6 @@ defmodule LocalLiveView.Component do
         """
       end
 
-      endpoint = resolve_endpoint(assigns)
-
-      if !endpoint do
-        raise ArgumentError, """
-        <.local_live_view> with mirror mechanism requires endpoint="..." parameter.
-        View "#{view}" uses mirror, but no endpoint was provided.
-        Add endpoint to your component call:
-          <.local_live_view view="#{view}" endpoint={@endpoint} />
-        """
-      end
-
       if Map.has_key?(assigns, :inner_block) do
         raise ArgumentError, "<.local_live_view> does not accept inner content"
       end
@@ -117,12 +105,12 @@ defmodule LocalLiveView.Component do
 
       mirror_token =
         if Phoenix.LiveView.connected?(socket) do
-          LocalLiveView.MirrorToken.sign(endpoint, view, mirror_id)
+          LocalLiveView.MirrorToken.sign(socket.endpoint, view, mirror_id)
         else
           nil
         end
 
-      comp_assigns = Map.drop(assigns, [:__changed__, :view, :flash, :id, :endpoint])
+      comp_assigns = Map.drop(assigns, [:__changed__, :view, :flash, :id])
 
       socket =
         assign(socket,
@@ -159,10 +147,6 @@ defmodule LocalLiveView.Component do
 
     defp encode_assigns(assigns) when assigns == %{}, do: nil
     defp encode_assigns(assigns), do: Jason.encode!(assigns)
-
-    defp resolve_endpoint(assigns) do
-      assigns[:endpoint] || Application.get_env(:local_live_view, :default_endpoint)
-    end
   end
 
   @doc """

--- a/local-live-view/lib/server/component.ex
+++ b/local-live-view/lib/server/component.ex
@@ -55,69 +55,38 @@ defmodule LocalLiveView.Component do
   end
 
   defp render_static(assigns) do
-    view = assigns[:view]
+    assigns =
+      assign(assigns,
+        mirror_token: nil,
+        mirror_id: nil
+      )
 
-    unless is_binary(view) do
-      raise ArgumentError, "<.local_live_view> expects view=\"...\" parameter to be a string"
-    end
-
-    if Map.has_key?(assigns, :inner_block) do
-      raise ArgumentError, "<.local_live_view> does not accept inner content"
-    end
-
-    comp_assigns = Map.drop(assigns, [:__changed__, :view, :flash, :id])
-    assigns = assign(assigns, comp_assigns: comp_assigns)
-
-    ~H"""
-    <div
-      data-pop-view={@view}
-      id={@id}
-      phx-hook="LocalLiveView"
-      data-pop-assigns={encode_assigns(@comp_assigns)}
-      phx-update="ignore"
-    >
-      <div id={"#{@id}-llv-event-bus"} data-llv-event-bus-for={@id} phx-hook="LocalLiveViewEventBus" hidden>
-      </div>
-    </div>
-    """
+    render_markup(assigns)
   end
 
   defmodule Live do
     @moduledoc false
     use Phoenix.LiveComponent
+    alias LocalLiveView.Component
 
     @impl true
     def update(assigns, socket) do
       view = assigns[:view]
-
-      unless is_binary(view) do
-        raise ArgumentError, """
-        <.local_live_view> expects view="..." parameter to be a string, got:
-          #{inspect(view)}
-        """
-      end
-
-      if Map.has_key?(assigns, :inner_block) do
-        raise ArgumentError, "<.local_live_view> does not accept inner content"
-      end
-
       mirror_id = socket.id <> assigns.id
 
       mirror_token =
         if Phoenix.LiveView.connected?(socket) do
-          LocalLiveView.MirrorToken.sign(socket.endpoint, view, mirror_id)
+          endpoint = socket.endpoint || Component.resolve_default_endpoint()
+          LocalLiveView.MirrorToken.sign(endpoint, view, mirror_id)
         else
           nil
         end
-
-      comp_assigns = Map.drop(assigns, [:__changed__, :view, :flash, :id])
 
       socket =
         assign(socket,
           view: view,
           id: assigns.id,
           mirror_token: mirror_token,
-          comp_assigns: comp_assigns,
           mirror_id: mirror_id
         )
 
@@ -126,27 +95,62 @@ defmodule LocalLiveView.Component do
 
     @impl true
     def render(assigns) do
-      ~H"""
-      <div>
-      <div
-        data-pop-view={@view}
-        id={@id}
-        phx-hook="LocalLiveView"
-        data-pop-mirror-token={@mirror_token}
-        data-pop-mirror-id={@mirror_id}
-        data-pop-assigns={encode_assigns(@comp_assigns)}
-        phx-update="ignore"
-      >
-      </div>
-      <%!-- Stub for sending events from client to server. See LLVEngine class. --%>
-      <div id={"#{@id}-llv-event-bus"} data-llv-event-bus-for={@id} phx-hook="LocalLiveViewEventBus" hidden>
-      </div>
-      </div>
+      Component.render_markup(assigns)
+    end
+  end
+
+  @doc false
+  defp validate_assigns!(assigns) do
+    view = assigns[:view]
+
+    unless is_binary(view) do
+      raise ArgumentError, """
+      <.local_live_view> expects view="..." parameter to be a string, got:
+        #{inspect(view)}
       """
     end
 
-    defp encode_assigns(assigns) when assigns == %{}, do: nil
-    defp encode_assigns(assigns), do: Jason.encode!(assigns)
+    if Map.has_key?(assigns, :inner_block) do
+      raise ArgumentError, "<.local_live_view> does not accept inner content"
+    end
+  end
+
+  @doc false
+  def render_markup(assigns) do
+    validate_assigns!(assigns)
+
+    comp_assigns = Map.drop(assigns, [:__changed__, :view, :flash, :id, :mirror_id, :mirror_token])
+
+    assigns =
+      assign(assigns,
+        comp_assigns: comp_assigns
+      )
+
+    ~H"""
+    <div>
+    <div
+      data-pop-view={@view}
+      id={@id}
+      phx-hook="LocalLiveView"
+      data-pop-mirror-token={@mirror_token}
+      data-pop-mirror-id={@mirror_id}
+      data-pop-assigns={encode_assigns(@comp_assigns)}
+      phx-update="ignore"
+    >
+    </div>
+    <%!-- Stub for sending events from client to server. See LLVEngine class. --%>
+    <div id={"#{@id}-llv-event-bus"} data-llv-event-bus-for={@id} phx-hook="LocalLiveViewEventBus" hidden>
+    </div>
+    </div>
+    """
+  end
+
+  @doc false
+  defp encode_assigns(assigns), do: Base.encode64(:erlang.term_to_binary(assigns))
+
+  @doc false
+  def resolve_default_endpoint do
+    Application.get_env(:local_live_view, :default_endpoint)
   end
 
   @doc """
@@ -185,8 +189,6 @@ defmodule LocalLiveView.Component do
   end
 
   defp default_id(_), do: "llv-view"
-
-  defp encode_assigns(assigns), do: Base.encode64(:erlang.term_to_binary(assigns))
 
   defp mirror_exists?(view_name), do: LocalLiveView.Mirror.find_module(view_name) != nil
 end

--- a/local-live-view/lib/server/component.ex
+++ b/local-live-view/lib/server/component.ex
@@ -42,62 +42,167 @@ defmodule LocalLiveView.Component do
   '''
   def local_live_view(assigns) do
     view = assigns[:view]
+    id = assigns[:id] || default_id(view)
+
+    assigns = assign(assigns, id: id)
+
+    if mirror_exists?(view) do
+      ~H"""
+      <.live_component module={__MODULE__.Live} {assigns} />
+      """
+    else
+      render_dead(assigns)
+    end
+  end
+
+  defp render_dead(assigns) do
+    view = assigns[:view]
 
     unless is_binary(view) do
-      raise ArgumentError, """
-      <.local_live_view> expects view="..." parameter to be a string, got:
-        #{inspect(view)}
-      """
-    end
-
-    if mirror_exists?(view) && !assigns[:endpoint] do
-      raise ArgumentError, """
-      <.local_live_view> with mirror mechanism requires endpoint="..." parameter.
-      View "#{view}" uses mirror, but no endpoint was provided.
-      Add endpoint to your component call:
-        <.local_live_view view="#{view}" endpoint={@endpoint} />
-      """
+      raise ArgumentError, "<.local_live_view> expects view=\"...\" parameter to be a string"
     end
 
     if Map.has_key?(assigns, :inner_block) do
       raise ArgumentError, "<.local_live_view> does not accept inner content"
     end
 
-    assigns = assign_new(assigns, :id, fn -> default_id(view) end)
-
-    comp_assigns = Map.drop(assigns, [:__changed__, :view])
-
-    mirror_token =
-      if mirror_exists?(view),
-        do: LocalLiveView.MirrorToken.sign(assigns.endpoint, view, assigns.id)
-
-    assigns = assign(assigns, mirror_token: mirror_token, comp_assigns: comp_assigns)
+    comp_assigns = Map.drop(assigns, [:__changed__, :view, :flash, :id, :endpoint])
+    assigns = assign(assigns, comp_assigns: comp_assigns)
 
     ~H"""
     <div
       data-pop-view={@view}
       id={@id}
       phx-hook="LocalLiveView"
-      data-pop-mirror-token={@mirror_token}
       data-pop-assigns={encode_assigns(@comp_assigns)}
       phx-update="ignore"
     >
-    </div>
-    <%!-- Stub for sending events from client to server. See LLVEngine class. --%>
-    <div id={"#{@id}-llv-event-bus"} data-llv-event-bus-for={@id} phx-hook="LocalLiveViewEventBus" hidden>
+      <div id={"#{@id}-llv-event-bus"} data-llv-event-bus-for={@id} phx-hook="LocalLiveViewEventBus" hidden>
+      </div>
     </div>
     """
   end
 
-  defp encode_assigns(assigns), do: Base.encode64(:erlang.term_to_binary(assigns))
+  defmodule Live do
+    @moduledoc false
+    use Phoenix.LiveComponent
 
-  # The mount point lives under `phx-update="ignore"`, so its id MUST be stable
-  # across the host LiveView's dead and connected renders — otherwise morphdom
-  # rebuilds the element on connect and the serialized assigns are lost before
-  # the runtime reads them. A random id would differ between renders, so derive a
-  # deterministic one from the module name. Pass an explicit `id` when mounting
-  # more than one instance of the same module on a page.
-  defp default_id(name), do: "llv-" <> String.replace(name, ~r/[^A-Za-z0-9_-]/, "-")
+    @impl true
+    def update(assigns, socket) do
+      view = assigns[:view]
+
+      unless is_binary(view) do
+        raise ArgumentError, """
+        <.local_live_view> expects view="..." parameter to be a string, got:
+          #{inspect(view)}
+        """
+      end
+
+      endpoint = resolve_endpoint(assigns)
+
+      if !endpoint do
+        raise ArgumentError, """
+        <.local_live_view> with mirror mechanism requires endpoint="..." parameter.
+        View "#{view}" uses mirror, but no endpoint was provided.
+        Add endpoint to your component call:
+          <.local_live_view view="#{view}" endpoint={@endpoint} />
+        """
+      end
+
+      if Map.has_key?(assigns, :inner_block) do
+        raise ArgumentError, "<.local_live_view> does not accept inner content"
+      end
+
+      mirror_id = socket.id <> assigns.id
+
+      mirror_token =
+        if Phoenix.LiveView.connected?(socket) do
+          LocalLiveView.MirrorToken.sign(endpoint, view, mirror_id)
+        else
+          nil
+        end
+
+      comp_assigns = Map.drop(assigns, [:__changed__, :view, :flash, :id, :endpoint])
+
+      socket =
+        assign(socket,
+          view: view,
+          id: assigns.id,
+          mirror_token: mirror_token,
+          comp_assigns: comp_assigns,
+          mirror_id: mirror_id
+        )
+
+      {:ok, socket}
+    end
+
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <div>
+      <div
+        data-pop-view={@view}
+        id={@id}
+        phx-hook="LocalLiveView"
+        data-pop-mirror-token={@mirror_token}
+        data-pop-mirror-id={@mirror_id}
+        data-pop-assigns={encode_assigns(@comp_assigns)}
+        phx-update="ignore"
+      >
+      </div>
+      <%!-- Stub for sending events from client to server. See LLVEngine class. --%>
+      <div id={"#{@id}-llv-event-bus"} data-llv-event-bus-for={@id} phx-hook="LocalLiveViewEventBus" hidden>
+      </div>
+      </div>
+      """
+    end
+
+    defp encode_assigns(assigns) when assigns == %{}, do: nil
+    defp encode_assigns(assigns), do: Jason.encode!(assigns)
+
+    defp resolve_endpoint(assigns) do
+      assigns[:endpoint] || Application.get_env(:local_live_view, :default_endpoint)
+    end
+  end
+
+  @doc """
+  Assembles the deterministic `mirror_id` for a given LocalLiveView component
+  within a parent LiveView process.
+
+  Accepts the parent `socket` (or directly its `socket.id`), and either:
+  * a view module name / string (calculates the default DOM ID)
+  * an explicit custom DOM ID provided to `<.local_live_view id="..." />`
+
+  ## Examples
+
+      # Explicit ID passed to component:
+      mirror_id = LocalLiveView.Component.mirror_id(socket, "my-custom-cart")
+
+      # Default ID derived from view name:
+      mirror_id = LocalLiveView.Component.mirror_id(socket, "Cart")
+  """
+  def mirror_id(%Phoenix.LiveView.Socket{id: socket_id}, view_or_id) do
+    mirror_id(socket_id, view_or_id)
+  end
+
+  def mirror_id(socket_id, view_or_id) when is_binary(socket_id) and is_binary(view_or_id) do
+    dom_id =
+      if String.starts_with?(view_or_id, "llv-") do
+        view_or_id
+      else
+        default_id(view_or_id)
+      end
+
+    socket_id <> dom_id
+  end
+
+  defp default_id(name) when is_binary(name) do
+    "llv-" <> String.replace(name, ~r/[^A-Za-z0-9_-]/, "-")
+  end
+
+  defp default_id(_), do: "llv-view"
+
+  defp encode_assigns(assigns), do: Base.encode64(:erlang.term_to_binary(assigns))
 
   defp mirror_exists?(view_name), do: LocalLiveView.Mirror.find_module(view_name) != nil
 end

--- a/local-live-view/lib/server/component.ex
+++ b/local-live-view/lib/server/component.ex
@@ -47,7 +47,7 @@ defmodule LocalLiveView.Component do
 
     if mirror_exists?(view) do
       ~H"""
-      <.live_component module={__MODULE__.Live} {assigns} />
+      <.live_component module={__MODULE__.Mirrored} {assigns} />
       """
     else
       render_static(assigns)
@@ -64,7 +64,7 @@ defmodule LocalLiveView.Component do
     render_markup(assigns)
   end
 
-  defmodule Live do
+  defmodule Mirrored do
     @moduledoc false
     use Phoenix.LiveComponent
     alias LocalLiveView.Component
@@ -81,6 +81,8 @@ defmodule LocalLiveView.Component do
         else
           nil
         end
+
+      assigns = Component.add_comp_assigns(assigns)
 
       socket =
         assign(socket,
@@ -118,14 +120,7 @@ defmodule LocalLiveView.Component do
   @doc false
   def render_markup(assigns) do
     validate_assigns!(assigns)
-
-    comp_assigns =
-      Map.drop(assigns, [:__changed__, :view, :flash, :id, :mirror_id, :mirror_token])
-
-    assigns =
-      assign(assigns,
-        comp_assigns: comp_assigns
-      )
+    assigns = add_comp_assigns(assigns)
 
     ~H"""
     <div>
@@ -147,6 +142,15 @@ defmodule LocalLiveView.Component do
   end
 
   @doc false
+  def add_comp_assigns(assigns) do
+    comp_assigns =
+      Map.drop(assigns, [:__changed__, :view, :flash, :id, :mirror_id, :mirror_token])
+
+    assign(assigns,
+      comp_assigns: comp_assigns
+    )
+  end
+
   defp encode_assigns(assigns), do: Base.encode64(:erlang.term_to_binary(assigns))
 
   @doc false
@@ -170,19 +174,13 @@ defmodule LocalLiveView.Component do
       # Default ID derived from view name:
       mirror_id = LocalLiveView.Component.mirror_id(socket, "Cart")
   """
+  @spec mirror_id(%Phoenix.LiveView.Socket{id: String.t()}, String.t()) :: String.t()
   def mirror_id(%Phoenix.LiveView.Socket{id: socket_id}, view_or_id) do
     mirror_id(socket_id, view_or_id)
   end
 
   def mirror_id(socket_id, view_or_id) when is_binary(socket_id) and is_binary(view_or_id) do
-    dom_id =
-      if String.starts_with?(view_or_id, "llv-") do
-        view_or_id
-      else
-        default_id(view_or_id)
-      end
-
-    socket_id <> dom_id
+    socket_id <> "-" <> view_or_id
   end
 
   defp default_id(name) when is_binary(name) do

--- a/local-live-view/lib/server/component.ex
+++ b/local-live-view/lib/server/component.ex
@@ -55,10 +55,13 @@ defmodule LocalLiveView.Component do
   end
 
   defp render_static(assigns) do
+    comp_assigns = comp_assigns(assigns)
+
     assigns =
       assign(assigns,
         mirror_token: nil,
-        mirror_id: nil
+        mirror_id: nil,
+        comp_assigns: comp_assigns
       )
 
     render_markup(assigns)
@@ -67,29 +70,30 @@ defmodule LocalLiveView.Component do
   defmodule Mirrored do
     @moduledoc false
     use Phoenix.LiveComponent
-    alias LocalLiveView.Component
+    alias LocalLiveView.Component, as: LLVComponent
 
     @impl true
     def update(assigns, socket) do
       view = assigns[:view]
-      mirror_id = socket.id <> assigns.id
+      mirror_id = LLVComponent.mirror_id(socket, assigns.id)
 
       mirror_token =
         if Phoenix.LiveView.connected?(socket) do
-          endpoint = socket.endpoint || Component.resolve_default_endpoint()
+          endpoint = socket.endpoint || LLVComponent.resolve_default_endpoint()
           LocalLiveView.MirrorToken.sign(endpoint, view, mirror_id)
         else
           nil
         end
 
-      assigns = Component.add_comp_assigns(assigns)
+      comp_assings = LLVComponent.comp_assigns(assigns)
 
       socket =
         assign(socket,
           view: view,
           id: assigns.id,
           mirror_token: mirror_token,
-          mirror_id: mirror_id
+          mirror_id: mirror_id,
+          comp_assigns: comp_assings
         )
 
       {:ok, socket}
@@ -97,7 +101,7 @@ defmodule LocalLiveView.Component do
 
     @impl true
     def render(assigns) do
-      Component.render_markup(assigns)
+      LLVComponent.render_markup(assigns)
     end
   end
 
@@ -120,7 +124,6 @@ defmodule LocalLiveView.Component do
   @doc false
   def render_markup(assigns) do
     validate_assigns!(assigns)
-    assigns = add_comp_assigns(assigns)
 
     ~H"""
     <div>
@@ -142,13 +145,8 @@ defmodule LocalLiveView.Component do
   end
 
   @doc false
-  def add_comp_assigns(assigns) do
-    comp_assigns =
-      Map.drop(assigns, [:__changed__, :view, :flash, :id, :mirror_id, :mirror_token])
-
-    assign(assigns,
-      comp_assigns: comp_assigns
-    )
+  def comp_assigns(assigns) do
+    Map.drop(assigns, [:__changed__, :view])
   end
 
   defp encode_assigns(assigns), do: Base.encode64(:erlang.term_to_binary(assigns))

--- a/local-live-view/lib/server/component.ex
+++ b/local-live-view/lib/server/component.ex
@@ -75,14 +75,24 @@ defmodule LocalLiveView.Component do
     @impl true
     def update(assigns, socket) do
       view = assigns[:view]
-      mirror_id = LLVComponent.mirror_id(socket, assigns.id)
+
+      mirror_id =
+        case socket.assigns[:mirror_id] do
+          nil -> LLVComponent.mirror_id(socket, assigns.id)
+          mirror_id -> mirror_id
+        end
 
       mirror_token =
-        if Phoenix.LiveView.connected?(socket) do
-          endpoint = socket.endpoint || LLVComponent.resolve_default_endpoint()
-          LocalLiveView.MirrorToken.sign(endpoint, view, mirror_id)
-        else
-          nil
+        cond do
+          token = socket.assigns[:mirror_token] ->
+            token
+
+          Phoenix.LiveView.connected?(socket) ->
+            endpoint = socket.endpoint || LLVComponent.resolve_default_endpoint()
+            LocalLiveView.MirrorToken.sign(endpoint, view, mirror_id)
+
+          true ->
+            nil
         end
 
       comp_assings = LLVComponent.comp_assigns(assigns)
@@ -172,13 +182,13 @@ defmodule LocalLiveView.Component do
       # Default ID derived from view name:
       mirror_id = LocalLiveView.Component.mirror_id(socket, "llv-Cart")
   """
-  @spec mirror_id(%Phoenix.LiveView.Socket{id: String.t()}, String.t()) :: String.t()
-  def mirror_id(%Phoenix.LiveView.Socket{id: socket_id}, view_or_id) do
-    mirror_id(socket_id, view_or_id)
+  @spec mirror_id(Phoenix.LiveView.Socket.t(), String.t()) :: String.t()
+  def mirror_id(%Phoenix.LiveView.Socket{id: socket_id}, id) do
+    mirror_id(socket_id, id)
   end
 
-  def mirror_id(socket_id, view_or_id) when is_binary(socket_id) and is_binary(view_or_id) do
-    socket_id <> "-" <> view_or_id
+  def mirror_id(socket_id, id) when is_binary(socket_id) and is_binary(id) do
+    socket_id <> "-" <> id
   end
 
   defp default_id(name) when is_binary(name) do

--- a/local-live-view/lib/server/mirror.ex
+++ b/local-live-view/lib/server/mirror.ex
@@ -10,8 +10,8 @@ defmodule LocalLiveView.Mirror do
     use LocalLiveView.Mirror
 
     @impl true
-    def handle_sync(local_assigns, _mirror_assigns, %{llv_id: llv_id}) do
-      Phoenix.PubSub.broadcast(MyApp.PubSub, "llv_mirror:MyLive:#{llv_id}", {:llv_attrs, local_assigns})
+    def handle_sync(local_assigns, _mirror_assigns, %{mirror_id: mirror_id}) do
+      Phoenix.PubSub.broadcast(MyApp.PubSub, "llv_mirror:MyLive:#{mirror_id}", {:llv_attrs, local_assigns})
       {:ok, local_assigns}
     end
   end

--- a/local-live-view/priv/static/local_live_view.d.ts
+++ b/local-live-view/priv/static/local_live_view.d.ts
@@ -32,6 +32,7 @@ interface CreateArgs {
     url: string;
     urlParams: Record<string, string>;
     assigns: string;
+    mirrorId: string | undefined;
 }
 declare class PopcornClient {
     private popcorn;
@@ -39,10 +40,9 @@ declare class PopcornClient {
     attach(popcorn: Popcorn): void;
     private call;
     private fire;
-    create({ id, view, url, urlParams, assigns }: CreateArgs): Promise<CallResult>;
+    create({ id, view, url, urlParams, assigns, mirrorId }: CreateArgs): Promise<CallResult>;
     destroy(id: string): void;
     reconnected(id: string): void;
-    connectMirror(id: string, mirror_id: string): void;
     updateAssigns(id: string, assigns: string): void;
     handleParams(id: string, params: Record<string, string>, url: string): void;
     handleTransportFrame(id: string, event: string, payload: unknown): Promise<CallResult>;

--- a/local-live-view/priv/static/local_live_view.d.ts
+++ b/local-live-view/priv/static/local_live_view.d.ts
@@ -78,6 +78,7 @@ declare class LLVEngine {
     private bootPopcorn;
     private setupMirrorSync;
     private maybeSetupMirrorChannel;
+    private setupMirrorSocket;
     private exposeGlobals;
     private patchOwner;
     private scanAndMount;

--- a/local-live-view/priv/static/local_live_view.d.ts
+++ b/local-live-view/priv/static/local_live_view.d.ts
@@ -42,6 +42,7 @@ declare class PopcornClient {
     create({ id, view, url, urlParams, assigns }: CreateArgs): Promise<CallResult>;
     destroy(id: string): void;
     reconnected(id: string): void;
+    connectMirror(id: string, mirror_id: string): void;
     updateAssigns(id: string, assigns: string): void;
     handleParams(id: string, params: Record<string, string>, url: string): void;
     handleTransportFrame(id: string, event: string, payload: unknown): Promise<CallResult>;
@@ -58,6 +59,7 @@ declare class LLVEngine {
     private bufferedServerMessages;
     private eventBusHooks;
     private popcornLink;
+    private llvMirrorSocket;
     private constructor();
     /**
      * Initializes LLVEngine and connects the LiveSocket.
@@ -74,7 +76,8 @@ declare class LLVEngine {
     private registerHooks;
     private bindFormsIfHostless;
     private bootPopcorn;
-    private setupMirrorChannels;
+    private setupMirrorSync;
+    private maybeSetupMirrorChannel;
     private exposeGlobals;
     private patchOwner;
     private scanAndMount;

--- a/local-live-view/priv/static/local_live_view.js
+++ b/local-live-view/priv/static/local_live_view.js
@@ -1090,7 +1090,7 @@ class LLVEngine {
             }
         };
     }
-    maybeSetupMirrorChannel({ mirrorId, llvId, popView, popMirrorToken }) {
+    maybeSetupMirrorChannel({ mirrorId, llvId, popView, popMirrorToken, }) {
         if (!mirrorId || this.channels[mirrorId] || !popMirrorToken)
             return;
         const socket = this.llvMirrorSocket ?? this.setupMirrorSocket();

--- a/local-live-view/priv/static/local_live_view.js
+++ b/local-live-view/priv/static/local_live_view.js
@@ -1098,9 +1098,7 @@ class LLVEngine {
             view: popView,
             token: popMirrorToken,
         });
-        if (typeof mirrorId === "string") {
-            this.channels[mirrorId] = channel;
-        }
+        this.channels[mirrorId] = channel;
         channel
             .join()
             .receive("ok", () => {

--- a/local-live-view/priv/static/local_live_view.js
+++ b/local-live-view/priv/static/local_live_view.js
@@ -867,7 +867,7 @@ class PopcornClient {
                 console.error(`LLV ${action} error`, result.error);
         }, (err) => console.error(`LLV ${action} error`, err));
     }
-    create({ id, view, url, urlParams, assigns }) {
+    create({ id, view, url, urlParams, assigns, mirrorId }) {
         return this.call({
             action: "create",
             id,
@@ -875,6 +875,7 @@ class PopcornClient {
             url,
             url_params: urlParams,
             assigns,
+            mirror_id: mirrorId,
         });
     }
     destroy(id) {
@@ -882,13 +883,6 @@ class PopcornClient {
     }
     reconnected(id) {
         this.fire("reconnect sync", { action: "reconnected", id, payload: {} });
-    }
-    connectMirror(id, mirror_id) {
-        this.fire("connect mirror", {
-            action: "connect_mirror",
-            id,
-            payload: { mirror_id: mirror_id },
-        });
     }
     updateAssigns(id, assigns) {
         this.fire("update assigns", { action: "update_assigns", id, assigns });
@@ -974,6 +968,8 @@ class LLVEngine {
     // Start a view and wire it up.
     async mountView(pop_view_el) {
         const llvId = pop_view_el.id;
+        const mirrorId = pop_view_el.dataset.popMirrorId;
+        this.maybeSetupMirrorChannel(pop_view_el);
         if (this.views.has(llvId))
             return;
         const result = await this.pop.create({
@@ -982,6 +978,7 @@ class LLVEngine {
             url: window.location.href,
             urlParams: Object.fromEntries(new URLSearchParams(window.location.search)),
             assigns: pop_view_el.getAttribute("data-pop-assigns"),
+            mirrorId: mirrorId
         });
         // A rejected call resolves with ok: false (it does not throw). Bail on
         // failed or duplicate creates — wiring a fake view without a live
@@ -992,7 +989,6 @@ class LLVEngine {
         }
         const liveEl = document.getElementById(llvId);
         if (liveEl?.matches("[data-pop-view]")) {
-            this.maybeSetupMirrorChannel(liveEl);
             setupFakeView(this.socket, this.views, this.popcornLink.socket, liveEl);
         }
         else {
@@ -1105,14 +1101,16 @@ class LLVEngine {
         const mirrorId = el.dataset.popMirrorId;
         if (!mirrorId || (mirrorId && this.channels[mirrorId]))
             return;
+        if (!el.dataset.popMirrorToken)
+            return;
         const llvId = el.id;
+        console.log(el);
         const channel = this.llvMirrorSocket.channel(`llv:${mirrorId}`, {
             view: el.dataset.popView,
             token: el.dataset.popMirrorToken,
         });
         if (typeof mirrorId === "string") {
             this.channels[mirrorId] = channel;
-            this.pop.connectMirror(llvId, mirrorId);
         }
         channel
             .join()

--- a/local-live-view/priv/static/local_live_view.js
+++ b/local-live-view/priv/static/local_live_view.js
@@ -992,6 +992,7 @@ class LLVEngine {
         }
         const liveEl = document.getElementById(llvId);
         if (liveEl?.matches("[data-pop-view]")) {
+            this.maybeSetupMirrorChannel(liveEl);
             setupFakeView(this.socket, this.views, this.popcornLink.socket, liveEl);
         }
         else {
@@ -1034,10 +1035,8 @@ class LLVEngine {
         this.socket.hooks.LocalLiveView = {
             mounted() {
                 this.llvLastAssigns = this.el.getAttribute("data-pop-assigns");
-                if (pop.ready) {
-                    maybeSetupMirrorChannel(this.el);
+                if (pop.ready)
                     mountView(this.el);
-                }
             },
             updated() {
                 maybeSetupMirrorChannel(this.el);

--- a/local-live-view/priv/static/local_live_view.js
+++ b/local-live-view/priv/static/local_live_view.js
@@ -978,7 +978,7 @@ class LLVEngine {
             url: window.location.href,
             urlParams: Object.fromEntries(new URLSearchParams(window.location.search)),
             assigns: pop_view_el.getAttribute("data-pop-assigns"),
-            mirrorId: mirrorId
+            mirrorId: mirrorId,
         });
         // A rejected call resolves with ok: false (it does not throw). Bail on
         // failed or duplicate creates — wiring a fake view without a live
@@ -1104,7 +1104,6 @@ class LLVEngine {
         if (!el.dataset.popMirrorToken)
             return;
         const llvId = el.id;
-        console.log(el);
         const channel = this.llvMirrorSocket.channel(`llv:${mirrorId}`, {
             view: el.dataset.popView,
             token: el.dataset.popMirrorToken,

--- a/local-live-view/priv/static/local_live_view.js
+++ b/local-live-view/priv/static/local_live_view.js
@@ -950,11 +950,11 @@ class LLVEngine {
         // registerServerMessageListener / registerHooks comments).
         engine.registerServerMessageListener();
         registerNavigationHandlers(engine.socket, engine.views, engine.pop, engine.config);
+        engine.registerHooks();
         engine.bindFormsIfHostless();
         engine.connectPopcornSocket();
         await engine.bootPopcorn();
         engine.setupMirrorSync();
-        engine.registerHooks();
         engine.exposeGlobals();
         engine.patchOwner();
         registerCustomEventBindings(engine.socket);

--- a/local-live-view/priv/static/local_live_view.js
+++ b/local-live-view/priv/static/local_live_view.js
@@ -920,17 +920,10 @@ class LLVEngine {
     // by __llvPushServer.
     eventBusHooks = new Map();
     popcornLink;
-    llvMirrorSocket;
+    llvMirrorSocket = undefined;
     constructor(socket, config) {
         this.socket = socket;
         this.config = config;
-        const Socket = this.socketClass();
-        const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
-        const llvSocket = new Socket("/llv_socket", {
-            params: { _csrf_token: csrfToken },
-        });
-        llvSocket.connect();
-        this.llvMirrorSocket = llvSocket;
     }
     /**
      * Initializes LLVEngine and connects the LiveSocket.
@@ -969,7 +962,9 @@ class LLVEngine {
     async mountView(pop_view_el) {
         const llvId = pop_view_el.id;
         const mirrorId = pop_view_el.dataset.popMirrorId;
-        this.maybeSetupMirrorChannel(pop_view_el);
+        const popView = pop_view_el.dataset.popView;
+        const popMirrorToken = pop_view_el.dataset.popMirrorToken;
+        this.maybeSetupMirrorChannel({ mirrorId, llvId, popView, popMirrorToken });
         if (this.views.has(llvId))
             return;
         const result = await this.pop.create({
@@ -1027,7 +1022,6 @@ class LLVEngine {
         const pop = this.pop;
         const mountView = (el) => this.mountView(el);
         const unmountView = (el) => this.unmountView(el);
-        const maybeSetupMirrorChannel = (el) => this.maybeSetupMirrorChannel(el);
         this.socket.hooks.LocalLiveView = {
             mounted() {
                 this.llvLastAssigns = this.el.getAttribute("data-pop-assigns");
@@ -1035,7 +1029,6 @@ class LLVEngine {
                     mountView(this.el);
             },
             updated() {
-                maybeSetupMirrorChannel(this.el);
                 const assigns = this.el.getAttribute("data-pop-assigns");
                 if (assigns === this.llvLastAssigns)
                     return;
@@ -1097,16 +1090,13 @@ class LLVEngine {
             }
         };
     }
-    maybeSetupMirrorChannel(el) {
-        const mirrorId = el.dataset.popMirrorId;
-        if (!mirrorId || (mirrorId && this.channels[mirrorId]))
+    maybeSetupMirrorChannel({ mirrorId, llvId, popView, popMirrorToken }) {
+        if (!mirrorId || this.channels[mirrorId] || !popMirrorToken)
             return;
-        if (!el.dataset.popMirrorToken)
-            return;
-        const llvId = el.id;
-        const channel = this.llvMirrorSocket.channel(`llv:${mirrorId}`, {
-            view: el.dataset.popView,
-            token: el.dataset.popMirrorToken,
+        const socket = this.llvMirrorSocket ?? this.setupMirrorSocket();
+        const channel = socket.channel(`llv:${mirrorId}`, {
+            view: popView,
+            token: popMirrorToken,
         });
         if (typeof mirrorId === "string") {
             this.channels[mirrorId] = channel;
@@ -1119,6 +1109,16 @@ class LLVEngine {
             }
         })
             .receive("error", (err) => console.error("LLV channel join error", err));
+    }
+    setupMirrorSocket() {
+        const Socket = this.socketClass();
+        const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
+        const llvSocket = new Socket("/llv_socket", {
+            params: { _csrf_token: csrfToken },
+        });
+        llvSocket.connect();
+        this.llvMirrorSocket = llvSocket;
+        return llvSocket;
     }
     exposeGlobals() {
         // Out-of-band diffs (handle_info renders, send_update, push_error

--- a/local-live-view/priv/static/local_live_view.js
+++ b/local-live-view/priv/static/local_live_view.js
@@ -883,6 +883,13 @@ class PopcornClient {
     reconnected(id) {
         this.fire("reconnect sync", { action: "reconnected", id, payload: {} });
     }
+    connect_mirror(id, mirror_id) {
+        this.fire("connect mirror", {
+            action: "connect_mirror",
+            id,
+            payload: { mirror_id: mirror_id },
+        });
+    }
     updateAssigns(id, assigns) {
         this.fire("update assigns", { action: "update_assigns", id, assigns });
     }
@@ -919,9 +926,17 @@ class LLVEngine {
     // by __llvPushServer.
     eventBusHooks = new Map();
     popcornLink;
+    llvMirrorSocket;
     constructor(socket, config) {
         this.socket = socket;
         this.config = config;
+        const Socket = this.socketClass();
+        const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
+        const llvSocket = new Socket("/llv_socket", {
+            params: { _csrf_token: csrfToken },
+        });
+        llvSocket.connect();
+        this.llvMirrorSocket = llvSocket;
     }
     /**
      * Initializes LLVEngine and connects the LiveSocket.
@@ -939,7 +954,7 @@ class LLVEngine {
         engine.bindFormsIfHostless();
         engine.connectPopcornSocket();
         await engine.bootPopcorn();
-        engine.setupMirrorChannels();
+        engine.setupMirrorSync();
         engine.exposeGlobals();
         engine.patchOwner();
         registerCustomEventBindings(engine.socket);
@@ -1015,13 +1030,16 @@ class LLVEngine {
         const pop = this.pop;
         const mountView = (el) => this.mountView(el);
         const unmountView = (el) => this.unmountView(el);
+        const maybeSetupMirrorChannel = (el) => this.maybeSetupMirrorChannel(el);
         this.socket.hooks.LocalLiveView = {
             mounted() {
+                maybeSetupMirrorChannel(this.el);
                 this.llvLastAssigns = this.el.getAttribute("data-pop-assigns");
                 if (pop.ready)
                     mountView(this.el);
             },
             updated() {
+                maybeSetupMirrorChannel(this.el);
                 const assigns = this.el.getAttribute("data-pop-assigns");
                 if (assigns === this.llvLastAssigns)
                     return;
@@ -1075,38 +1093,35 @@ class LLVEngine {
         }
     }
     // Mirror channels: only created for views with a server-side Mirror module.
-    setupMirrorChannels() {
-        const mirrorEls = document.querySelectorAll("[data-pop-view][data-pop-mirror-token]");
-        if (mirrorEls.length === 0)
-            return;
-        const Socket = this.socketClass();
-        const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
-        const llvSocket = new Socket("/llv_socket", {
-            params: { _csrf_token: csrfToken },
-        });
-        llvSocket.connect();
-        mirrorEls.forEach((el) => {
-            const llvId = el.id;
-            const channel = llvSocket.channel(`llv:${llvId}`, {
-                view: el.dataset.popView,
-                token: el.dataset.popMirrorToken,
-            });
-            this.channels[llvId] = channel;
-            channel
-                .join()
-                .receive("ok", () => {
-                if (this.views.has(llvId)) {
-                    this.pop.reconnected(llvId);
-                }
-            })
-                .receive("error", (err) => console.error("LLV channel join error", err));
-        });
-        window.__llvSync = (id, eventName, payload) => {
-            const channel = this.channels[id];
+    setupMirrorSync() {
+        window.__llvSync = (mirror_id, eventName, payload) => {
+            const channel = this.channels[mirror_id];
             if (channel) {
                 channel.push(eventName, payload);
             }
         };
+    }
+    maybeSetupMirrorChannel(el) {
+        const mirrorId = el.dataset.popMirrorId;
+        if (!mirrorId || (mirrorId && this.channels[mirrorId]))
+            return;
+        const llvId = el.id;
+        const channel = this.llvMirrorSocket.channel(`llv:${mirrorId}`, {
+            view: el.dataset.popView,
+            token: el.dataset.popMirrorToken,
+        });
+        if (typeof mirrorId === "string") {
+            this.channels[mirrorId] = channel;
+            this.pop.connectMirror(llvId, mirrorId);
+        }
+        channel
+            .join()
+            .receive("ok", () => {
+            if (this.views.has(llvId)) {
+                this.pop.reconnected(llvId);
+            }
+        })
+            .receive("error", (err) => console.error("LLV channel join error", err));
     }
     exposeGlobals() {
         // Out-of-band diffs (handle_info renders, send_update, push_error

--- a/local-live-view/priv/static/local_live_view.js
+++ b/local-live-view/priv/static/local_live_view.js
@@ -950,11 +950,11 @@ class LLVEngine {
         // registerServerMessageListener / registerHooks comments).
         engine.registerServerMessageListener();
         registerNavigationHandlers(engine.socket, engine.views, engine.pop, engine.config);
-        engine.registerHooks();
         engine.bindFormsIfHostless();
         engine.connectPopcornSocket();
         await engine.bootPopcorn();
         engine.setupMirrorSync();
+        engine.registerHooks();
         engine.exposeGlobals();
         engine.patchOwner();
         registerCustomEventBindings(engine.socket);
@@ -1033,10 +1033,11 @@ class LLVEngine {
         const maybeSetupMirrorChannel = (el) => this.maybeSetupMirrorChannel(el);
         this.socket.hooks.LocalLiveView = {
             mounted() {
-                maybeSetupMirrorChannel(this.el);
                 this.llvLastAssigns = this.el.getAttribute("data-pop-assigns");
-                if (pop.ready)
+                if (pop.ready) {
+                    maybeSetupMirrorChannel(this.el);
                     mountView(this.el);
+                }
             },
             updated() {
                 maybeSetupMirrorChannel(this.el);

--- a/local-live-view/priv/static/local_live_view.js
+++ b/local-live-view/priv/static/local_live_view.js
@@ -883,7 +883,7 @@ class PopcornClient {
     reconnected(id) {
         this.fire("reconnect sync", { action: "reconnected", id, payload: {} });
     }
-    connect_mirror(id, mirror_id) {
+    connectMirror(id, mirror_id) {
         this.fire("connect mirror", {
             action: "connect_mirror",
             id,


### PR DESCRIPTION
Closes: https://github.com/software-mansion/popcorn/issues/679

Summary:

- LLV ID handling: Retained the default behavior. If a single instance of a LocalLiveView is present, `id` defaults to `"llv-LLVModuleName"`. If multiple instances of the same LocalLiveView exist, the user must explicitly provide a unique `id` for each instance.

- Mirror identification: The server uses `mirror_id` to uniquely identify mirrors connected to a specific LLV instance. The `mirror_id` is a combination of `socket.id` and the component's `id`.