### PR TITLE
otp: add stdin support

### DIFF
--- a/otp/js/e2e/runtime.spec.ts
+++ b/otp/js/e2e/runtime.spec.ts
@@ -116,6 +116,23 @@ test.describe("boot", () => {
 test.describe("lifecycle", () => {
   test("TTY output", async ({ page }) => {
     const result = await page.evaluate(async () => {
+      const command = async (
+        popcorn: {
+          onEvent: (handler: (event: unknown) => void) => () => void;
+          writeStdin: (chunk: Uint8Array) => { ok: boolean };
+        },
+        value: number,
+      ) =>
+        await new Promise<unknown>((resolve) => {
+          const unsubscribe = popcorn.onEvent((event) => {
+            unsubscribe();
+            resolve(event);
+          });
+          const write = popcorn.writeStdin(new Uint8Array([value]));
+          if (!write.ok) throw new Error("stdin command failed");
+        });
+
+      // Default text decodes split UTF-8 and uses 80×24.
       const stdout: string[] = [];
       const stderr: string[] = [];
       const text = new window.Popcorn({
@@ -125,21 +142,52 @@ test.describe("lifecycle", () => {
         onStderr: (chunk) => stderr.push(chunk),
       });
       await text.boot();
+      const defaultSize = await command(text, 2);
       text.deinit();
 
+      // init infers byte callbacks and forwards custom size.
       const rawStdout: number[][] = [];
       const rawStderr: number[][] = [];
-      const bytes = new window.Popcorn({
+      const init = await window.Popcorn.init({
         beam: { manifestUrl: "/unused.json" },
         workerUrl: "/output-worker.mjs",
-        tty: { output: "bytes" },
+        tty: {
+          size: { columns: 100, rows: 30 },
+          output: "bytes",
+        },
         onStdout: (chunk) => rawStdout.push(Array.from(chunk)),
         onStderr: (chunk) => rawStderr.push(Array.from(chunk)),
       });
-      await bytes.boot();
+      if (!init.ok) throw init.error;
+      const bytes = init.data;
+      const customSize = await command(bytes, 2);
       bytes.deinit();
 
-      return { stdout, stderr, rawStdout, rawStderr };
+      // Reboot discards an incomplete UTF-8 sequence.
+      const rebootStdout: string[] = [];
+      const reboot = new window.Popcorn({
+        beam: { manifestUrl: "/unused.json" },
+        workerUrl: "/output-worker.mjs",
+        onStdout: (chunk) => rebootStdout.push(chunk),
+      });
+      await reboot.boot();
+      rebootStdout.length = 0;
+      await command(reboot, 0);
+      reboot.deinit();
+      await reboot.boot();
+      rebootStdout.length = 0;
+      await command(reboot, 1);
+      reboot.deinit();
+
+      return {
+        stdout,
+        stderr,
+        rawStdout,
+        rawStderr,
+        defaultSize,
+        customSize,
+        rebootStdout,
+      };
     });
 
     expect(result).toEqual({
@@ -151,6 +199,9 @@ test.describe("lifecycle", () => {
         [0x8d, 0xf0, 0x9f, 0x9a, 0x80],
       ],
       rawStderr: [[0xf0, 0x9f, 0x9a], [0x80]],
+      defaultSize: { ttySize: { columns: 80, rows: 24 } },
+      customSize: { ttySize: { columns: 100, rows: 30 } },
+      rebootStdout: ["👩‍🚀"],
     });
   });
 

--- a/otp/js/e2e/runtime.spec.ts
+++ b/otp/js/e2e/runtime.spec.ts
@@ -114,6 +114,46 @@ test.describe("boot", () => {
 });
 
 test.describe("lifecycle", () => {
+  test("TTY output", async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const stdout: string[] = [];
+      const stderr: string[] = [];
+      const text = new window.Popcorn({
+        beam: { manifestUrl: "/unused.json" },
+        workerUrl: "/output-worker.mjs",
+        onStdout: (chunk) => stdout.push(chunk),
+        onStderr: (chunk) => stderr.push(chunk),
+      });
+      await text.boot();
+      text.deinit();
+
+      const rawStdout: number[][] = [];
+      const rawStderr: number[][] = [];
+      const bytes = new window.Popcorn({
+        beam: { manifestUrl: "/unused.json" },
+        workerUrl: "/output-worker.mjs",
+        tty: { output: "bytes" },
+        onStdout: (chunk) => rawStdout.push(Array.from(chunk)),
+        onStderr: (chunk) => rawStderr.push(Array.from(chunk)),
+      });
+      await bytes.boot();
+      bytes.deinit();
+
+      return { stdout, stderr, rawStdout, rawStderr };
+    });
+
+    expect(result).toEqual({
+      stdout: ["👩", "‍🚀"],
+      stderr: ["🚀"],
+      rawStdout: [
+        [0xf0, 0x9f],
+        [0x91, 0xa9, 0xe2, 0x80],
+        [0x8d, 0xf0, 0x9f, 0x9a, 0x80],
+      ],
+      rawStderr: [[0xf0, 0x9f, 0x9a], [0x80]],
+    });
+  });
+
   test("init", async ({ page }) => {
     const result = await page.evaluate(async () => {
       const init = await window.Popcorn.init({

--- a/otp/js/e2e/setup/output-worker.mjs
+++ b/otp/js/e2e/setup/output-worker.mjs
@@ -1,25 +1,33 @@
-self.onmessage = (event) => {
-  if (event.data?.type !== "popcorn:boot") return;
+let ttySize;
 
-  self.postMessage({
-    type: "otp:stdout",
-    payload: new Uint8Array([0xf0, 0x9f]),
-  });
-  self.postMessage({
-    type: "otp:stderr",
-    payload: new Uint8Array([0xf0, 0x9f, 0x9a]),
-  });
-  self.postMessage({
-    type: "otp:stdout",
-    payload: new Uint8Array([0x91, 0xa9, 0xe2, 0x80]),
-  });
-  self.postMessage({
-    type: "otp:stdout",
-    payload: new Uint8Array([0x8d, 0xf0, 0x9f, 0x9a, 0x80]),
-  });
-  self.postMessage({
-    type: "otp:stderr",
-    payload: new Uint8Array([0x80]),
-  });
-  self.postMessage({ type: "popcorn:boot-end", payload: {} });
+self.onmessage = (event) => {
+  if (event.data?.type === "popcorn:boot") {
+    ttySize = event.data.payload.ttySize;
+    emit("otp:stdout", [0xf0, 0x9f]);
+    emit("otp:stderr", [0xf0, 0x9f, 0x9a]);
+    emit("otp:stdout", [0x91, 0xa9, 0xe2, 0x80]);
+    emit("otp:stdout", [0x8d, 0xf0, 0x9f, 0x9a, 0x80]);
+    emit("otp:stderr", [0x80]);
+    self.postMessage({ type: "popcorn:boot-end", payload: {} });
+    return;
+  }
+
+  if (event.data?.type === "popcorn:stdin") {
+    const command = event.data.payload.chunk[0];
+    if (command === 0) emit("otp:stdout", [0xf0, 0x9f]);
+    if (command === 1) {
+      emit("otp:stdout", [
+        0xf0, 0x9f, 0x91, 0xa9, 0xe2, 0x80, 0x8d, 0xf0, 0x9f, 0x9a, 0x80,
+      ]);
+    }
+    self.postMessage({ type: "otp:stdin-consumed", payload: 1 });
+    self.postMessage({
+      type: "otp:message",
+      payload: command === 2 ? { ttySize } : { command },
+    });
+  }
 };
+
+function emit(type, bytes) {
+  self.postMessage({ type, payload: new Uint8Array(bytes) });
+}

--- a/otp/js/e2e/setup/output-worker.mjs
+++ b/otp/js/e2e/setup/output-worker.mjs
@@ -1,0 +1,25 @@
+self.onmessage = (event) => {
+  if (event.data?.type !== "popcorn:boot") return;
+
+  self.postMessage({
+    type: "otp:stdout",
+    payload: new Uint8Array([0xf0, 0x9f]),
+  });
+  self.postMessage({
+    type: "otp:stderr",
+    payload: new Uint8Array([0xf0, 0x9f, 0x9a]),
+  });
+  self.postMessage({
+    type: "otp:stdout",
+    payload: new Uint8Array([0x91, 0xa9, 0xe2, 0x80]),
+  });
+  self.postMessage({
+    type: "otp:stdout",
+    payload: new Uint8Array([0x8d, 0xf0, 0x9f, 0x9a, 0x80]),
+  });
+  self.postMessage({
+    type: "otp:stderr",
+    payload: new Uint8Array([0x80]),
+  });
+  self.postMessage({ type: "popcorn:boot-end", payload: {} });
+};

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -20,6 +20,8 @@ const DEFAULT_HOME_DIR = "/home/web_user";
 const FS_DIRS = ["/bin", "/lib", "/etc", "/tmp", "/home", DEFAULT_HOME_DIR];
 const BOOT_NAME = "vm";
 const BOOT_PATH = `/bin/${BOOT_NAME}.boot`;
+const STDOUT_FD = 1;
+const STDERR_FD = 2;
 const UTF8 = new TextEncoder();
 const BASE_ARGS = [
   "-root",
@@ -38,6 +40,8 @@ export async function boot({
   manifestUrl,
   emulatorArgs,
   extraArgs,
+  env,
+  ttySize,
   createModule,
   emit,
 }: BeamBootOptions): Promise<Result<EmscriptenModule>> {
@@ -47,9 +51,20 @@ export async function boot({
   }
 
   const fsData = loadedFsData.data;
+  const runtimeEnv = {
+    ...env,
+    BINDIR: "/bin",
+    EMU: "beam",
+    HOME: DEFAULT_HOME_DIR,
+    USER: DEFAULT_USER,
+    LOGNAME: DEFAULT_USER,
+    COLUMNS: String(ttySize.columns),
+    LINES: String(ttySize.rows),
+  };
   const moduleConfig: Partial<EmscriptenModule> = {
-    print: (text) => emit({ type: "otp:stdout", payload: text }),
-    printErr: (text) => emit({ type: "otp:stderr", payload: text }),
+    print: (text) => emit({ type: "otp:stdout", payload: UTF8.encode(text) }),
+    printErr: (text) =>
+      emit({ type: "otp:stderr", payload: UTF8.encode(text) }),
     onExit: (code) =>
       emit({ type: "otp:error", payload: { kind: "exit", data: code } }),
     onAbort: (text) =>
@@ -62,6 +77,8 @@ export async function boot({
     },
     onError: (text) =>
       emit({ type: "otp:error", payload: { kind: "error", data: text } }),
+    onStdinConsumed: (size) =>
+      emit({ type: "otp:stdin-consumed", payload: size }),
     onTrackedValueDelete: (key) =>
       emit({ type: "otp:tracked-value-delete", payload: key }),
     arguments: buildArgs({
@@ -70,14 +87,13 @@ export async function boot({
       emulator: emulatorArgs ?? [],
       extra: extraArgs ?? [],
     }),
-    ENV: {
-      BINDIR: "/bin",
-      EMU: "beam",
-      HOME: DEFAULT_HOME_DIR,
-      USER: DEFAULT_USER,
-      LOGNAME: DEFAULT_USER,
-    },
-    preRun: [(mod) => initFs({ module: mod, fsData })],
+    preRun: [
+      (mod) => {
+        Object.assign(mod.ENV, runtimeEnv);
+        forwardTtyOutput(mod, emit);
+        initFs({ module: mod, fsData });
+      },
+    ],
   };
 
   try {
@@ -86,6 +102,25 @@ export async function boot({
   } catch (error) {
     return { ok: false, error: toPopcornError(error) };
   }
+}
+
+function forwardTtyOutput(
+  module: EmscriptenModule,
+  emit: BeamBootOptions["emit"],
+): void {
+  const originalWrite = module.TTY.stream_ops.write;
+  module.TTY.stream_ops.write = (stream, buffer, offset, length, position) => {
+    const interceptable = stream.fd === STDOUT_FD || stream.fd === STDERR_FD;
+    if (!interceptable) {
+      return originalWrite(stream, buffer, offset, length, position);
+    }
+
+    const chunk = new Uint8Array(length);
+    chunk.set(buffer.subarray(offset, offset + length));
+    const type = stream.fd === STDOUT_FD ? "otp:stdout" : "otp:stderr";
+    emit({ type, payload: chunk });
+    return length;
+  };
 }
 
 function toPopcornError(error: unknown): PopcornError {

--- a/otp/js/src/errors.ts
+++ b/otp/js/src/errors.ts
@@ -1,6 +1,9 @@
 export type Result<T, E extends Tag = Tag> =
   | { ok: true; data: T }
-  | { ok: false; error: PopcornError<E> };
+  | {
+      ok: false;
+      error: PopcornError<E>;
+    };
 
 type Tag = keyof PopcornErrors;
 export type PopcornErrors = {
@@ -16,6 +19,7 @@ export type PopcornErrors = {
   "genserver:noproc": { target: string };
   "genserver:exit": { reason: string };
   "genserver:unserializable": EmptyData;
+  "stdio:overflow": { capacityBytes: number; attemptedBytes: number };
   "beam:missing-boot-script": { url: string };
   "beam:missing-manifest": { url: string };
   "beam:missing-tarball": { name: string; all: string[] };
@@ -123,6 +127,8 @@ function message(error: SerializedError): string {
       return `Genserver exited: ${error.data.reason}`;
     case "genserver:unserializable":
       return "Genserver reply can't be serialized to JSON";
+    case "stdio:overflow":
+      return `Stdin chunk exceeds the ${error.data.capacityBytes} byte queue capacity`;
     case "beam:missing-boot-script":
       return `Missing boot script: '${error.data.url}'`;
     case "beam:missing-manifest":
@@ -167,6 +173,9 @@ function parse(value: unknown): SerializedError {
     case "bridge:listener-not-found":
       check(isListenerNotFoundData(value.data));
       return { t: value.t, data: value.data };
+    case "stdio:overflow":
+      check(isStdioOverflowData(value.data));
+      return { t: value.t, data: value.data };
     case "beam:missing-boot-script":
     case "beam:missing-manifest":
       check(isUrlData(value.data));
@@ -186,9 +195,7 @@ function parse(value: unknown): SerializedError {
   }
 }
 
-function isTimeoutData(
-  value: unknown,
-): value is PopcornErrors["timeout:init"] {
+function isTimeoutData(value: unknown): value is PopcornErrors["timeout:init"] {
   return objectWithKeys(value, ["timeoutMs"]) !== null;
 }
 
@@ -206,6 +213,12 @@ function isListenerNotFoundData(
   value: unknown,
 ): value is PopcornErrors["bridge:listener-not-found"] {
   return objectWithKeys(value, ["targetName"]) !== null;
+}
+
+function isStdioOverflowData(
+  value: unknown,
+): value is PopcornErrors["stdio:overflow"] {
+  return objectWithKeys(value, ["capacityBytes", "attemptedBytes"]) !== null;
 }
 
 function isUnserializableData(

--- a/otp/js/src/events.ts
+++ b/otp/js/src/events.ts
@@ -7,14 +7,29 @@ import type {
   BeamSendPayload,
   BeamTarget,
 } from "./types";
-import { base64ToBytes, check, objectWithKeys } from "./utils";
+import { base64ToBytes, check, objectWithKeys, unreachable } from "./utils";
 
 type BootEvent = {
   type: "popcorn:boot";
   payload: Pick<
     BeamBootOptions,
-    "manifestUrl" | "emulatorArgs" | "extraArgs"
+    "manifestUrl" | "emulatorArgs" | "extraArgs" | "env" | "ttySize"
   >;
+};
+
+type StdinEvent = {
+  type: "popcorn:stdin";
+  payload: { chunk: Uint8Array };
+};
+
+type StdinCloseEvent = {
+  type: "popcorn:stdin-close";
+  payload: {};
+};
+
+type TtyResizeEvent = {
+  type: "popcorn:tty-resize";
+  payload: { columns: number; rows: number };
 };
 
 type SendEvent = {
@@ -37,8 +52,7 @@ export type SendRequestPayload = {
 };
 
 export type SerializedSendResult =
-  | { ok: true; data: null }
-  | { ok: false; error: SerializedError };
+  { ok: true; data: null } | { ok: false; error: SerializedError };
 
 export type SendCompletionPayload = {
   id: string;
@@ -54,7 +68,13 @@ type BootEndEvent =
   | { type: "popcorn:boot-end"; payload: {} }
   | { type: "popcorn:boot-fail"; payload: SerializedError };
 
-export type MainToVmEvent = BootEvent | SendEvent | RunJsReplyEvent;
+export type MainToVmEvent =
+  | BootEvent
+  | SendEvent
+  | RunJsReplyEvent
+  | StdinEvent
+  | StdinCloseEvent
+  | TtyResizeEvent;
 
 export type PopcornEvent = AnyValue;
 
@@ -79,27 +99,26 @@ type BridgeEnvelope =
       return: "value" | "ref";
     };
 
-export function readMainEvent(value: unknown): MainToVmEvent | null {
+export function readMainEvent(value: unknown): MainToVmEvent {
   const data = objectWithKeys(value, ["type", "payload"]);
-  if (data === null || typeof data.type !== "string") {
-    return null;
-  }
+  check(data !== null && typeof data.type === "string");
 
   switch (data.type) {
     case "popcorn:boot":
+    case "popcorn:stdin":
+    case "popcorn:stdin-close":
+    case "popcorn:tty-resize":
     case "popcorn:send":
     case "popcorn:run-js-reply":
       return data as MainToVmEvent;
     default:
-      return null;
+      unreachable();
   }
 }
 
-export function readWorkerEvent(value: unknown): VmToMainEvent | null {
+export function readWorkerEvent(value: unknown): VmToMainEvent {
   const data = objectWithKeys(value, ["type", "payload"]);
-  if (data === null || typeof data.type !== "string") {
-    return null;
-  }
+  check(data !== null && typeof data.type === "string");
 
   switch (data.type) {
     case "otp:stdout":
@@ -112,8 +131,11 @@ export function readWorkerEvent(value: unknown): VmToMainEvent | null {
     case "popcorn:boot-fail":
     case "popcorn:send-end":
       return data as VmToMainEvent;
+    case "otp:stdin-consumed":
+      check(Number(data.payload) > 0);
+      return data as VmToMainEvent;
     default:
-      return null;
+      unreachable();
   }
 }
 
@@ -186,7 +208,14 @@ export function toVm(
 
 /** Usable only from webworkers. */
 export function toMain(event: VmToMainEvent): void {
-  self.postMessage(event);
+  self.postMessage(event, { transfer: getTransferables(event) });
+}
+
+function getTransferables(event: VmToMainEvent): Transferable[] {
+  const isTtyEvent = event.type === "otp:stdout" || event.type === "otp:stderr";
+  if (!isTtyEvent) return [];
+  check(event.payload.buffer instanceof ArrayBuffer);
+  return [event.payload.buffer];
 }
 
 function isBridgeEnvelope(value: unknown): value is BridgeEnvelope {

--- a/otp/js/src/index.ts
+++ b/otp/js/src/index.ts
@@ -4,5 +4,5 @@ export { a, atom, t, tuple } from "./etf";
 export { Popcorn, schedulers } from "./popcorn";
 export type { PopcornOpts, SchedulerOptions, GenServer } from "./popcorn";
 export type { PopcornEvent } from "./events";
-export type { Pid, OtpErrorPayload } from "./types";
-export type { PopcornErrors, SerializedError, Result } from "./errors";
+export type { Pid, OtpErrorPayload, TtySize } from "./types";
+export type { PopcornErrors, Result, SerializedError } from "./errors";

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -28,25 +28,34 @@ const UTF8 = new TextEncoder();
 const STDIN_QUEUE_CAPACITY_BYTES = 64 * 1024;
 const DEFAULT_TTY_SIZE: TtySize = { columns: 80, rows: 24 };
 
-export type PopcornOpts = {
+type TtyOutput = "text" | "bytes";
+type OutputChunk<Output extends TtyOutput> = Output extends "bytes"
+  ? Uint8Array
+  : string;
+
+export type PopcornOpts<Output extends TtyOutput = "text"> = {
   beam: Pick<
     BeamBootOptions,
     "manifestUrl" | "emulatorArgs" | "extraArgs" | "env"
   >;
-  ttySize?: TtySize;
+  tty?: {
+    size?: TtySize;
+    output?: Output;
+  };
   timeoutsMs?: {
     boot?: number;
     send?: number;
   };
-  onStdout?: (chunk: Uint8Array) => void;
-  onStderr?: (chunk: Uint8Array) => void;
+  onStdout?: (chunk: OutputChunk<Output>) => void;
+  onStderr?: (chunk: OutputChunk<Output>) => void;
   onError?: (event: OtpErrorPayload) => void;
   workerUrl?: string | URL;
 };
 
 type ResolvedTimeouts = Required<NonNullable<PopcornOpts["timeoutsMs"]>>;
-type ResolvedPopcornOpts = Omit<PopcornOpts, "ttySize"> & {
-  ttySize: TtySize;
+type OutputHandlers = {
+  stdout: (chunk: Uint8Array) => void;
+  stderr: (chunk: Uint8Array) => void;
 };
 const DEFAULT_TIMEOUTS_MS: ResolvedTimeouts = {
   boot: 10_000,
@@ -162,12 +171,14 @@ function assertRunJsFn(value: unknown): asserts value is RunJsFn {
   check(typeof value === "function");
 }
 
-export class Popcorn {
+export class Popcorn<Output extends TtyOutput = "text"> {
   private vmWorker!: Worker;
   private state: PopcornState = { status: "created" };
-  private readonly opts: ResolvedPopcornOpts;
+  private readonly opts: PopcornOpts<Output>;
+  private readonly ttySize: TtySize;
+  private output: OutputHandlers;
   private requestSeq = 0;
-  private settleBoot: ((result: Result<Popcorn>) => void) | null = null;
+  private settleBoot: ((result: Result<Popcorn<Output>>) => void) | null = null;
   private readonly eventHandlers = new Set<(event: PopcornEvent) => void>();
   private readonly pendingSends = new Map<string, PendingSend>();
   private readonly pendingCalls = new Map<string, PendingCall>();
@@ -227,8 +238,8 @@ export class Popcorn {
     }
   };
 
-  public constructor(opts: PopcornOpts) {
-    const ttySize = opts.ttySize ?? DEFAULT_TTY_SIZE;
+  public constructor(opts: PopcornOpts<Output>) {
+    const ttySize = opts.tty?.size ?? DEFAULT_TTY_SIZE;
     check(isValidTtySize(ttySize));
     this.opts = {
       ...opts,
@@ -238,8 +249,9 @@ export class Popcorn {
           opts.beam.emulatorArgs ??
           schedulers({ base: 1, dirtyCpu: 1, dirtyIo: 1 }),
       },
-      ttySize: { ...ttySize },
     };
+    this.ttySize = { ...ttySize };
+    this.output = resolveOutputHandlers(opts);
     this.spawnWorker();
   }
 
@@ -250,7 +262,9 @@ export class Popcorn {
     this.vmWorker.addEventListener("message", this.onWorkerMessage);
   }
 
-  public static async init(opts: PopcornOpts): Promise<Result<Popcorn>> {
+  public static async init<Output extends TtyOutput = "text">(
+    opts: PopcornOpts<Output>,
+  ): Promise<Result<Popcorn<Output>>> {
     if (!canEval()) {
       return { ok: false, error: err("runtime:eval-unavailable", {}) };
     }
@@ -265,7 +279,7 @@ export class Popcorn {
     return { ok: true, data: popcorn };
   }
 
-  public async boot(): Promise<Result<Popcorn>> {
+  public async boot(): Promise<Result<Popcorn<Output>>> {
     if (this.state.status === "booted") {
       return { ok: true, data: this };
     }
@@ -285,12 +299,13 @@ export class Popcorn {
 
     this.Pid = createPidClass();
     this.io = createIoState();
+    this.output = resolveOutputHandlers(this.opts);
     this.state = { status: "booting" };
 
-    return await new Promise<Result<Popcorn>>((resolve) => {
+    return await new Promise<Result<Popcorn<Output>>>((resolve) => {
       const timeoutsMs = { ...DEFAULT_TIMEOUTS_MS, ...this.opts.timeoutsMs };
 
-      const settle = (result: Result<Popcorn>) => {
+      const settle = (result: Result<Popcorn<Output>>) => {
         if (this.settleBoot === null) return;
         clearTimeout(timer);
         cleanup();
@@ -333,7 +348,7 @@ export class Popcorn {
       this.vmWorker.addEventListener("message", onBootMessage);
       toVm(this.vmWorker, {
         type: "popcorn:boot",
-        payload: { ...this.opts.beam, ttySize: this.opts.ttySize },
+        payload: { ...this.opts.beam, ttySize: this.ttySize },
       });
     });
   }
@@ -742,13 +757,11 @@ export class Popcorn {
   }
 
   private handleStdout(chunk: Uint8Array): void {
-    const onStdout = this.opts.onStdout ?? defaultOnStdout;
-    onStdout(chunk);
+    this.output.stdout(chunk);
   }
 
   private handleStderr(chunk: Uint8Array): void {
-    const onStderr = this.opts.onStderr ?? defaultOnStderr;
-    onStderr(chunk);
+    this.output.stderr(chunk);
   }
 
   private handleOtpError(payload: OtpErrorPayload): void {
@@ -790,6 +803,40 @@ function isValidTtySize({ columns, rows }: TtySize): boolean {
   const colInRange = 0 < columns && columns <= 0xffff;
   const rowInRange = 0 < rows && rows <= 0xffff;
   return colInRange && rowInRange;
+}
+
+function resolveOutputHandlers<Output extends TtyOutput>(
+  opts: PopcornOpts<Output>,
+): OutputHandlers {
+  type BytesHandler = (chunk: Uint8Array) => void;
+  type TextHandler = (chunk: string) => void;
+
+  if (opts.tty?.output === "bytes") {
+    const onStdout = opts.onStdout as BytesHandler | undefined;
+    const onStderr = opts.onStderr as BytesHandler | undefined;
+    return {
+      stdout: onStdout ?? defaultOnStdoutBytes,
+      stderr: onStderr ?? defaultOnStderrBytes,
+    };
+  }
+
+  const stdoutDecoder = new TextDecoder();
+  const stderrDecoder = new TextDecoder();
+  const onStdout = (opts.onStdout as TextHandler | undefined) ?? defaultOnStdout;
+  const onStderr = (opts.onStderr as TextHandler | undefined) ?? defaultOnStderr;
+  return {
+    stdout: (chunk) => decodeOutput(stdoutDecoder, onStdout, chunk),
+    stderr: (chunk) => decodeOutput(stderrDecoder, onStderr, chunk),
+  };
+}
+
+function decodeOutput(
+  decoder: TextDecoder,
+  onOutput: (chunk: string) => void,
+  chunk: Uint8Array,
+): void {
+  const output = decoder.decode(chunk, { stream: true });
+  if (output.length > 0) onOutput(output);
 }
 
 function createIoState() {
@@ -859,11 +906,19 @@ function canEval(): boolean {
   }
 }
 
-function defaultOnStdout(chunk: Uint8Array): void {
+function defaultOnStdout(chunk: string): void {
   console.log(`${LOG_PREFIX} stdout:`, chunk);
 }
 
-function defaultOnStderr(chunk: Uint8Array): void {
+function defaultOnStderr(chunk: string): void {
+  console.error(`${LOG_PREFIX} stderr:`, chunk);
+}
+
+function defaultOnStdoutBytes(chunk: Uint8Array): void {
+  console.log(`${LOG_PREFIX} stdout:`, chunk);
+}
+
+function defaultOnStderrBytes(chunk: Uint8Array): void {
   console.error(`${LOG_PREFIX} stderr:`, chunk);
 }
 

--- a/otp/js/src/popcorn.ts
+++ b/otp/js/src/popcorn.ts
@@ -15,6 +15,7 @@ import type {
   OtpErrorPayload,
   Pid,
   RunJsRequest,
+  TtySize,
 } from "./types";
 import { base64ToBytes, check, objectWithKeys, unreachable } from "./utils";
 
@@ -23,20 +24,30 @@ type PendingTracked = TrackedEntry & { key: number };
 
 const TRACKED_REF_KEY = "popcorn_ref";
 const PID_REF_KEY = "popcorn_pid";
+const UTF8 = new TextEncoder();
+const STDIN_QUEUE_CAPACITY_BYTES = 64 * 1024;
+const DEFAULT_TTY_SIZE: TtySize = { columns: 80, rows: 24 };
 
 export type PopcornOpts = {
-  beam: Pick<BeamBootOptions, "manifestUrl" | "emulatorArgs" | "extraArgs">;
+  beam: Pick<
+    BeamBootOptions,
+    "manifestUrl" | "emulatorArgs" | "extraArgs" | "env"
+  >;
+  ttySize?: TtySize;
   timeoutsMs?: {
     boot?: number;
     send?: number;
   };
-  onStdout?: (text: string) => void;
-  onStderr?: (text: string) => void;
+  onStdout?: (chunk: Uint8Array) => void;
+  onStderr?: (chunk: Uint8Array) => void;
   onError?: (event: OtpErrorPayload) => void;
   workerUrl?: string | URL;
 };
 
 type ResolvedTimeouts = Required<NonNullable<PopcornOpts["timeoutsMs"]>>;
+type ResolvedPopcornOpts = Omit<PopcornOpts, "ttySize"> & {
+  ttySize: TtySize;
+};
 const DEFAULT_TIMEOUTS_MS: ResolvedTimeouts = {
   boot: 10_000,
   send: 5_000,
@@ -154,7 +165,7 @@ function assertRunJsFn(value: unknown): asserts value is RunJsFn {
 export class Popcorn {
   private vmWorker!: Worker;
   private state: PopcornState = { status: "created" };
-  private readonly opts: PopcornOpts;
+  private readonly opts: ResolvedPopcornOpts;
   private requestSeq = 0;
   private settleBoot: ((result: Result<Popcorn>) => void) | null = null;
   private readonly eventHandlers = new Set<(event: PopcornEvent) => void>();
@@ -163,6 +174,7 @@ export class Popcorn {
   private callSeq = 0;
   private readonly trackedValues = new Map<number, TrackedEntry>();
   private trackedKeySeq = 0;
+  private io = createIoState();
 
   public readonly genserver: GenServer = {
     call: (target, request, opts) => this.call(target, request, opts),
@@ -179,7 +191,6 @@ export class Popcorn {
   private Pid = createPidClass();
   private readonly onWorkerMessage = (event: MessageEvent<unknown>) => {
     const data = readWorkerEvent(event.data);
-    check(data !== null);
 
     switch (data.type) {
       case "popcorn:boot-end":
@@ -200,6 +211,10 @@ export class Popcorn {
       case "otp:stderr":
         this.handleStderr(data.payload);
         return;
+      case "otp:stdin-consumed":
+        check(data.payload > 0 && data.payload <= this.io.stdin.reservedBytes);
+        this.io.stdin.reservedBytes -= data.payload;
+        return;
       case "otp:error":
         this.handleOtpError(data.payload);
         return;
@@ -213,6 +228,8 @@ export class Popcorn {
   };
 
   public constructor(opts: PopcornOpts) {
+    const ttySize = opts.ttySize ?? DEFAULT_TTY_SIZE;
+    check(isValidTtySize(ttySize));
     this.opts = {
       ...opts,
       beam: {
@@ -221,6 +238,7 @@ export class Popcorn {
           opts.beam.emulatorArgs ??
           schedulers({ base: 1, dirtyCpu: 1, dirtyIo: 1 }),
       },
+      ttySize: { ...ttySize },
     };
     this.spawnWorker();
   }
@@ -266,6 +284,7 @@ export class Popcorn {
     }
 
     this.Pid = createPidClass();
+    this.io = createIoState();
     this.state = { status: "booting" };
 
     return await new Promise<Result<Popcorn>>((resolve) => {
@@ -289,7 +308,6 @@ export class Popcorn {
 
       const onBootMessage = (event: MessageEvent<unknown>) => {
         const data = readWorkerEvent(event.data);
-        check(data !== null);
 
         switch (data.type) {
           case "popcorn:boot-end":
@@ -313,8 +331,59 @@ export class Popcorn {
       };
 
       this.vmWorker.addEventListener("message", onBootMessage);
-      toVm(this.vmWorker, { type: "popcorn:boot", payload: this.opts.beam });
+      toVm(this.vmWorker, {
+        type: "popcorn:boot",
+        payload: { ...this.opts.beam, ttySize: this.opts.ttySize },
+      });
     });
+  }
+
+  public writeStdin(chunk: string | Uint8Array): Result<null> {
+    if (this.state.status === "closed") {
+      return { ok: false, error: this.state.error };
+    }
+    check(this.state.status === "booted");
+    check(
+      !this.io.stdin.closed,
+      "ctrl-d (byte 0x04) was sent to input stream before, stdin is closed",
+    );
+
+    const bytes = toBytes(chunk);
+    check(bytes.byteLength > 0);
+    if (isEof(bytes)) {
+      this.io.stdin.closed = true;
+      toVm(this.vmWorker, { type: "popcorn:stdin-close", payload: {} });
+      return { ok: true, data: null };
+    }
+
+    const attemptedBytes = this.io.stdin.reservedBytes + bytes.byteLength;
+    if (attemptedBytes > STDIN_QUEUE_CAPACITY_BYTES) {
+      const error = err("stdio:overflow", {
+        capacityBytes: STDIN_QUEUE_CAPACITY_BYTES,
+        attemptedBytes,
+      });
+      return { ok: false, error };
+    }
+
+    this.io.stdin.reservedBytes = attemptedBytes;
+    const event = { type: "popcorn:stdin", payload: { chunk: bytes } } as const;
+    toVm(this.vmWorker, event, [bytes.buffer]);
+
+    return { ok: true, data: null };
+  }
+
+  public resizeTty(columns: number, rows: number): Result<null> {
+    if (this.state.status === "closed") {
+      return { ok: false, error: this.state.error };
+    }
+    check(this.state.status === "booted");
+    check(isValidTtySize({ columns, rows }));
+
+    toVm(this.vmWorker, {
+      type: "popcorn:tty-resize",
+      payload: { columns, rows },
+    });
+    return { ok: true, data: null };
   }
 
   /**
@@ -672,14 +741,14 @@ export class Popcorn {
     return `send:${this.requestSeq}`;
   }
 
-  private handleStdout(text: string): void {
+  private handleStdout(chunk: Uint8Array): void {
     const onStdout = this.opts.onStdout ?? defaultOnStdout;
-    onStdout(text);
+    onStdout(chunk);
   }
 
-  private handleStderr(text: string): void {
+  private handleStderr(chunk: Uint8Array): void {
     const onStderr = this.opts.onStderr ?? defaultOnStderr;
-    onStderr(text);
+    onStderr(chunk);
   }
 
   private handleOtpError(payload: OtpErrorPayload): void {
@@ -715,6 +784,30 @@ export function schedulers(opts: SchedulerOptions): string[] {
   check(dirtyIo > 0);
 
   return ["-S", base, "-SDcpu", dirtyCpu, "-SDio", dirtyIo].map(String);
+}
+
+function isValidTtySize({ columns, rows }: TtySize): boolean {
+  const colInRange = 0 < columns && columns <= 0xffff;
+  const rowInRange = 0 < rows && rows <= 0xffff;
+  return colInRange && rowInRange;
+}
+
+function createIoState() {
+  return {
+    stdin: {
+      closed: false,
+      reservedBytes: 0,
+    },
+  };
+}
+
+function toBytes(chunk: string | Uint8Array): Uint8Array {
+  return typeof chunk === "string" ? UTF8.encode(chunk) : chunk.slice();
+}
+
+function isEof(bytes: Uint8Array): boolean {
+  const CTRL_D_BYTE = 0x04;
+  return bytes.byteLength === 1 && bytes[0] === CTRL_D_BYTE;
 }
 
 function exitReason(payload: OtpErrorPayload): VmExitReason {
@@ -766,12 +859,12 @@ function canEval(): boolean {
   }
 }
 
-function defaultOnStdout(text: string): void {
-  console.log(`${LOG_PREFIX} stdout:`, text);
+function defaultOnStdout(chunk: Uint8Array): void {
+  console.log(`${LOG_PREFIX} stdout:`, chunk);
 }
 
-function defaultOnStderr(text: string): void {
-  console.error(`${LOG_PREFIX} stderr:`, text);
+function defaultOnStderr(chunk: Uint8Array): void {
+  console.error(`${LOG_PREFIX} stderr:`, chunk);
 }
 
 function defaultOnError(payload: OtpErrorPayload): void {

--- a/otp/js/src/types.ts
+++ b/otp/js/src/types.ts
@@ -17,13 +17,16 @@ export type BeamBootOptions = {
   manifestUrl: string;
   emulatorArgs?: string[];
   extraArgs?: string[];
+  env?: Record<string, string>;
+  ttySize: TtySize;
   createModule: CreateModuleFn<EmscriptenModule>;
   emit: (event: BeamEvent) => void;
 };
 
 export type BeamEvent =
-  | { type: "otp:stdout"; payload: string }
-  | { type: "otp:stderr"; payload: string }
+  | { type: "otp:stdout"; payload: Uint8Array }
+  | { type: "otp:stderr"; payload: Uint8Array }
+  | { type: "otp:stdin-consumed"; payload: number }
   | { type: "otp:error"; payload: OtpErrorPayload }
   | { type: "otp:message"; payload: AnyValue }
   | { type: "otp:run_js"; payload: RunJsRequest }
@@ -41,6 +44,11 @@ export type OtpErrorPayload =
   | { kind: "error"; data: string }
   | { kind: "exit"; data: number };
 
+export type TtySize = {
+  columns: number;
+  rows: number;
+};
+
 export type EmscriptenFS = {
   mkdir: (path: string) => void;
   writeFile: (path: string, data: Uint8Array) => void;
@@ -50,11 +58,20 @@ export type EmscriptenFS = {
   ) => Uint8Array | string;
 };
 
+type TtyWrite = (
+  stream: { fd: number },
+  buffer: Uint8Array,
+  offset: number,
+  length: number,
+  position: number,
+) => number;
+
 /** Emscripten Module interface (subset exposed after instantiation). */
 export type EmscriptenModule = {
   ENV: Record<string, string>;
   FS: EmscriptenFS;
   HEAPU8: Uint8Array;
+  TTY: { stream_ops: { write: TtyWrite } };
   ccall: (
     ident: string,
     returnType: string | null,
@@ -71,6 +88,7 @@ export type EmscriptenModule = {
   _free: (ptr: number) => void;
   onBeamMessage?: (text: string) => void | Promise<void>;
   onError?: (text: string) => void | Promise<void>;
+  onStdinConsumed?: (size: number) => void;
   onTrackedValueDelete?: (key: number) => void;
   addRunDependency: (id: string) => void;
   removeRunDependency: (id: string) => void;

--- a/otp/js/src/worker.ts
+++ b/otp/js/src/worker.ts
@@ -9,7 +9,6 @@ let instance: EmscriptenModule | null = null;
 
 self.onmessage = async (event: MessageEvent<unknown>) => {
   const data = readMainEvent(event.data);
-  check(data !== null);
 
   switch (data.type) {
     case "popcorn:boot": {
@@ -19,6 +18,8 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
         manifestUrl: data.payload.manifestUrl,
         emulatorArgs: data.payload.emulatorArgs,
         extraArgs: data.payload.extraArgs,
+        env: data.payload.env,
+        ttySize: data.payload.ttySize,
         createModule,
         emit: toMain,
       });
@@ -50,6 +51,34 @@ self.onmessage = async (event: MessageEvent<unknown>) => {
     case "popcorn:run-js-reply": {
       // ignore the `send()` result, process could've died
       send(instance, data.payload.message);
+      break;
+    }
+    case "popcorn:stdin": {
+      check(instance !== null);
+      const status = instance.ccall(
+        "popcornStdinEnqueue",
+        "number",
+        ["array", "number"],
+        [data.payload.chunk, data.payload.chunk.byteLength],
+      );
+      check(status === 0);
+      break;
+    }
+    case "popcorn:stdin-close": {
+      check(instance !== null);
+      const status = instance.ccall("popcornStdinClose", "number", [], []);
+      check(status === 0);
+      break;
+    }
+    case "popcorn:tty-resize": {
+      check(instance !== null);
+      const status = instance.ccall(
+        "popcornTtyResize",
+        "number",
+        ["number", "number"],
+        [data.payload.columns, data.payload.rows],
+      );
+      check(status === 0);
       break;
     }
     default:

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -230,14 +230,16 @@ index d5b3b9d52b710538f0c3a94ad62dcb54654ac12a..6702ab0f2a2fc3adc2b089c0e125eda3
              erts_add_taint(dp->name_atom);
 diff --git a/erts/emulator/js_bridge/beam-bridge.pre.js b/erts/emulator/js_bridge/beam-bridge.pre.js
 new file mode 100644
-index 0000000000000000000000000000000000000000..2e85c729e92e9948fd15302a88ed12a4d3bfbe60
+index 0000000000000000000000000000000000000000..a01c5d18cd1c394a85535694775299d279876c61
 --- /dev/null
 +++ b/erts/emulator/js_bridge/beam-bridge.pre.js
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,24 @@
 +var __beamBridgeOnMessage =
 +  typeof Module['onBeamMessage'] === 'function' ? Module['onBeamMessage'] : null;
 +var __beamBridgeOnError =
 +  typeof Module['onError'] === 'function' ? Module['onError'] : null;
++var __beamBridgeOnStdinConsumed =
++  typeof Module['onStdinConsumed'] === 'function' ? Module['onStdinConsumed'] : null;
 +
 +Module['onBeamMessage'] = function(envelope) {
 +  if (typeof __beamBridgeOnMessage === 'function') {
@@ -250,12 +252,18 @@ index 0000000000000000000000000000000000000000..2e85c729e92e9948fd15302a88ed12a4
 +    __beamBridgeOnError(envelope);
 +  }
 +};
++
++Module['onStdinConsumed'] = function(size) {
++  if (typeof __beamBridgeOnStdinConsumed === 'function') {
++    __beamBridgeOnStdinConsumed(size);
++  }
++};
 diff --git a/erts/emulator/js_bridge/js_bridge.js b/erts/emulator/js_bridge/js_bridge.js
 new file mode 100644
-index 0000000000000000000000000000000000000000..ed09e8dd4ff11df4fe5e8b9adcb4dc7036722f5c
+index 0000000000000000000000000000000000000000..80870eaa00f0d8e57f8987457378adc08c15a0cb
 --- /dev/null
 +++ b/erts/emulator/js_bridge/js_bridge.js
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,42 @@
 +mergeInto(LibraryManager.library, {
 +  js_bridge_on_from_beam_async__proxy: 'async',
 +  js_bridge_on_from_beam_async__sig: 'vii',
@@ -289,10 +297,332 @@ index 0000000000000000000000000000000000000000..ed09e8dd4ff11df4fe5e8b9adcb4dc70
 +      Module['onError'](envelope);
 +    }
 +  },
++
++  js_bridge_on_stdin_consumed__proxy: 'async',
++  js_bridge_on_stdin_consumed__sig: 'vi',
++  js_bridge_on_stdin_consumed: function(size) {
++    if (typeof Module['onStdinConsumed'] === 'function') {
++      Module['onStdinConsumed'](size);
++    }
++  },
 +});
+diff --git a/erts/emulator/nifs/common/prim_tty_nif.c b/erts/emulator/nifs/common/prim_tty_nif.c
+index 6615c41065d22e8d9275efcd043b85594f36e4b0..820780659b35f8a9e9c7131af0c26989c07a7089 100644
+--- a/erts/emulator/nifs/common/prim_tty_nif.c
++++ b/erts/emulator/nifs/common/prim_tty_nif.c
+@@ -38,6 +38,7 @@
+ #include "erl_driver.h"
+ 
+ #include <errno.h>
++#include <stdlib.h>
+ #include <string.h>
+ #include <ctype.h>
+ #include <wchar.h>
+@@ -66,6 +67,9 @@
+ #ifdef HAVE_POLL_H
+ #include <poll.h>
+ #endif
++#ifdef __EMSCRIPTEN__
++#include <emscripten/emscripten.h>
++#endif
+ 
+ #if defined IOV_MAX
+ #define MAXIOV IOV_MAX
+@@ -109,6 +113,11 @@ typedef struct {
+ #endif
+     ErlNifPid self;
+     ErlNifPid reader;
++#ifdef __EMSCRIPTEN__
++    ErlNifEnv *select_env;
++    ERL_NIF_TERM select_ref;
++    int has_reader;
++#endif
+     enum TTYState tty;       /* if the tty is initialized */
+ #ifdef HAVE_TERMCAP
+     struct termios tty_smode;
+@@ -116,6 +125,105 @@ typedef struct {
+ #endif
+ } TTYResource;
+ 
++#ifdef __EMSCRIPTEN__
++#define POPCORN_STDIN_CAPACITY (64 * 1024)
++
++typedef struct {
++    ErlNifMutex *lock;
++    TTYResource *tty;
++    unsigned char data[POPCORN_STDIN_CAPACITY];
++    size_t head;
++    size_t size;
++    int closed;
++    int notified;
++    int columns;
++    int rows;
++} PopcornStdin;
++
++static PopcornStdin popcorn_stdin;
++
++extern void js_bridge_on_stdin_consumed(int size);
++
++static void popcorn_stdin_notify_locked(void) {
++    TTYResource *tty = popcorn_stdin.tty;
++    ErlNifEnv *env;
++    ERL_NIF_TERM message;
++
++    if (popcorn_stdin.notified || tty == NULL || !tty->has_reader)
++        return;
++
++    env = enif_alloc_env();
++    ASSERT(env != NULL);
++    message = enif_make_tuple4(
++        env,
++        enif_make_atom(env, "select"),
++        enif_make_resource(env, tty),
++        enif_make_copy(env, tty->select_ref),
++        enif_make_atom(env, "ready_input"));
++    enif_send(NULL, &tty->reader, env, message);
++    enif_free_env(env);
++    popcorn_stdin.notified = 1;
++}
++
++EMSCRIPTEN_KEEPALIVE
++int popcornStdinEnqueue(const unsigned char *data, int size) {
++    size_t tail;
++    size_t first;
++
++    ASSERT(data != NULL && size > 0);
++    enif_mutex_lock(popcorn_stdin.lock);
++    ASSERT(!popcorn_stdin.closed);
++    ASSERT((size_t)size <= POPCORN_STDIN_CAPACITY - popcorn_stdin.size);
++
++    tail = (popcorn_stdin.head + popcorn_stdin.size) % POPCORN_STDIN_CAPACITY;
++    first = MIN((size_t)size, POPCORN_STDIN_CAPACITY - tail);
++    memcpy(popcorn_stdin.data + tail, data, first);
++    memcpy(popcorn_stdin.data, data + first, (size_t)size - first);
++    popcorn_stdin.size += (size_t)size;
++    popcorn_stdin_notify_locked();
++    enif_mutex_unlock(popcorn_stdin.lock);
++    return 0;
++}
++
++EMSCRIPTEN_KEEPALIVE
++int popcornStdinClose(void) {
++    enif_mutex_lock(popcorn_stdin.lock);
++    ASSERT(!popcorn_stdin.closed);
++    popcorn_stdin.closed = 1;
++    popcorn_stdin_notify_locked();
++    enif_mutex_unlock(popcorn_stdin.lock);
++    return 0;
++}
++
++EMSCRIPTEN_KEEPALIVE
++int popcornTtyResize(int columns, int rows) {
++    TTYResource *tty;
++    ErlNifEnv *env;
++    ERL_NIF_TERM message;
++
++    ASSERT(columns > 0 && columns <= 65535 && rows > 0 && rows <= 65535);
++    enif_mutex_lock(popcorn_stdin.lock);
++    popcorn_stdin.columns = columns;
++    popcorn_stdin.rows = rows;
++    tty = popcorn_stdin.tty;
++    if (tty != NULL && tty->has_reader) {
++        env = enif_alloc_env();
++        ASSERT(env != NULL);
++        message = enif_make_tuple2(
++            env,
++            enif_make_copy(env, tty->select_ref),
++            enif_make_tuple2(
++                env,
++                enif_make_atom(env, "signal"),
++                enif_make_atom(env, "sigwinch")));
++        enif_send(NULL, &tty->self, env, message);
++        enif_free_env(env);
++    }
++    enif_mutex_unlock(popcorn_stdin.lock);
++    return 0;
++}
++#endif
++
+ // #define HARD_DEBUG
+ #ifdef HARD_DEBUG
+ static FILE *logFile = NULL;
+@@ -641,6 +749,34 @@ static ERL_NIF_TERM tty_read_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
+             return make_errno_error(env, errorFunction);
+         }
+     }
++#else
++#ifdef __EMSCRIPTEN__
++    {
++        size_t first;
++        size_t consumed;
++
++        enif_alloc_binary(n, &bin);
++        enif_mutex_lock(popcorn_stdin.lock);
++        popcorn_stdin.notified = 0;
++        consumed = MIN((size_t)n, popcorn_stdin.size);
++        if (consumed == 0 && popcorn_stdin.closed) {
++            enif_mutex_unlock(popcorn_stdin.lock);
++            enif_release_binary(&bin);
++            return make_error(env, enif_make_atom(env, "closed"));
++        }
++        first = MIN(consumed, POPCORN_STDIN_CAPACITY - popcorn_stdin.head);
++        memcpy(bin.data, popcorn_stdin.data + popcorn_stdin.head, first);
++        memcpy(bin.data + first, popcorn_stdin.data, consumed - first);
++        popcorn_stdin.head =
++            (popcorn_stdin.head + consumed) % POPCORN_STDIN_CAPACITY;
++        popcorn_stdin.size -= consumed;
++        res = (ssize_t)consumed;
++        if (popcorn_stdin.size > 0 || popcorn_stdin.closed)
++            popcorn_stdin_notify_locked();
++        enif_mutex_unlock(popcorn_stdin.lock);
++        if (consumed > 0)
++            js_bridge_on_stdin_consumed((int)consumed);
++    }
+ #else
+     enif_alloc_binary(n, &bin);
+     res = read(tty->ifd, bin.data, bin.size);
+@@ -654,9 +790,12 @@ static ERL_NIF_TERM tty_read_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
+         enif_release_binary(&bin);
+         return make_error(env, enif_make_atom(env, "closed"));
+     }
++#endif
+ #endif
+     debug("select on %d\r\n",select_event);
++#ifndef __EMSCRIPTEN__
+     enif_select(env, select_event, ERL_NIF_SELECT_READ, tty, NULL, argv[1]);
++#endif
+     if (res == bin.size) {
+ 	res_term = enif_make_binary(env, &bin);
+     } else if (res < bin.size / 2) {
+@@ -949,6 +1088,17 @@ static ERL_NIF_TERM tty_create_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM
+ 
+     enif_set_pid_undefined(&tty->self);
+     enif_set_pid_undefined(&tty->reader);
++#ifdef __EMSCRIPTEN__
++    tty->select_env = enif_alloc_env();
++    ASSERT(tty->select_env != NULL);
++    tty->has_reader = 0;
++    if (tty->ofd == 1) {
++        enif_mutex_lock(popcorn_stdin.lock);
++        ASSERT(popcorn_stdin.tty == NULL);
++        popcorn_stdin.tty = tty;
++        enif_mutex_unlock(popcorn_stdin.lock);
++    }
++#endif
+ 
+     return enif_make_tuple2(env, atom_ok, tty_term);
+ }
+@@ -1056,7 +1206,12 @@ static ERL_NIF_TERM tty_window_size_nif(ErlNifEnv* env, int argc, const ERL_NIF_
+     if (!enif_get_resource(env, argv[0], tty_rt, (void **)&tty))
+         return enif_make_badarg(env);
+     {
+-#ifdef TIOCGWINSZ
++#ifdef __EMSCRIPTEN__
++        enif_mutex_lock(popcorn_stdin.lock);
++        width = popcorn_stdin.columns;
++        height = popcorn_stdin.rows;
++        enif_mutex_unlock(popcorn_stdin.lock);
++#elif defined(TIOCGWINSZ)
+         struct winsize ws;
+         if (ioctl(tty->ifd,TIOCGWINSZ,&ws) == 0) {
+             if (ws.ws_col > 0)
+@@ -1106,9 +1261,20 @@ static ERL_NIF_TERM tty_select_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM
+     using_oldshell = 0;
+ #endif
+     debug("Select on %d\r\n", tty->ifd);
++#ifdef __EMSCRIPTEN__
++    enif_mutex_lock(popcorn_stdin.lock);
++    enif_clear_env(tty->select_env);
++    tty->select_ref = enif_make_copy(tty->select_env, argv[1]);
++    enif_self(env, &tty->reader);
++    tty->has_reader = 1;
++    if (popcorn_stdin.size > 0 || popcorn_stdin.closed)
++        popcorn_stdin_notify_locked();
++    enif_mutex_unlock(popcorn_stdin.lock);
++#else
+     enif_select(env, tty->ifd, ERL_NIF_SELECT_READ, tty, NULL, argv[1]);
+ 
+     enif_self(env, &tty->reader);
++#endif
+     enif_monitor_process(env, tty, &tty->reader, NULL);
+ 
+     return atom_ok;
+@@ -1122,7 +1288,14 @@ static void tty_monitor_down(ErlNifEnv* caller_env, void* obj, ErlNifPid* pid, E
+     }
+ #endif
+     if (enif_compare_pids(pid, &tty->reader) == 0) {
++#ifdef __EMSCRIPTEN__
++        enif_mutex_lock(popcorn_stdin.lock);
++        tty->has_reader = 0;
++        popcorn_stdin.notified = 0;
++        enif_mutex_unlock(popcorn_stdin.lock);
++#else
+         enif_select(caller_env, tty->ifd, ERL_NIF_SELECT_STOP, tty, NULL, atom_undefined);
++#endif
+     }
+ }
+ 
+@@ -1134,9 +1307,25 @@ static void tty_select_stop(ErlNifEnv* caller_env, void* obj, ErlNifEvent event,
+ #endif
+ }
+ 
++static void tty_dtor(ErlNifEnv* env, void* obj) {
++    (void)env;
++#ifdef __EMSCRIPTEN__
++    TTYResource *tty = obj;
++
++    enif_mutex_lock(popcorn_stdin.lock);
++    if (popcorn_stdin.tty == tty)
++        popcorn_stdin.tty = NULL;
++    enif_mutex_unlock(popcorn_stdin.lock);
++    if (tty->select_env != NULL)
++        enif_free_env(tty->select_env);
++#else
++    (void)obj;
++#endif
++}
++
+ static void load_resources(ErlNifEnv* env, ErlNifResourceFlags rt_flags) {
+     ErlNifResourceTypeInit rt = {
+-        NULL /* dtor */,
++        tty_dtor,
+         tty_select_stop,
+         tty_monitor_down};
+ 
+@@ -1150,13 +1339,29 @@ static void load_resources(ErlNifEnv* env, ErlNifResourceFlags rt_flags) {
+ static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
+ {
+     *priv_data = NULL;
++#ifdef __EMSCRIPTEN__
++    const char *columns;
++    const char *rows;
++
++    memset(&popcorn_stdin, 0, sizeof(popcorn_stdin));
++    popcorn_stdin.lock = enif_mutex_create("popcorn_stdin");
++    ASSERT(popcorn_stdin.lock != NULL);
++    columns = getenv("COLUMNS");
++    rows = getenv("LINES");
++    ASSERT(columns != NULL && rows != NULL);
++    popcorn_stdin.columns = atoi(columns);
++    popcorn_stdin.rows = atoi(rows);
++#endif
+     load_resources(env, ERL_NIF_RT_CREATE);
+     return 0;
+ }
+ 
+ static void unload(ErlNifEnv* env, void* priv_data)
+ {
+-
++#ifdef __EMSCRIPTEN__
++    enif_mutex_destroy(popcorn_stdin.lock);
++    popcorn_stdin.lock = NULL;
++#endif
+ }
+ 
+ static int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data,
 diff --git a/erts/emulator/nifs/common/wasm_nif.c b/erts/emulator/nifs/common/wasm_nif.c
 new file mode 100644
-index 0000000000000000000000000000000000000000..e39af2a963bdf9697de3e9f61d18d17629a7228d
+index 0000000000000000000000000000000000000000..ad4a8fa2b6776814a1e6e5ac83ecadfa242590f5
 --- /dev/null
 +++ b/erts/emulator/nifs/common/wasm_nif.c
 @@ -0,0 +1,645 @@


### PR DESCRIPTION
Putting data to stdin is needed for terminal applications (such as iex). Unfortunately, Emscripten don't work well enough for our cases, so we have another patch for the VM, which redirects the stdin to reading a queue shared with the JS. We process data in chunks and queue is bounded. This adds new `tty` options, where we can configure "terminal" size and type of output in our io callbacks(strings or bytes).