### PR TITLE
scripts: fix tarball creation

### DIFF
--- a/scripts/stdlib.sh
+++ b/scripts/stdlib.sh
@@ -329,7 +329,7 @@ create_otp_tarballs() {
         fi
 
         tarball="${outdir}/${app}.tar"
-        tar -C "${src_root}" -cf "${tarball}" "lib/${app}/ebin"
+        tar --format ustar -C "${src_root}" -cf "${tarball}" "lib/${app}/ebin"
         GENERATED_TARBALLS+=("${tarball}")
     done
 
@@ -351,7 +351,7 @@ create_elixir_tarballs() {
         }
 
         tarball="${outdir}/${app}.tar"
-        tar -C "${elixir_dir}" -cf "${tarball}" "lib/${app}/ebin"
+        tar --format ustar -C "${elixir_dir}" -cf "${tarball}" "lib/${app}/ebin"
         GENERATED_TARBALLS+=("${tarball}")
     done
 


### PR DESCRIPTION
MacOS uses BSD tar which emits extended header records (coming from pax). Ustar format should work with :erl_tar.