### PR TITLE
plugin: add patcher, patch prim_tty

### DIFF
--- a/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/beam_patcher.ex
+++ b/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/beam_patcher.ex
@@ -1,0 +1,184 @@
+defmodule Popcorn.BeamTools.BeamPatcher do
+  @moduledoc """
+  Replaces functions in a compiled BEAM with implementations taken from a patch
+  module, by merging both modules as Core Erlang and recompiling with the host
+  compiler.
+
+  A patch function replaces the original of the same name and arity, including
+  for calls made from the original module's own code. Exported patch functions
+  listed in `-compile([{popcorn_patch_private, [{f, a}]}])` stay private.
+  `popcorn_module:f(...)` calls the original implementation of `f`.
+  """
+
+  @orig_prefix "popcorn_orig"
+  @patch_prefix "popcorn_patch"
+
+  @doc """
+  Compiles `patch_path` and merges it into the BEAM at `beam_path`, overwriting it.
+  """
+  def patch_beam(beam_path, patch_path) do
+    with {:ok, original} <- read_ast(beam_path),
+         {:ok, patch} <- compile_patch(patch_path) do
+      beam =
+        original
+        |> merge_modules(patch)
+        |> serialize()
+
+      File.write!(beam_path, beam)
+      :ok
+    end
+  end
+
+  defp read_ast(beam_path) do
+    case :beam_lib.chunks(to_charlist(beam_path), [:abstract_code]) do
+      {:ok, {_module, [abstract_code: {_backend, abstract_code}]}} ->
+        {:ok, _module, ast} = :compile.noenv_forms(abstract_code, [:to_core])
+        {:ok, ast}
+
+      _ ->
+        err(:unpatchable_beam, beam_path)
+    end
+  end
+
+  defp compile_patch(patch_path) do
+    case :compile.file(to_charlist(patch_path), [:binary, :debug_info, :return_errors, :to_core]) do
+      {:ok, _module, ast} ->
+        {:ok, ast}
+
+      {:error, errors, _warnings} ->
+        err(:bad_patch, {patch_path, errors})
+    end
+  end
+
+  defp serialize(ast) do
+    {:ok, _module, beam} = :compile.noenv_forms(ast, [:from_core, debug_info: {:core_v1, ast}])
+    beam
+  end
+
+  defp merge_modules(orig_ast, patch_ast) do
+    {:c_module, _meta, module_spec, orig_exports, orig_specs, orig_body} = orig_ast
+    {:c_module, _meta, _module_spec, patch_exports, patch_specs, patch_body} = patch_ast
+    private_overrides = private_overrides(patch_specs)
+    orig_exports = MapSet.new(orig_exports, fn {:c_var, _meta, fa} -> fa end)
+
+    patch_exports =
+      patch_exports
+      |> MapSet.new(fn {:c_var, _meta, fa} -> fa end)
+      |> MapSet.difference(private_overrides)
+      |> MapSet.difference(MapSet.new(module_info: 0, module_info: 1))
+
+    exports = MapSet.union(orig_exports, patch_exports)
+    replaced = MapSet.union(patch_exports, private_overrides)
+
+    # Everything the patch does not replace keeps its name: the module's own
+    # `-nifs` declarations and internal calls refer to private functions by name.
+    # Replaced originals are renamed rather than dropped so a patch can delegate
+    # to them; an original nothing delegates to is dead code and the compiler
+    # removes it. Patch-private helpers are renamed so they cannot collide with
+    # an original of the same name.
+    orig_body = rename_replaced_funs(orig_body, replaced)
+
+    patch_body =
+      patch_body
+      |> rename_funs_and_local_calls(%{prefix: @patch_prefix, except: replaced})
+      |> inject_original_calls(replaced)
+
+    exports_ast = exports |> Enum.sort() |> Enum.map(&{:c_var, [], &1})
+
+    {:c_module, [], module_spec, exports_ast, orig_specs ++ patch_specs, patch_body ++ orig_body}
+  end
+
+  defp private_overrides(patch_specs) do
+    patch_specs
+    |> Enum.flat_map(fn
+      {{:c_literal, _meta1, :compile}, {:c_literal, _meta2, params}} -> params
+      _other -> []
+    end)
+    |> Enum.flat_map(fn
+      {:popcorn_patch_private, funs} -> List.wrap(funs)
+      _other -> []
+    end)
+    |> MapSet.new()
+  end
+
+  defp rename_replaced_funs(ast, funs) do
+    Enum.map(ast, fn
+      {{:c_var, var_meta, {fun, arity}}, definition} ->
+        if {fun, arity} in funs do
+          {{:c_var, var_meta, {prefixed(@orig_prefix, fun), arity}}, definition}
+        else
+          {{:c_var, var_meta, {fun, arity}}, definition}
+        end
+
+      form ->
+        form
+    end)
+  end
+
+  defp inject_original_calls(ast, replaced) do
+    with {:c_call, call_meta, mod_ast, fun_ast, args} <- ast,
+         {:c_literal, _mod_meta, :popcorn_module} <- mod_ast,
+         {:c_literal, fun_meta, fun} <- fun_ast do
+      arity = length(args)
+      original = if {fun, arity} in replaced, do: prefixed(@orig_prefix, fun), else: fun
+
+      {:c_apply, call_meta, {:c_var, fun_meta, {original, arity}}, args}
+    else
+      _other -> traverse(ast, &inject_original_calls(&1, replaced))
+    end
+  end
+
+  defp rename_funs_and_local_calls({:c_var, meta, {function, arity} = fa} = ast, ctx)
+       when is_atom(function) and is_integer(arity) do
+    if fa in ctx.except do
+      ast
+    else
+      {:c_var, meta, {prefixed(ctx.prefix, function), arity}}
+    end
+  end
+
+  defp rename_funs_and_local_calls({:function, {function, arity} = fa} = ast, ctx)
+       when is_atom(function) and is_integer(arity) do
+    if fa in ctx.except do
+      ast
+    else
+      {:function, {prefixed(ctx.prefix, function), arity}}
+    end
+  end
+
+  defp rename_funs_and_local_calls({:id, {line, col, id}}, ctx) do
+    id =
+      case Atom.to_string(id) do
+        "-" <> id -> id
+        id -> id
+      end
+
+    {:id, {line, col, prefixed("-" <> ctx.prefix, id)}}
+  end
+
+  defp rename_funs_and_local_calls(ast, ctx) do
+    traverse(ast, &rename_funs_and_local_calls(&1, ctx))
+  end
+
+  defp prefixed(prefix, name), do: String.to_atom("#{prefix}_#{name}")
+
+  defp traverse(ast, fun) when is_tuple(ast) do
+    ast |> Tuple.to_list() |> fun.() |> List.to_tuple()
+  end
+
+  defp traverse([h | t], fun) do
+    [fun.(h) | fun.(t)]
+  end
+
+  defp traverse(ast, _fun) do
+    ast
+  end
+
+  defp err(:unpatchable_beam, beam_path) do
+    {:error, %{code: "unpatchable_beam", beam: beam_path}}
+  end
+
+  defp err(:bad_patch, {patch_path, errors}) do
+    {:error, %{code: "bad_patch", patch: patch_path, errors: inspect(errors)}}
+  end
+end

--- a/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/packager.ex
+++ b/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/packager.ex
@@ -68,8 +68,10 @@ defmodule Popcorn.BeamTools.Packager do
 
       File.mkdir_p!(out_dir)
 
+      staged_apps = stage_apps(Path.join(out_dir, "staging"), apps_info)
+
       packed_apps =
-        apps_info
+        staged_apps
         |> async_stream(fn {app, info} ->
           version = Keyword.get(info.props, :vsn, ~c"") |> to_string()
           tar_path = create_tarball(out_dir, app, info.ebin_dir)
@@ -79,7 +81,7 @@ defmodule Popcorn.BeamTools.Packager do
         |> Map.new()
 
       diagnostics =
-        apps_info
+        staged_apps
         |> async_stream(fn {app, info} ->
           case loaded_dynamic_nifs(app, info.ebin_dir) do
             [] ->
@@ -164,6 +166,18 @@ defmodule Popcorn.BeamTools.Packager do
     [app, _version] = String.split(app_version, "-", parts: 2)
 
     to_charlist(Path.join([root, "lib", app, "ebin"]))
+  end
+
+  # Apps are copied out of the host installation so packing can modify them.
+  defp stage_apps(staging_dir, apps_info) do
+    async_stream(apps_info, fn {app, info} ->
+      ebin_dir = Path.join([staging_dir, app, "ebin"])
+
+      File.mkdir_p!(Path.dirname(ebin_dir))
+      File.cp_r!(info.ebin_dir, ebin_dir)
+
+      {app, %{info | ebin_dir: ebin_dir}}
+    end)
   end
 
   defp async_stream(enumerable, fun) do

--- a/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/packager.ex
+++ b/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/packager.ex
@@ -1,6 +1,11 @@
 defmodule Popcorn.BeamTools.Packager do
+  alias Popcorn.BeamTools.BeamPatcher
+
   @static_nif_beams MapSet.new(["wasm.beam"])
   @boot_name "bin/vm.boot"
+
+  # Using `__DIR__` is safe – the plugin is compiled on user's machine
+  @patches_dir Path.expand("../../../patches", __DIR__)
 
   # To run, Beam needs following apps:
   # - kernel
@@ -62,13 +67,13 @@ defmodule Popcorn.BeamTools.Packager do
          {:ok, project_apps} <- root_dir |> project_build_dir() |> get_apps_info(),
          {:ok, builtin_apps} <- get_builtin_apps(toolchain),
          {:ok, apps_info} <- apps_to_pack(project_apps, builtin_apps, entrypoint_app),
-         {:ok, boot_path} <- create_boot(out_dir, toolchain.otp_root, manifest.preloaded) do
+         {:ok, boot_path} <- create_boot(out_dir, toolchain.otp_root, manifest.preloaded),
+         staged_apps = stage_apps(Path.join(out_dir, "staging"), apps_info),
+         :ok <- patch_apps(staged_apps) do
       vm_version = manifest.version
       toolchain = Map.take(toolchain, ~w(otp elixir)a)
 
       File.mkdir_p!(out_dir)
-
-      staged_apps = stage_apps(Path.join(out_dir, "staging"), apps_info)
 
       packed_apps =
         staged_apps
@@ -170,7 +175,8 @@ defmodule Popcorn.BeamTools.Packager do
 
   # Apps are copied out of the host installation so packing can modify them.
   defp stage_apps(staging_dir, apps_info) do
-    async_stream(apps_info, fn {app, info} ->
+    apps_info
+    |> async_stream(fn {app, info} ->
       ebin_dir = Path.join([staging_dir, app, "ebin"])
 
       File.mkdir_p!(Path.dirname(ebin_dir))
@@ -178,6 +184,26 @@ defmodule Popcorn.BeamTools.Packager do
 
       {app, %{info | ebin_dir: ebin_dir}}
     end)
+    |> Map.new()
+  end
+
+  # we patch only selected modules from OTP, see patches/
+  defp patch_apps(staged_apps) do
+    [@patches_dir, "*", "*.erl"]
+    |> Path.join()
+    |> Path.wildcard()
+    |> reduce_while_ok(:ok, fn patch_path, :ok ->
+      app = patch_path |> Path.dirname() |> Path.basename()
+      name = Path.basename(patch_path, ".erl") <> ".beam"
+      ebin_dir = Map.fetch!(staged_apps, app).ebin_dir
+      beam_path = Path.join(ebin_dir, name)
+
+      BeamPatcher.patch_beam(beam_path, patch_path)
+    end)
+    |> case do
+      {:ok, _} -> :ok
+      {:error, _} = error -> error
+    end
   end
 
   defp async_stream(enumerable, fun) do
@@ -296,6 +322,7 @@ defmodule Popcorn.BeamTools.Packager do
   defp reduce_while_ok(enumerable, acc, f) do
     Enum.reduce_while(enumerable, {:ok, acc}, fn value, {:ok, acc} ->
       case f.(value, acc) do
+        :ok -> {:cont, {:ok, acc}}
         {:ok, new_acc} -> {:cont, {:ok, new_acc}}
         {:error, _} = error -> {:halt, error}
       end

--- a/popcorn/js/plugins/beam_tools/patches/kernel/prim_tty.erl
+++ b/popcorn/js/plugins/beam_tools/patches/kernel/prim_tty.erl
@@ -1,0 +1,13 @@
+%% The emscripten target has no terminal to query, so terminal capability
+%% detection is skipped and the state is returned unchanged.
+-module(prim_tty).
+-compile([{popcorn_patch_private, [{init, 2}]}]).
+-export([init/2]).
+
+init(State, {unix, _} = OsType) ->
+    case erlang:system_info(system_architecture) of
+        "wasm32-unknown-emscripten" -> State;
+        _ -> popcorn_module:init(State, OsType)
+    end;
+init(State, OsType) ->
+    popcorn_module:init(State, OsType).

--- a/popcorn/js/rollup.config.mjs
+++ b/popcorn/js/rollup.config.mjs
@@ -97,6 +97,10 @@ export default [
           src: "plugins/beam_tools/lib",
           dest: "dist/plugins/beam_tools/lib",
         },
+        {
+          src: "plugins/beam_tools/patches",
+          dest: "dist/plugins/beam_tools/patches",
+        },
       ]),
     ],
   },

--- a/popcorn/patches/0001-emscripten-support.patch
+++ b/popcorn/patches/0001-emscripten-support.patch
@@ -646,7 +646,7 @@ index 6615c41065d22e8d9275efcd043b85594f36e4b0..96dab652d0d3329ff1d8291e8f761361
  static int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data,
 diff --git a/erts/emulator/nifs/common/wasm_nif.c b/erts/emulator/nifs/common/wasm_nif.c
 new file mode 100644
-index 0000000000000000000000000000000000000000..ad4a8fa2b6776814a1e6e5ac83ecadfa242590f5
+index 0000000000000000000000000000000000000000..086797fa6f81d81cdebb74f86bb58b85e90f4111
 --- /dev/null
 +++ b/erts/emulator/nifs/common/wasm_nif.c
 @@ -0,0 +1,651 @@
@@ -1673,40 +1673,6 @@ index 72a9397bc1a5863dc88c1458e143ebbca708d891..14160385f06a8229d3b0611ab33e2ed5
    struct hostent *result;
    int err;
  
-diff --git a/lib/kernel/src/prim_tty.erl b/lib/kernel/src/prim_tty.erl
-index f438f9f816371d7721fe1c0ce3c7f367fd1a3bab..2f206e9519f1539078d89c2f9b722fe9425466a7 100644
---- a/lib/kernel/src/prim_tty.erl
-+++ b/lib/kernel/src/prim_tty.erl
-@@ -357,6 +357,16 @@ options(UserOptions) ->
- init(State, ssh) ->
-     State#state{ xn = true };
- init(State, {unix,_}) ->
-+    case erlang:system_info(system_architecture) of
-+        "wasm32-unknown-emscripten" -> State;
-+        _ -> init_unix(State)
-+    end;
-+init(State, {win32, _}) ->
-+    State#state{
-+      %% position = false,
-+      xn = true }.
-+
-+init_unix(State) ->
- 
-     case os:getenv("TERM") of
-         false ->
-@@ -445,11 +455,7 @@ init(State, {unix,_}) ->
-       tab = Tab,
-       position = Position,
-       delete_after_cursor = DeleteAfter
--     };
--init(State, {win32, _}) ->
--    State#state{
--      %% position = false,
--      xn = true }.
-+     }.
- 
- -spec handles(state()) -> #{ read := undefined | reference(),
-                              write := reference() }.
 diff --git a/lib/odbc/configure.ac b/lib/odbc/configure.ac
 index 1f9e23e9976d9345a424002476acaeb8f767732b..bed8fa83f7f16c0d9beeb6c1fa0f8fc3a503af02 100644
 --- a/lib/odbc/configure.ac


### PR DESCRIPTION
We now don't use apps from Wasm build and need to patch user's builtin apps.
This patch adds a patcher logic and moves prim_tty patch from OTP patch to plugin patches.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>