### PR TITLE
otp: disable distribution start

### DIFF
--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -32,6 +32,9 @@ const BASE_ARGS = [
   "erl",
   "-home",
   DEFAULT_HOME_DIR,
+  "-kernel",
+  "start_distribution",
+  "false",
 ];
 
 const CORE_APPS = new Set(["kernel", "stdlib", "compiler"]);


### PR DESCRIPTION
`start_distribution` is `true` by default. [^1]

[^1]: https://www.erlang.org/doc/apps/kernel/kernel_app.html#start_distribution:~:text=start_distribution%20%3D%20true%20%7C%20false