### PR TITLE
otp: avoid nested BEAM compression

### DIFF
--- a/otp/js/plugins/tarballs.exs
+++ b/otp/js/plugins/tarballs.exs
@@ -55,7 +55,9 @@ defmodule Tarballs do
   end
 
   defp strip_beam(content) do
-    :beam_lib.strip(content)
+    with {:ok, {module, stripped}} <- :beam_lib.strip(content) do
+      {:ok, {module, :zlib.gunzip(stripped)}}
+    end
   rescue
     _error -> :error
   end


### PR DESCRIPTION
:beam_lib.strip/1 compresses .beam files after stripping[^1] which is counterproductive when we gzip/brotli compress all apps to tarballs.

By avoiding that, we save about 30% brotli (3.5M -> 2.44M).


[^1]: https://github.com/erlang/otp/blob/OTP-29.0.4/lib/stdlib/src/beam_lib.erl#L806