### PR TITLE
otp: intercept spawning OS processes

### DIFF
--- a/otp/js/e2e/runtime.spec.ts
+++ b/otp/js/e2e/runtime.spec.ts
@@ -113,6 +113,70 @@ test.describe("boot", () => {
   });
 });
 
+test.describe("runtime", () => {
+  test("spawning OS processes don't kill the VM", async ({ otp }) => {
+    const boot = await otp.boot(
+      evalOpts(`
+        Ticker = spawn(fun Tick() ->
+          receive
+            {ticks, From} -> From ! {ticks, get(ticks)}
+          after 20 ->
+            put(ticks, case get(ticks) of undefined -> 1; N -> N + 1 end),
+            Tick()
+          end
+        end),
+
+        Fmt = fun(Term) -> iolist_to_binary(io_lib:format("~p", [Term])) end,
+        Raises = fun(Fun) ->
+          Fmt(try Fun() of Value -> {ok, Value}
+              catch Class:Reason -> {Class, Reason}
+              end)
+        end,
+
+        ok = file:write_file("/tmp/executable", <<"code">>),
+        ok = file:change_mode("/tmp/executable", 8#755),
+
+        ok = wasm:send(#{
+          lookup => Fmt(inet_db:res_option(lookup)),
+          getaddr => Fmt(inet:getaddr("example.com", inet)),
+          gethostbyname => Fmt(inet:gethostbyname("example.com")),
+          loopback => Fmt(inet:getaddr({127,0,0,1}, inet)),
+          cmd => Raises(fun() -> os:cmd("echo hi") end),
+          spawn_port => Raises(fun() -> open_port({spawn, "echo hi"}, []) end),
+          spawn_executable =>
+            Raises(fun() -> open_port({spawn_executable, "/tmp/executable"}, []) end),
+          find_executable => os:find_executable("echo"),
+          ram_file => element(1, ram_file:open("x", [read, write, ram]))
+        }),
+
+        receive after 300 -> ok end,
+        Ticker ! {ticks, self()},
+        receive {ticks, Ticks} -> ok = wasm:send(#{ticks => Ticks}) end.
+      `),
+    );
+    assert(boot.ok);
+
+    expect(await otp.waitForEvent("lookup")).toEqual({
+      // `native` would spawn /bin/inet_gethost and halt the VM
+      lookup: "[file]",
+      getaddr: "{error,nxdomain}",
+      gethostbyname: "{error,nxdomain}",
+      loopback: "{ok,{127,0,0,1}}",
+      cmd: "{error,badarg}",
+      spawn_port: "{error,badarg}",
+      spawn_executable: "{error,badarg}",
+      find_executable: false,
+      // A linked-in driver opened with the {spawn, _} tag works
+      ram_file: "ok",
+    });
+
+    // Other processes keep working, failure would be getting `undefined` atom
+    expect(await otp.waitForEvent("ticks")).toEqual({
+      ticks: expect.any(Number),
+    });
+  });
+});
+
 test.describe("lifecycle", () => {
   test("TTY output", async ({ page }) => {
     const result = await page.evaluate(async () => {

--- a/otp/js/src/beam.ts
+++ b/otp/js/src/beam.ts
@@ -20,6 +20,14 @@ const DEFAULT_HOME_DIR = "/home/web_user";
 const FS_DIRS = ["/bin", "/lib", "/etc", "/tmp", "/home", DEFAULT_HOME_DIR];
 const BOOT_NAME = "vm";
 const BOOT_PATH = `/bin/${BOOT_NAME}.boot`;
+
+// https://www.erlang.org/doc/apps/erts/inet_cfg.html
+const INETRC_PATH = "/etc/inetrc";
+// lookup types: `native | file | dns`
+// We need `file` lookup to avoid spawning
+// /bin/inet_gethost which is not available
+const INETRC = "{lookup, [file]}.\n";
+
 const STDOUT_FD = 1;
 const STDERR_FD = 2;
 const UTF8 = new TextEncoder();
@@ -60,6 +68,7 @@ export async function boot({
     LOGNAME: DEFAULT_USER,
     COLUMNS: String(ttySize.columns),
     LINES: String(ttySize.rows),
+    ERL_INETRC: INETRC_PATH,
   };
   const moduleConfig: Partial<EmscriptenModule> = {
     print: (text) => emit({ type: "otp:stdout", payload: UTF8.encode(text) }),
@@ -262,6 +271,7 @@ function initFs({ module, fsData }: InitFsArgs): void {
   }
 
   module.FS.writeFile(BOOT_PATH, fsData.bootFile);
+  module.FS.writeFile(INETRC_PATH, UTF8.encode(INETRC));
 
   const createDir = (dirPath: string) => {
     ensureDir(module.FS, dirPath);

--- a/otp/patches/0001-emscripten-support.patch
+++ b/otp/patches/0001-emscripten-support.patch
@@ -1409,6 +1409,17 @@ index c06d6b66036a316dd6d5179dfcf8ee684ce161b6..7fb18a09bc90f80d892eca0102ccfc8d
  }
  
  /* II. Prototypes */
+@@ -482,6 +484,10 @@ static ErlDrvData spawn_start(ErlDrvPort port_num, char* name,
+     char *wd, *cwd;
+     int ifd[2], ofd[2], stderrfd;
+ 
++#ifdef ERTS_EMSCRIPTEN
++    return ERL_DRV_ERROR_BADARG;
++#endif
++
+     if (pipe(ifd) < 0) return ERL_DRV_ERROR_ERRNO;
+     errno = EMFILE;		/* default for next three conditions */
+     if (ifd[0] >= sys_max_files() || pipe(ofd) < 0) {
 diff --git a/erts/preloaded/src/Makefile b/erts/preloaded/src/Makefile
 index e76af6ce766adb16ce964733c7eba6f3554b8f6e..be1005e2490384368dde68305207c50a477e86c3 100644
 --- a/erts/preloaded/src/Makefile


### PR DESCRIPTION
```
# this killed the VM
inet:getaddr("example.com", inet).
# BEAM fatal error: Can not execute /bin/inet_gethost : enoent

# this froze the VM
os:cmd("echo hi").
```

Let's avoid doing that by patching native port code and replacing inet resolution logic to load values from prepared file.