### PR TITLE
otp: increase pool size

### DIFF
--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -1764,7 +1764,7 @@ index 0000000000000000000000000000000000000000..1170f6b6e2839f1246de95bffdc315c0
 +## Note: These are passed to emcc during linking
 +LDFLAGS="-pthread \
 +    -sUSE_PTHREADS=1 \
-+    -sPTHREAD_POOL_SIZE=4 \
++    -sPTHREAD_POOL_SIZE=8 \
 +    -sPROXY_TO_PTHREAD=1 \
 +    -sENVIRONMENT=web,worker,node \
 +    -sEXPORT_ES6=1 \

--- a/scripts/build-beam.sh
+++ b/scripts/build-beam.sh
@@ -281,7 +281,7 @@ run_configure() {
     # Linker flags
     export LDFLAGS="-pthread -flto"
     LDFLAGS+=" -sUSE_PTHREADS=1"
-    LDFLAGS+=" -sPTHREAD_POOL_SIZE=4"
+    LDFLAGS+=" -sPTHREAD_POOL_SIZE=8"
     LDFLAGS+=" -sPROXY_TO_PTHREAD=1"
     LDFLAGS+=" -sENVIRONMENT=web,worker,node"
     LDFLAGS+=" -sEXPORT_ES6=1"


### PR DESCRIPTION
Popcorn needs 8 threads (webworkers):
1. (proxied) main thread (PROXY_TO_PTHREAD)
2. bridge
3. async driver (+A 1)
4. process scheduler (+S 1)
5. dirty CPU scheduler (+SDcpu 1, used for big GC, prim_buffer searches >1MB, crypto)
6. dirty IO scheduler (+SDio 1, used for prim_file fs ops)
7. aux work thread (number of them based on: dirty alloc threads + `+S` threads number, currently 1, used for GC, timers, reaping ports)
8. poll thread (1, for select())

20 runs were tested (cold, warm).
Median time warm:
157.14 ms -> 133.71 ms (delta 24.07 ms, 15.3%)

Median time cold:
221.66 ms -> 199.55 ms (delta 19.02 ms, 8.6%)

Increases RSS by ~30MB (about 5% of baseline in the test harness).