### PR TITLE
plugin: move packager to mix project

### DIFF
--- a/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/cli.ex
+++ b/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/cli.ex
@@ -1,0 +1,70 @@
+defmodule Popcorn.BeamTools.CLI do
+  alias Popcorn.BeamTools.Packager
+
+  @options [
+    root_dir: :string,
+    entrypoint_app: :string,
+    out_dir: :string,
+    manifest_path: :string,
+    strip: :boolean
+  ]
+
+  @required_options [:root_dir, :out_dir, :manifest_path]
+
+  def main(argv) do
+    if String.to_integer(System.otp_release()) < 27 do
+      IO.puts(:stderr, "tarballs.exs requires host OTP >= 27 for the built-in :json module")
+      System.halt(1)
+    end
+
+    argv
+    |> run()
+    |> report()
+    |> encode_json()
+    |> IO.puts()
+  end
+
+  def run(argv) do
+    with {:ok, options} <- parse_argv(argv) do
+      Packager.run(options)
+    end
+  end
+
+  defp parse_argv(argv) do
+    {opts, tar_paths, invalid} = OptionParser.parse(argv, strict: @options)
+    missing_opts = Enum.reject(@required_options, &Keyword.has_key?(opts, &1))
+
+    case {invalid, missing_opts} do
+      {[], []} ->
+        options =
+          opts
+          |> Map.new()
+          |> Map.put_new(:entrypoint_app, nil)
+          |> Map.put_new(:strip, false)
+          |> Map.put(:tar_paths, tar_paths)
+
+        {:ok, options}
+
+      _ ->
+        bad_args(invalid, missing_opts)
+    end
+  end
+
+  defp bad_args(invalid, missing_opts) do
+    invalid =
+      Enum.map(invalid, fn {option, value} ->
+        %{option: option, value: value}
+      end)
+
+    missing = Enum.map(missing_opts, &to_string/1)
+
+    {:error, %{code: "bad_args", invalid: invalid, missing: missing}}
+  end
+
+  defp report({:ok, report}), do: report
+  defp report({:error, error}), do: %{ok: false, error: error}
+
+  defp encode_json(term) do
+    term |> :json.encode() |> IO.iodata_to_binary()
+  end
+end

--- a/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/packager.ex
+++ b/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/packager.ex
@@ -1,33 +1,14 @@
-if String.to_integer(System.otp_release()) < 27 do
-  IO.puts(:stderr, "tarballs.exs requires host OTP >= 27 for the built-in :json module")
-  System.halt(1)
-end
-
-defmodule Tarballs do
-  @options [
-    root_dir: :string,
-    entrypoint_app: :string,
-    out_dir: :string,
-    provided_apps_manifest_path: :string,
-    strip: :boolean
-  ]
-
-  @required_options [:root_dir, :out_dir, :provided_apps_manifest_path]
+defmodule Popcorn.BeamTools.Packager do
   @static_nif_apps MapSet.new(["wasm"])
 
-  def main(argv) do
-    case run(argv) do
-      {:ok, report} ->
-        report
-        |> encode_json()
-        |> IO.puts()
-
-      {:error, error} ->
-        %{ok: false, error: error}
-        |> encode_json()
-        |> IO.puts()
-    end
-  end
+  @type options :: %{
+          root_dir: Path.t(),
+          entrypoint_app: String.t() | nil,
+          out_dir: Path.t(),
+          manifest_path: Path.t(),
+          strip: boolean(),
+          tar_paths: [Path.t()]
+        }
 
   defp strip_tarball(path, out_dir) do
     {:ok, entries} = :erl_tar.extract(to_charlist(path), [:memory])
@@ -62,21 +43,28 @@ defmodule Tarballs do
     _error -> :error
   end
 
-  defp run(argv) do
-    with {:ok, args} <- parse_argv(argv),
-         {:ok, provided_apps} <- fetch_provided_apps(args.provided_apps_manifest_path),
-         {:ok, user_apps} <- fetch_user_apps(args.root_dir),
-         {:ok, apps} <- fetch_apps_to_pack(user_apps, provided_apps.names, args.entrypoint_app) do
+  @spec run(options()) :: {:ok, map()} | {:error, map()}
+  def run(%{
+        root_dir: root_dir,
+        entrypoint_app: entrypoint_app,
+        out_dir: out_dir,
+        manifest_path: manifest_path,
+        strip: strip,
+        tar_paths: input_tar_paths
+      }) do
+    with {:ok, provided_apps} <- fetch_provided_apps(manifest_path),
+         {:ok, user_apps} <- fetch_user_apps(root_dir),
+         {:ok, apps} <- fetch_apps_to_pack(user_apps, provided_apps.names, entrypoint_app) do
       vm_version = provided_apps.version
 
-      File.mkdir_p!(args.out_dir)
+      File.mkdir_p!(out_dir)
 
       packed_apps =
         apps
         |> Task.async_stream(fn app ->
           info = Map.fetch!(user_apps, app)
           version = Keyword.get(info.props, :vsn, ~c"") |> to_string()
-          tar_path = create_tarball(args.out_dir, app, info.ebin_dir)
+          tar_path = create_tarball(out_dir, app, info.ebin_dir)
 
           {app, %{tar: tar_path, version: version}}
         end)
@@ -91,18 +79,18 @@ defmodule Tarballs do
         |> Enum.flat_map(fn {:ok, notes} -> notes end)
 
       notes = dynamic_nifs ++ otp_version(vm_version)
-      manifest_path = Path.join(args.out_dir, "manifest.json")
+      manifest_path = Path.join(out_dir, "manifest.json")
       manifest_apps = Map.merge(packed_apps, provided_apps.apps)
 
-      tar_paths =
+      packed_tar_paths =
         packed_apps
         |> Map.values()
-        |> Enum.map(&Path.expand(Path.join(args.out_dir, &1.tar)))
+        |> Enum.map(&Path.expand(Path.join(out_dir, &1.tar)))
 
-      tar_paths = maybe_strip_tarballs(tar_paths ++ args.tar_paths, args.strip, args.out_dir)
+      tar_paths = maybe_strip_tarballs(packed_tar_paths ++ input_tar_paths, strip, out_dir)
 
       manifest = %{
-        entrypoint: args.entrypoint_app,
+        entrypoint: entrypoint_app,
         apps: manifest_apps,
         notes: notes,
         vm: %{boot: "bin/vm.boot", version: vm_version}
@@ -113,7 +101,7 @@ defmodule Tarballs do
       {:ok,
        %{
          ok: true,
-         entrypoint: args.entrypoint_app,
+         entrypoint: entrypoint_app,
          manifestPath: Path.expand(manifest_path),
          tarPaths: tar_paths,
          apps: manifest_apps,
@@ -272,38 +260,6 @@ defmodule Tarballs do
     |> Enum.map(&to_string/1)
   end
 
-  defp parse_argv(argv) do
-    {opts, tar_paths, invalid} = OptionParser.parse(argv, strict: @options)
-
-    missing_opts = Enum.reject(@required_options, &Keyword.has_key?(opts, &1))
-
-    case {invalid, missing_opts} do
-      {[], []} ->
-        args =
-          opts
-          |> Map.new()
-          |> Map.put_new(:entrypoint_app, nil)
-          |> Map.put_new(:strip, false)
-          |> Map.put(:tar_paths, tar_paths)
-
-        {:ok, args}
-
-      _ ->
-        err(:bad_args, {invalid, missing_opts})
-    end
-  end
-
-  defp err(:bad_args, {invalid, missing_opts}) do
-    invalid =
-      Enum.map(invalid, fn {option, value} ->
-        %{option: option, value: value}
-      end)
-
-    missing = Enum.map(missing_opts, &to_string/1)
-
-    {:error, %{code: "bad_args", invalid: invalid, missing: missing}}
-  end
-
   defp err(:missing_entrypoint, app) do
     {:error, %{code: "missing_entrypoint", app: app}}
   end
@@ -333,5 +289,3 @@ defmodule Tarballs do
     _ -> :error
   end
 end
-
-Tarballs.main(System.argv())

--- a/popcorn/js/plugins/beam_tools/mix.exs
+++ b/popcorn/js/plugins/beam_tools/mix.exs
@@ -1,0 +1,16 @@
+defmodule Popcorn.BeamTools.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :popcorn_beam_tools,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      deps: []
+    ]
+  end
+
+  def application do
+    []
+  end
+end

--- a/popcorn/js/plugins/shared.ts
+++ b/popcorn/js/plugins/shared.ts
@@ -81,7 +81,7 @@ export async function popcorn(opts: Options): Promise<Prepared> {
       const report = await packTarballs({
         rootDir: resolve(opts.rootDir),
         outDir: packedDir,
-        providedAppsManifestPath: p`${distDir}/assets/manifest.json`,
+        manifestPath: p`${distDir}/assets/manifest.json`,
         app: opts.app,
         tarPaths: coreTarballs,
         strip,
@@ -110,43 +110,49 @@ export async function popcorn(opts: Options): Promise<Prepared> {
   }
 }
 
-async function packTarballs({
-  rootDir,
-  outDir,
-  providedAppsManifestPath,
-  app,
-  tarPaths,
-  strip,
-}: {
+type PackTarballsParams = {
   rootDir: string;
   outDir: string;
-  providedAppsManifestPath: string;
+  manifestPath: string;
   app: string | null;
   tarPaths: string[];
   strip: boolean;
-}): Promise<Report> {
-  const scriptPath = p`${dirname(fileURLToPath(import.meta.url))}/tarballs.exs`;
-  const args = [
-    scriptPath,
+};
+async function packTarballs(opts: PackTarballsParams): Promise<Report> {
+  const { rootDir, outDir, manifestPath, app, tarPaths, strip } = opts;
+  const toolDir = p`${dirname(fileURLToPath(import.meta.url))}/beam_tools`;
+
+  const packerArgs = [
+    "run",
+    "--no-start",
+    "-e",
+    "Popcorn.BeamTools.CLI.main(System.argv())",
+    "--",
     "--root-dir",
     rootDir,
     "--out-dir",
     outDir,
-    "--provided-apps-manifest-path",
-    providedAppsManifestPath,
+    "--manifest-path",
+    manifestPath,
   ];
 
   if (app !== null) {
-    args.push("--entrypoint-app", app);
+    packerArgs.push("--entrypoint-app", app);
   }
-
   if (strip) {
-    args.push("--strip");
+    packerArgs.push("--strip");
   }
+  packerArgs.push(...tarPaths);
 
-  args.push(...tarPaths);
-
-  const { stdout } = await execFileAsync("elixir", args);
+  const env = {
+    ...process.env,
+    MIX_BUILD_PATH: p`${outDir}/beam_tools_build`,
+    MIX_QUIET: "1",
+  };
+  const { stdout } = await execFileAsync("mix", packerArgs, {
+    cwd: toolDir,
+    env,
+  });
   return JSON.parse(stdout) as Report;
 }
 

--- a/popcorn/js/plugins/shared.ts
+++ b/popcorn/js/plugins/shared.ts
@@ -212,21 +212,22 @@ async function copy(
                 await copyFile(sourcePath, targetPath);
                 break;
 
-              case "gzip":
-                await writeFile(
-                  `${targetPath}.gz`,
-                  await gzipAsync(await read(), { level: 9 }),
-                );
+              case "gzip": {
+                const input = await read();
+                const buffer = await gzipAsync(input, { level: 9 });
+                await writeFile(`${targetPath}.gz`, buffer);
                 break;
+              }
 
-              case "brotli":
-                await writeFile(
-                  `${targetPath}.br`,
-                  await brotliCompressAsync(await read(), {
-                    params: { [constants.BROTLI_PARAM_QUALITY]: 11 },
-                  }),
-                );
+              case "brotli": {
+                const Q = constants.BROTLI_PARAM_QUALITY;
+                const opts = { params: { [Q]: 11 } };
+
+                const input = await read();
+                const buffer = await brotliCompressAsync(input, opts);
+                await writeFile(`${targetPath}.br`, buffer);
                 break;
+              }
             }
           }),
       );

--- a/popcorn/js/rollup.config.mjs
+++ b/popcorn/js/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readdir, rm } from "node:fs/promises";
+import { cp, mkdir, readdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import typescript from "@rollup/plugin-typescript";
 
@@ -9,7 +9,7 @@ function copyFiles(targets) {
       await Promise.all(
         targets.map(async ({ src, dest }) => {
           await mkdir(dirname(dest), { recursive: true });
-          await copyFile(src, dest);
+          await cp(src, dest, { recursive: true });
         }),
       );
     },
@@ -89,7 +89,14 @@ export default [
         outputToFilesystem: true,
       }),
       copyFiles([
-        { src: "plugins/tarballs.exs", dest: "dist/plugins/tarballs.exs" },
+        {
+          src: "plugins/beam_tools/mix.exs",
+          dest: "dist/plugins/beam_tools/mix.exs",
+        },
+        {
+          src: "plugins/beam_tools/lib",
+          dest: "dist/plugins/beam_tools/lib",
+        },
       ]),
     ],
   },


### PR DESCRIPTION
Previously, it was called as standalone script. We want to separate CLI args and logic and, in future, add treeshaking.

We compile the mix project on user's computer and run it from there.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>