### PR TITLE
otp: allow JS to construct tuples and atoms

### DIFF
--- a/otp/js/e2e/bridge.spec.ts
+++ b/otp/js/e2e/bridge.spec.ts
@@ -1,4 +1,4 @@
-import { encode } from "../src/etf";
+import { a, atom, encode, t, tuple } from "../src/etf";
 import { assert, evalOpts, expect, test } from "./helpers";
 
 const OVERFLOWED = Number.MAX_SAFE_INTEGER + 1;
@@ -26,6 +26,14 @@ const PAYLOAD = {
 };
 
 test.describe("ETF", () => {
+  test("atoms and tuples", () => {
+    const tupleJs = tuple as (...entries: unknown[]) => unknown;
+
+    assert.equal(hex(atom("ok")), hex(a("ok")));
+    assert.equal(hex(tuple(atom("ok"), "value")), hex(t(a("ok"), "value")));
+    assert.throws(() => tupleJs("only"), /at least two entries/);
+  });
+
   test("objects", () => {
     const nullPrototype = Object.assign(Object.create(null), { key: "value" });
     const symbolKey = { visible: true, [Symbol("key")]: true };
@@ -75,6 +83,50 @@ test.describe("ETF", () => {
 });
 
 test.describe("events", () => {
+  test("atoms and tuples", async ({ otp, page }) => {
+    function inJs<Result>(fn: () => Result) {
+      return page.evaluateHandle(fn);
+    }
+
+    const boot = await otp.boot(
+      evalOpts(`
+          true = register(term_receiver, self()),
+          ok = wasm:send(#{bridge_ready => true}),
+          receive
+            {wasm, Payload} ->
+              ok = wasm:send(#{
+                term_received => Payload =:= {ok, <<"value">>}
+              })
+          end,
+          receive
+            stop -> ok
+          end.
+        `),
+    );
+    assert(boot.ok);
+
+    await otp.waitForEvent("bridge_ready");
+    const tuplePayload = await inJs(() => {
+      const a = window.popcorn.atom;
+      const t = window.popcorn.tuple;
+      return t(a("ok"), "value");
+    });
+    assert((await otp.send("term_receiver", tuplePayload)).ok);
+    await tuplePayload.dispose();
+    expect(await otp.waitForEvent("term_received")).toEqual({
+      term_received: true,
+    });
+
+    const atomPayload = await inJs(() => {
+      const a = window.popcorn.atom;
+      return a("popcorn_atom_that_does_not_exist");
+    });
+    const result = await otp.send("term_receiver", atomPayload);
+    await atomPayload.dispose();
+    assert(!result.ok);
+    assert.equal(result.error.t, "bridge:unserializable");
+  });
+
   test("round trip", async ({ otp }) => {
     const boot = await otp.boot(
       evalOpts(`

--- a/otp/js/e2e/helpers.ts
+++ b/otp/js/e2e/helpers.ts
@@ -7,18 +7,24 @@ import {
   type Page,
 } from "@playwright/test";
 import type {
+  atom,
   Popcorn,
   PopcornOpts,
   PopcornEvent,
   OtpErrorPayload,
   Pid,
   SerializedError,
+  tuple,
 } from "@swmansion/popcorn-otp";
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Window {
     Popcorn: typeof Popcorn;
+    popcorn: {
+      atom: typeof atom;
+      tuple: typeof tuple;
+    };
   }
 }
 

--- a/otp/js/e2e/setup/index.html
+++ b/otp/js/e2e/setup/index.html
@@ -7,7 +7,8 @@
     </head>
     <body>
         <script type="module">
-            import { Popcorn } from "@swmansion/popcorn-otp";
+            import { atom, Popcorn, tuple } from "@swmansion/popcorn-otp";
+            window.popcorn = { atom, tuple };
             window.Popcorn = Popcorn;
         </script>
     </body>

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -304,6 +304,16 @@ export function send(
       error: err("bridge:listener-not-found", { targetName: t }),
     };
   }
+  if (status === 2) {
+    return {
+      ok: false,
+      error: err("bridge:unserializable", {
+        data: null,
+        part: null,
+        reason: "unsupported",
+      }),
+    };
+  }
   unreachable();
 }
 

--- a/otp/js/src/etf.ts
+++ b/otp/js/src/etf.ts
@@ -4,21 +4,48 @@ import {
   type Result,
   type UnserializableReason,
 } from "./errors";
+import { check } from "./utils";
 
 const VERSION = 0x83;
 const NEW_FLOAT_EXT = 0x46;
 const SMALL_INTEGER_EXT = 0x61;
 const INTEGER_EXT = 0x62;
+const SMALL_TUPLE_EXT = 0x68;
+const LARGE_TUPLE_EXT = 0x69;
 const NIL_EXT = 0x6a;
 const LIST_EXT = 0x6c;
 const BINARY_EXT = 0x6d;
 const SMALL_BIG_EXT = 0x6e;
 const MAP_EXT = 0x74;
+const ATOM_UTF8_EXT = 0x76;
 const SMALL_ATOM_UTF8_EXT = 0x77;
 
 const UTF8 = new TextEncoder();
 
-type Atom = "true" | "false" | "nil";
+class AtomTerm {
+  public constructor(public readonly name: string) {}
+}
+
+class TupleTerm {
+  public constructor(public readonly entries: unknown[]) {}
+}
+
+export function atom(name: string): AtomTerm {
+  return new AtomTerm(name);
+}
+
+export const a = atom;
+
+export function tuple(
+  first: unknown,
+  second: unknown,
+  ...rest: unknown[]
+): TupleTerm {
+  check(arguments.length > 1, "tuple requires at least two entries");
+  return new TupleTerm([first, second, ...rest]);
+}
+
+export const t = tuple;
 
 /** Pre-encoded ETF sub-term bytes (no version prefix), spliced verbatim. */
 export class RawTerm {
@@ -142,11 +169,19 @@ class Encoder {
       this.bytes(value.bytes);
       return;
     }
+    if (value instanceof AtomTerm) {
+      this.atom(value.name);
+      return;
+    }
     if (this.ancestors.has(value)) {
       throw err("cyclic-object", value);
     }
     this.ancestors.add(value);
     try {
+      if (value instanceof TupleTerm) {
+        this.tuple(value.entries);
+        return;
+      }
       if (Array.isArray(value)) {
         this.array(value);
         return;
@@ -160,6 +195,19 @@ class Encoder {
       this.map(value);
     } finally {
       this.ancestors.delete(value);
+    }
+  }
+
+  private tuple(entries: unknown[]): void {
+    if (entries.length < 2 ** 8) {
+      this.byte(SMALL_TUPLE_EXT);
+      this.byte(entries.length);
+    } else {
+      this.byte(LARGE_TUPLE_EXT);
+      this.uint32(entries.length);
+    }
+    for (const entry of entries) {
+      this.value(entry);
     }
   }
 
@@ -187,10 +235,18 @@ class Encoder {
     }
   }
 
-  private atom(atom: Atom): void {
+  private atom(atom: string): void {
     const bytes = UTF8.encode(atom);
-    this.byte(SMALL_ATOM_UTF8_EXT);
-    this.byte(bytes.length);
+    if (bytes.length >= 2 ** 16) {
+      throw err("unsupported", atom);
+    }
+    if (bytes.length < 2 ** 8) {
+      this.byte(SMALL_ATOM_UTF8_EXT);
+      this.byte(bytes.length);
+    } else {
+      this.byte(ATOM_UTF8_EXT);
+      this.uint16(bytes.length);
+    }
     this.bytes(bytes);
   }
 
@@ -214,6 +270,11 @@ class Encoder {
   private uint32(value: number): void {
     this.view.setUint32(0, value);
     this.bytes(new Uint8Array(this.buffer, 0, 4));
+  }
+
+  private uint16(value: number): void {
+    this.view.setUint16(0, value);
+    this.bytes(new Uint8Array(this.buffer, 0, 2));
   }
 
   private int32(value: number): void {

--- a/otp/js/src/index.ts
+++ b/otp/js/src/index.ts
@@ -1,5 +1,6 @@
 export { PopcornError } from "./errors";
 
+export { a, atom, t, tuple } from "./etf";
 export { Popcorn, schedulers } from "./popcorn";
 export type { PopcornOpts, SchedulerOptions } from "./popcorn";
 export type { PopcornEvent } from "./events";

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -295,7 +295,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..e39af2a963bdf9697de3e9f61d18d17629a7228d
 --- /dev/null
 +++ b/erts/emulator/nifs/common/wasm_nif.c
-@@ -0,0 +1,644 @@
+@@ -0,0 +1,645 @@
 +/*
 + * %CopyrightBegin%
 + *
@@ -891,7 +891,8 @@ index 0000000000000000000000000000000000000000..e39af2a963bdf9697de3e9f61d18d176
 +  decoded_size = enif_binary_to_term(env, etf, (size_t)etf_len, &payload_term,
 +                                     ERL_NIF_BIN2TERM_SAFE);
 +  if (decoded_size != etf_len) {
-+    abort();
++    enif_free_env(env);
++    return 2;
 +  }
 +
 +  if (target_kind == WASM_TARGET_PID_BYTES) {


### PR DESCRIPTION
VM event handlers commonly pattern match on tagged tuples, which plain JavaScript values cannot represent. Add explicit constructors for these terms while keeping atom decoding restricted to atoms already in the VM.