### PR TITLE
otp: treeshake packaged applications

### DIFF
--- a/otp/js/plugins/shared.ts
+++ b/otp/js/plugins/shared.ts
@@ -24,6 +24,7 @@ export type Options = {
   app: string | null;
   brotli?: boolean;
   strip?: boolean;
+  treeshake?: boolean;
 };
 
 export type Prepared = {
@@ -85,6 +86,7 @@ export async function popcorn(opts: Options): Promise<Prepared> {
         app: opts.app,
         tarPaths: coreTarballs,
         strip,
+        treeshake: opts.treeshake ?? false,
       });
 
       if (!report.ok) {
@@ -117,6 +119,7 @@ async function packTarballs({
   app,
   tarPaths,
   strip,
+  treeshake,
 }: {
   rootDir: string;
   outDir: string;
@@ -124,6 +127,7 @@ async function packTarballs({
   app: string | null;
   tarPaths: string[];
   strip: boolean;
+  treeshake: boolean;
 }): Promise<Report> {
   const scriptPath = p`${dirname(fileURLToPath(import.meta.url))}/tarballs.exs`;
   const args = [
@@ -142,6 +146,10 @@ async function packTarballs({
 
   if (strip) {
     args.push("--strip");
+  }
+
+  if (treeshake) {
+    args.push("--treeshake");
   }
 
   args.push(...tarPaths);

--- a/otp/js/plugins/tarballs.exs
+++ b/otp/js/plugins/tarballs.exs
@@ -9,7 +9,8 @@ defmodule Tarballs do
     entrypoint_app: :string,
     out_dir: :string,
     provided_apps_manifest_path: :string,
-    strip: :boolean
+    strip: :boolean,
+    treeshake: :boolean
   ]
 
   @required_options [:root_dir, :out_dir, :provided_apps_manifest_path]
@@ -66,7 +67,8 @@ defmodule Tarballs do
     with {:ok, args} <- parse_argv(argv),
          {:ok, provided_apps} <- fetch_provided_apps(args.provided_apps_manifest_path),
          {:ok, user_apps} <- fetch_user_apps(args.root_dir),
-         {:ok, apps} <- fetch_apps_to_pack(user_apps, provided_apps.names, args.entrypoint_app) do
+         {:ok, apps} <- fetch_apps_to_pack(user_apps, provided_apps.names, args.entrypoint_app),
+         {:ok, user_apps} <- maybe_treeshake(args, apps, user_apps) do
       vm_version = provided_apps.version
 
       File.mkdir_p!(args.out_dir)
@@ -129,6 +131,54 @@ defmodule Tarballs do
       :ok = strip_tarball(path, out_dir)
       Path.expand(Path.join(out_dir, Path.basename(path)))
     end)
+  end
+
+  defp maybe_treeshake(%{treeshake: false}, _apps, user_apps), do: {:ok, user_apps}
+
+  defp maybe_treeshake(args, apps, user_apps) do
+    selected_apps = Map.take(user_apps, apps)
+    apps_dir = Path.join([args.out_dir, "treeshake", "apps"])
+    treeshake_out_dir = Path.join([args.out_dir, "treeshake", "output"])
+    File.rm_rf!(Path.dirname(apps_dir))
+    staged_apps = Map.new(selected_apps, &stage_app(&1, apps_dir))
+    ebin_dir = Path.join([__DIR__, "treeshake", "ebin"])
+
+    arguments = [
+      "-pa",
+      ebin_dir,
+      "-e",
+      "Popcorn.Treeshake.CLI.main(System.argv())",
+      "--",
+      "--apps-dir",
+      apps_dir,
+      "--out-dir",
+      treeshake_out_dir
+    ]
+
+    case System.cmd("elixir", arguments, stderr_to_stdout: true) do
+      {_output, 0} ->
+        staged_apps =
+          Map.new(selected_apps, fn {app, info} ->
+            {app, %{info | ebin_dir: Map.fetch!(staged_apps, app)}}
+          end)
+
+        {:ok, Map.merge(user_apps, staged_apps)}
+
+      {output, status} ->
+        {:error, %{code: "treeshake_process_failed", status: status, output: output}}
+    end
+  end
+
+  defp stage_app({app, info}, apps_dir) do
+    staged_ebin = Path.join([apps_dir, app, "ebin"])
+    File.mkdir_p!(staged_ebin)
+
+    info.ebin_dir
+    |> Path.join("*")
+    |> Path.wildcard()
+    |> Enum.each(&File.cp!(&1, Path.join(staged_ebin, Path.basename(&1))))
+
+    {app, staged_ebin}
   end
 
   defp fetch_user_apps(root_dir) do
@@ -283,6 +333,7 @@ defmodule Tarballs do
           |> Map.new()
           |> Map.put_new(:entrypoint_app, nil)
           |> Map.put_new(:strip, false)
+          |> Map.put_new(:treeshake, false)
           |> Map.put(:tar_paths, tar_paths)
 
         {:ok, args}

--- a/otp/js/plugins/treeshake/lib/popcorn/treeshake/cli.ex
+++ b/otp/js/plugins/treeshake/lib/popcorn/treeshake/cli.ex
@@ -1,0 +1,78 @@
+defmodule Popcorn.Treeshake.CLI do
+  def main(["--apps-dir", apps_dir, "--out-dir", output_dir]) do
+    apps = find_apps(apps_dir)
+    files = ebin_files(apps)
+    owners = module_owners(apps)
+
+    Treeshake.run(ebin_files: files, output_dir: output_dir)
+    replace_beams(apps, owners, output_dir)
+    rewrite_app_files(apps)
+  end
+
+  defp find_apps(apps_dir) do
+    apps_dir
+    |> Path.join("*/ebin/*.app")
+    |> Path.wildcard()
+    |> Map.new(fn path -> {Path.basename(path, ".app"), Path.dirname(path)} end)
+  end
+
+  defp ebin_files(apps) do
+    apps
+    |> Map.values()
+    |> Enum.flat_map(&Path.wildcard(Path.join(&1, "*.{beam,app}")))
+  end
+
+  defp module_owners(apps) do
+    apps
+    |> Enum.flat_map(fn {app, ebin_dir} ->
+      ebin_dir
+      |> Path.join("*.beam")
+      |> Path.wildcard()
+      |> Enum.map(&{beam_module(&1), app})
+    end)
+    |> Map.new()
+  end
+
+  defp replace_beams(apps, owners, output_dir) do
+    apps
+    |> Map.values()
+    |> Enum.each(fn ebin_dir ->
+      ebin_dir
+      |> Path.join("*.beam")
+      |> Path.wildcard()
+      |> Enum.each(&File.rm!/1)
+    end)
+
+    output_dir
+    |> Path.join("*.beam")
+    |> Path.wildcard()
+    |> Enum.each(fn path ->
+      app = Map.fetch!(owners, beam_module(path))
+      File.cp!(path, Path.join(apps[app], Path.basename(path)))
+    end)
+  end
+
+  defp rewrite_app_files(apps) do
+    Enum.each(apps, fn {app, ebin_dir} ->
+      path = Path.join(ebin_dir, "#{app}.app")
+      {:ok, [{:application, name, props}]} = :file.consult(path)
+
+      modules =
+        ebin_dir
+        |> Path.join("*.beam")
+        |> Path.wildcard()
+        |> Enum.map(&beam_module/1)
+        |> Enum.sort()
+
+      File.write!(
+        path,
+        :io_lib.format(~c"~p.~n", [{:application, name, Keyword.put(props, :modules, modules)}])
+      )
+    end)
+  end
+
+  defp beam_module(path) do
+    {:ok, {module, _chunks}} = :beam_lib.chunks(to_charlist(path), [:exports])
+    module
+  end
+end

--- a/otp/js/plugins/treeshake/mix.exs
+++ b/otp/js/plugins/treeshake/mix.exs
@@ -1,0 +1,15 @@
+defmodule PopcornTreeshake.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :popcorn_treeshake,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      elixirc_paths: [
+        "lib",
+        Path.expand("../../../../popcorn/elixir/lib/treeshake", __DIR__)
+      ]
+    ]
+  end
+end

--- a/otp/js/rollup.config.mjs
+++ b/otp/js/rollup.config.mjs
@@ -1,6 +1,10 @@
-import { copyFile, mkdir, readdir, rm } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { copyFile, cp, mkdir, readdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { promisify } from "node:util";
 import typescript from "@rollup/plugin-typescript";
+
+const execFileAsync = promisify(execFile);
 
 function copyFiles(targets) {
   return {
@@ -35,6 +39,24 @@ function cleanModules(dir) {
         entries
           .filter((entry) => entry.isFile() && entry.name.endsWith(".mjs"))
           .map((entry) => rm(join(dir, entry.name))),
+      );
+    },
+  };
+}
+
+function buildTreeshake() {
+  return {
+    name: "build-treeshake",
+    async buildEnd() {
+      const cwd = "plugins/treeshake";
+      await execFileAsync("mix", ["compile"], {
+        cwd,
+        env: { ...process.env, MIX_ENV: "prod" },
+      });
+      await cp(
+        join(cwd, "_build/prod/lib/popcorn_treeshake/ebin"),
+        "dist/plugins/treeshake/ebin",
+        { recursive: true },
       );
     },
   };
@@ -88,6 +110,7 @@ export default [
         tsconfig: "./plugins/tsconfig.json",
         outputToFilesystem: true,
       }),
+      buildTreeshake(),
       copyFiles([
         { src: "plugins/tarballs.exs", dest: "dist/plugins/tarballs.exs" },
       ]),


### PR DESCRIPTION
It's a bit silly, we package the treeshaker in app so TS plugin can compile
and run it. The better way would be to just create treeshaker app or combine files
into a script.

We could also move the packaging part into Elixir but frankly, it already needs
assets from JS.