### PR TITLE
plugin: copy uncompressed binaries variants

### DIFF
--- a/popcorn/js/plugins/shared.ts
+++ b/popcorn/js/plugins/shared.ts
@@ -50,6 +50,7 @@ export async function popcorn(opts: Options): Promise<Prepared> {
   const useBrotli = opts.brotli ?? false;
   const strip = opts.strip ?? true;
   const assetVariants: CopyOptions["variants"] = [
+    "uncompressed",
     "gzip",
     useBrotli && "brotli",
   ];


### PR DESCRIPTION
.wasm blobs are served by user-controlled webserver and we can't force correct config for compression.