### PR TITLE
plugin: add extraApps

### DIFF
--- a/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/cli.ex
+++ b/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/cli.ex
@@ -4,6 +4,7 @@ defmodule Popcorn.BeamTools.CLI do
   @options [
     root_dir: :string,
     entrypoint_app: :string,
+    extra_app: [:string, :keep],
     out_dir: :string,
     manifest_path: :string,
     strip: :boolean
@@ -38,7 +39,9 @@ defmodule Popcorn.BeamTools.CLI do
       {[], []} ->
         options =
           opts
+          |> Keyword.delete(:extra_app)
           |> Map.new()
+          |> Map.put(:extra_apps, Keyword.get_values(opts, :extra_app))
           |> Map.put_new(:entrypoint_app, nil)
           |> Map.put_new(:strip, false)
 

--- a/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/packager.ex
+++ b/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/packager.ex
@@ -30,6 +30,7 @@ defmodule Popcorn.BeamTools.Packager do
   @type options :: %{
           root_dir: Path.t(),
           entrypoint_app: String.t() | nil,
+          extra_apps: [String.t()],
           out_dir: Path.t(),
           manifest_path: Path.t(),
           strip: boolean()
@@ -66,6 +67,7 @@ defmodule Popcorn.BeamTools.Packager do
     %{
       root_dir: root_dir,
       entrypoint_app: entrypoint_app,
+      extra_apps: extra_apps,
       out_dir: out_dir,
       manifest_path: manifest_path,
       strip: strip
@@ -75,7 +77,7 @@ defmodule Popcorn.BeamTools.Packager do
          {:ok, toolchain} <- fetch_toolchain_info(manifest.version),
          {:ok, project_apps} <- root_dir |> project_build_dir() |> get_apps_info(),
          {:ok, builtin_apps} <- get_builtin_apps(toolchain),
-         {:ok, apps_info} <- apps_to_pack(project_apps, builtin_apps, entrypoint_app),
+         {:ok, apps_info} <- apps_to_pack(project_apps, builtin_apps, extra_apps, entrypoint_app),
          :ok <- check_capabilities(apps_info, manifest.capabilities),
          {:ok, boot_path} <- create_boot(out_dir, toolchain.otp_root, manifest.preloaded),
          staged_apps = stage_apps(Path.join(out_dir, "staging"), apps_info),
@@ -286,14 +288,14 @@ defmodule Popcorn.BeamTools.Packager do
     end
   end
 
-  defp apps_to_pack(project_apps, builtin_apps, entrypoint) do
+  defp apps_to_pack(project_apps, builtin_apps, extra_apps, entrypoint) do
     all_apps_info = Map.merge(builtin_apps, project_apps)
 
     gather_from_root = fn app, selected ->
       gather_required_apps(all_apps_info, project_apps, app, selected)
     end
 
-    with {:ok, roots} <- root_apps(project_apps, entrypoint),
+    with {:ok, roots} <- root_apps(project_apps, all_apps_info, extra_apps, entrypoint),
          {:ok, selected_apps} <- reduce_while_ok(roots, MapSet.new(), gather_from_root) do
       all_apps_info
       |> Map.filter(fn {app, _info} -> MapSet.member?(selected_apps, app) end)
@@ -316,13 +318,27 @@ defmodule Popcorn.BeamTools.Packager do
     if unsupported == [], do: :ok, else: err(:unsupported_apps, unsupported)
   end
 
-  defp root_apps(_project_apps, nil), do: {:ok, @base_apps}
+  defp root_apps(project_apps, all_apps_info, extra_apps, entrypoint) do
+    with {:ok, roots} <- entrypoint_roots(project_apps, entrypoint),
+         {:ok, extra} <- extra_roots(all_apps_info, extra_apps) do
+      {:ok, extra ++ roots}
+    end
+  end
 
-  defp root_apps(project_apps, entrypoint) when is_map_key(project_apps, entrypoint) do
+  defp entrypoint_roots(_project_apps, nil), do: {:ok, @base_apps}
+
+  defp entrypoint_roots(project_apps, entrypoint) when is_map_key(project_apps, entrypoint) do
     {:ok, [entrypoint | @base_apps]}
   end
 
-  defp root_apps(_project_apps, entrypoint), do: err(:missing_entrypoint, entrypoint)
+  defp entrypoint_roots(_project_apps, entrypoint), do: err(:missing_entrypoint, entrypoint)
+
+  defp extra_roots(all_apps_info, extra_apps) do
+    case Enum.reject(extra_apps, &is_map_key(all_apps_info, &1)) do
+      [] -> {:ok, extra_apps}
+      missing -> err(:missing_extra_apps, Enum.sort(missing))
+    end
+  end
 
   defp gather_required_apps(all_apps_info, project_apps, app, selected) do
     if MapSet.member?(selected, app) do
@@ -448,6 +464,10 @@ defmodule Popcorn.BeamTools.Packager do
 
   defp err(:missing_entrypoint, app) do
     {:error, %{code: "missing_entrypoint", app: app}}
+  end
+
+  defp err(:missing_extra_apps, apps) do
+    {:error, %{code: "missing_extra_apps", apps: apps}}
   end
 
   defp err(:bad_manifest, path) do

--- a/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/packager.ex
+++ b/popcorn/js/plugins/beam_tools/lib/popcorn/beam_tools/packager.ex
@@ -295,7 +295,7 @@ defmodule Popcorn.BeamTools.Packager do
       gather_required_apps(all_apps_info, project_apps, app, selected)
     end
 
-    with {:ok, roots} <- root_apps(project_apps, all_apps_info, extra_apps, entrypoint),
+    with {:ok, roots} <- root_apps(all_apps_info, extra_apps, entrypoint),
          {:ok, selected_apps} <- reduce_while_ok(roots, MapSet.new(), gather_from_root) do
       all_apps_info
       |> Map.filter(fn {app, _info} -> MapSet.member?(selected_apps, app) end)
@@ -318,20 +318,24 @@ defmodule Popcorn.BeamTools.Packager do
     if unsupported == [], do: :ok, else: err(:unsupported_apps, unsupported)
   end
 
-  defp root_apps(project_apps, all_apps_info, extra_apps, entrypoint) do
-    with {:ok, roots} <- entrypoint_roots(project_apps, entrypoint),
+  defp root_apps(all_apps_info, extra_apps, entrypoint) do
+    with {:ok, roots} <- entrypoint_roots(all_apps_info, entrypoint),
          {:ok, extra} <- extra_roots(all_apps_info, extra_apps) do
       {:ok, extra ++ roots}
     end
   end
 
-  defp entrypoint_roots(_project_apps, nil), do: {:ok, @base_apps}
+  defp entrypoint_roots(_all_apps_info, nil), do: {:ok, @base_apps}
 
-  defp entrypoint_roots(project_apps, entrypoint) when is_map_key(project_apps, entrypoint) do
+  # The entrypoint may be a builtin app, so a project with no code of its own
+  # doesn't need a stub application just to depend on one.
+  defp entrypoint_roots(all_apps_info, entrypoint)
+       when is_map_key(all_apps_info, entrypoint) do
     {:ok, [entrypoint | @base_apps]}
   end
 
-  defp entrypoint_roots(_project_apps, entrypoint), do: err(:missing_entrypoint, entrypoint)
+  defp entrypoint_roots(_all_apps_info, entrypoint),
+    do: err(:missing_entrypoint, entrypoint)
 
   defp extra_roots(all_apps_info, extra_apps) do
     case Enum.reject(extra_apps, &is_map_key(all_apps_info, &1)) do

--- a/popcorn/js/plugins/shared.ts
+++ b/popcorn/js/plugins/shared.ts
@@ -21,6 +21,7 @@ const OTP_DIR = "assets/otp";
 export type Options = {
   rootDir: string;
   app: string | null;
+  extraApps?: string[];
   brotli?: boolean;
   strip?: boolean;
 };
@@ -74,6 +75,7 @@ export async function popcorn(opts: Options): Promise<Prepared> {
         outDir: packedDir,
         manifestPath: p`${distDir}/assets/manifest.json`,
         app: opts.app,
+        extraApps: opts.extraApps ?? [],
         strip,
       });
 
@@ -106,10 +108,11 @@ type PackTarballsParams = {
   outDir: string;
   manifestPath: string;
   app: string | null;
+  extraApps: string[];
   strip: boolean;
 };
 async function packTarballs(opts: PackTarballsParams): Promise<Report> {
-  const { rootDir, outDir, manifestPath, app, strip } = opts;
+  const { rootDir, outDir, manifestPath, app, extraApps, strip } = opts;
   const toolDir = p`${dirname(fileURLToPath(import.meta.url))}/beam_tools`;
 
   const packerArgs = [
@@ -128,6 +131,9 @@ async function packTarballs(opts: PackTarballsParams): Promise<Report> {
 
   if (app !== null) {
     packerArgs.push("--entrypoint-app", app);
+  }
+  for (const extraApp of extraApps) {
+    packerArgs.push("--extra-app", extraApp);
   }
   if (strip) {
     packerArgs.push("--strip");
@@ -163,6 +169,11 @@ type UnsupportedAppsError = {
   apps: { app: string; capability: string }[];
 };
 
+type MissingExtraAppsError = {
+  code: "missing_extra_apps";
+  apps: string[];
+};
+
 function hasCode(error: unknown, code: string): boolean {
   return (
     typeof error === "object" &&
@@ -177,6 +188,12 @@ function isMissingDepError(error: unknown): error is MissingDepError {
 
 function isUnsupportedAppsError(error: unknown): error is UnsupportedAppsError {
   return hasCode(error, "unsupported_apps");
+}
+
+function isMissingExtraAppsError(
+  error: unknown,
+): error is MissingExtraAppsError {
+  return hasCode(error, "missing_extra_apps");
 }
 
 function toolchainOf(error: unknown): Toolchain | undefined {
@@ -205,6 +222,13 @@ function errorLines(error: unknown): string[] {
       `These applications need native support the WASM runtime wasn't built`,
       `with: ${apps}.`,
       `Drop them from your dependencies, or use a runtime built with it.`,
+    ];
+  }
+
+  if (isMissingExtraAppsError(error)) {
+    return [
+      `Extra apps not found: ${error.apps.join(", ")}.`,
+      `They have to come from your project build or your Erlang/Elixir install.`,
     ];
   }
 

--- a/popcorn/js/src/beam.ts
+++ b/popcorn/js/src/beam.ts
@@ -231,10 +231,6 @@ function buildArgs({
 }: BuildArgsArgs): string[] {
   const args = [...emulator, "--", ...BASE_ARGS, "-boot", BOOT_NAME];
 
-  if (true) {
-    args.push("-noshell");
-  }
-
   for (const app of CORE_APPS) {
     args.push("-pa", `/lib/${app}/ebin`);
   }


### PR DESCRIPTION
- `extra_apps` allows to add apps invisible to packager roots (e.g. adding OTP app as an entrypoint
- removes `-noshell` which shouldn't have any effect on non-tty apps and allow tty-ful apps to run