### PR TITLE
treeshake: prepare for otp

### DIFF
--- a/popcorn/elixir/lib/treeshake/call_graph.ex
+++ b/popcorn/elixir/lib/treeshake/call_graph.ex
@@ -150,18 +150,25 @@ defmodule Treeshake.CallGraph do
       Enum.map(info.behaviour_impls, &{info.module, &1})
     end)
     |> Enum.flat_map(fn {module, behaviour} ->
-      case module_index[behaviour] do
-        %{abstraction: {:behaviour, callbacks}} ->
-          callbacks
-
-        nil ->
-          []
-
-        _non_behaviour ->
-          raise "Module #{module} implements #{behaviour} as if it was a behaviour, but it's not"
-      end
+      behaviour_callbacks(module_index[behaviour], module, behaviour)
       |> Enum.map(fn {f, a} -> {module, f, a} end)
     end)
+  end
+
+  defp behaviour_callbacks(%{abstraction: {:behaviour, callbacks}}, _module, _behaviour),
+    do: callbacks
+
+  defp behaviour_callbacks(nil, _module, behaviour) do
+    with {:module, ^behaviour} <- Code.ensure_loaded(behaviour),
+         true <- function_exported?(behaviour, :behaviour_info, 1) do
+      behaviour.behaviour_info(:callbacks)
+    else
+      _not_available -> []
+    end
+  end
+
+  defp behaviour_callbacks(_non_behaviour, module, behaviour) do
+    raise "Module #{module} implements #{behaviour} as if it was a behaviour, but it's not"
   end
 
   # When a module atom appears as a literal (e.g. passed to Supervisor.start_link),

--- a/popcorn/elixir/lib/treeshake/treeshake.ex
+++ b/popcorn/elixir/lib/treeshake/treeshake.ex
@@ -217,8 +217,11 @@ defmodule Treeshake do
     end
 
     stats = Treeshake.Shaker.shake(opts, call_graph, module_index)
+    stub_functions = Map.get(opts, :stub_removed_functions, false)
+    stub_modules = Map.get(opts, :stub_removed_modules, false)
+    add_stubs = stub_functions or stub_modules
 
-    unless opts.dry_run do
+    if not opts.dry_run and add_stubs do
       helper_path = :code.which(:treeshake_helper)
       File.cp!(helper_path, Path.join(opts.output_dir, Path.basename(helper_path)))
     end


### PR DESCRIPTION
- avoids adding helper when it's not needed.
- sidesteps the problem of otp packager not handling builtin apps by providing behaviour information from host (this has its drawbacks, maybe we should redesign packager in the future).