### PR TITLE
style: fix Wasm casing (WASM → Wasm)

### DIFF
--- a/.github/actions/build-otp-wasm/action.yml
+++ b/.github/actions/build-otp-wasm/action.yml
@@ -1,5 +1,5 @@
-name: Build OTP WASM
-description: Install the build toolchain, restore caches, and build OTP/BEAM for WASM
+name: Build OTP Wasm
+description: Install the build toolchain, restore caches, and build OTP/BEAM for Wasm
 
 inputs:
   build-mode:
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: debug
   otp-tag:
-    description: OTP git tag to build for WASM
+    description: OTP git tag to build for Wasm
     required: false
     default: OTP-28.3.1
   host-otp-version:
@@ -66,7 +66,7 @@ runs:
     - name: Reuse cached OTP/BEAM build
       if: steps.otp-build-cache.outputs.cache-hit == 'true'
       shell: bash
-      run: echo "Using cached OTP WASM build from popcorn/out"
+      run: echo "Using cached OTP Wasm build from popcorn/out"
 
     # scripts/build-beam.sh needs emconfigure and an erlc to compile the
     # preloaded modules the native bootstrap emulator embeds.
@@ -128,7 +128,7 @@ runs:
         env | awk -F'=' '{print length($0), $1}' | sort -rn | head -15
         printf "ulimit -s: %s  ARG_MAX: %s\n" "$(ulimit -s)" "$(getconf ARG_MAX)"
 
-    - name: Build OTP/BEAM for WASM
+    - name: Build OTP/BEAM for Wasm
       if: steps.otp-build-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |

--- a/.github/actions/verify-llv-app/action.yml
+++ b/.github/actions/verify-llv-app/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     # The same command a user runs: deps.get, llv.build (JS bundle + Popcorn
-    # runtime files + the WASM bundle) and the Phoenix asset pipeline.
+    # runtime files + the Wasm bundle) and the Phoenix asset pipeline.
     #
     # MIX_ENV is pinned to dev because the calling workflows set it to test for
     # their test jobs, and this check is about the developer flow: config/test.exs
@@ -34,7 +34,7 @@ runs:
     # Deliberately only asks whether the endpoint answers. What the response
     # contains, and whether every generated asset is in place, is covered by
     # local_live_view_build.yml — checking it again per example would make each
-    # run longer and add a race with the dev watcher, which recooks the WASM
+    # run longer and add a race with the dev watcher, which recooks the Wasm
     # bundle right after boot.
     - name: Boot the server
       shell: bash

--- a/.github/workflows/eval_in_wasm_build_test.yml
+++ b/.github/workflows/eval_in_wasm_build_test.yml
@@ -3,7 +3,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Eval in WASM Build & test
+name: Eval in Wasm Build & test
 
 on:
   push:
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build OTP/BEAM for WASM
+      - name: Build OTP/BEAM for Wasm
         uses: ./.github/actions/build-otp-wasm
         with:
           host-otp-version: &host_otp "28.3.1"

--- a/.github/workflows/examples_build_test.yml
+++ b/.github/workflows/examples_build_test.yml
@@ -38,8 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Produces popcorn/out with the OTP/BEAM WASM runtime (cached across runs).
-      - name: Build OTP/BEAM for WASM
+      # Produces popcorn/out with the OTP/BEAM Wasm runtime (cached across runs).
+      - name: Build OTP/BEAM for Wasm
         uses: ./.github/actions/build-otp-wasm
         with:
           host-otp-version: &host_otp "28.3.1"
@@ -47,7 +47,7 @@ jobs:
           with-crypto: "false"
 
       # The example is compiled to BEAM that runs on the OTP 28 / Elixir 1.19.5
-      # runtime shipped in the WASM VM, so the host toolchain must match it.
+      # runtime shipped in the Wasm VM, so the host toolchain must match it.
       # (Note: repo-wide mise.toml pins the older AtomVM toolchain, 1.17/OTP 26.)
       - name: Set up Elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
@@ -96,7 +96,7 @@ jobs:
         run: pnpm test
         working-directory: examples/hello-popcorn/assets
 
-      - name: Run IEx WASM e2e tests
+      - name: Run IEx Wasm e2e tests
         run: pnpm test
         working-directory: examples/iex-wasm/assets
 

--- a/.github/workflows/langtour_e2e_test.yml
+++ b/.github/workflows/langtour_e2e_test.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build OTP/BEAM for WASM
+      - name: Build OTP/BEAM for Wasm
         uses: ./.github/actions/build-otp-wasm
         with:
           host-otp-version: &host_otp "28.3.1"

--- a/.github/workflows/local_lv_compare_test.yml
+++ b/.github/workflows/local_lv_compare_test.yml
@@ -119,7 +119,7 @@ jobs:
         run: mix test
 
       # The host app is only exercised here, after AtomVM exists: `mix setup`
-      # builds the JS bundle and the WASM bundle, neither of which is committed.
+      # builds the JS bundle and the Wasm bundle, neither of which is committed.
       - name: Verify setup and phx.server
         uses: ./.github/actions/verify-llv-app
         with:

--- a/.github/workflows/local_lv_forms_test.yml
+++ b/.github/workflows/local_lv_forms_test.yml
@@ -121,7 +121,7 @@ jobs:
         run: mix test
 
       # The host app is only exercised here, after AtomVM exists: `mix setup`
-      # builds the JS bundle and the WASM bundle, neither of which is committed.
+      # builds the JS bundle and the Wasm bundle, neither of which is committed.
       - name: Verify setup and phx.server
         uses: ./.github/actions/verify-llv-app
         with:

--- a/.github/workflows/local_lv_thermostat_test.yml
+++ b/.github/workflows/local_lv_thermostat_test.yml
@@ -119,7 +119,7 @@ jobs:
         run: mix test
 
       # The host app is only exercised here, after AtomVM exists: `mix setup`
-      # builds the JS bundle and the WASM bundle, neither of which is committed.
+      # builds the JS bundle and the Wasm bundle, neither of which is committed.
       - name: Verify setup and phx.server
         uses: ./.github/actions/verify-llv-app
         with:

--- a/.github/workflows/otp_js_e2e_test.yml
+++ b/.github/workflows/otp_js_e2e_test.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build OTP/BEAM for WASM
+      - name: Build OTP/BEAM for Wasm
         uses: ./.github/actions/build-otp-wasm
         with:
           host-otp-version: &host_otp "28.3.1"
@@ -76,7 +76,7 @@ jobs:
           version: "1.61.1"
 
       # The e2e suite compiles and packages an OTP fixture app, so a host
-      # toolchain matching the WASM runtime is required even on cache hits.
+      # toolchain matching the Wasm runtime is required even on cache hits.
       - name: Setup Elixir and Erlang
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:

--- a/.github/workflows/popcorn_build_test.yml
+++ b/.github/workflows/popcorn_build_test.yml
@@ -80,5 +80,5 @@ jobs:
       - name: Run tests
         run: mix test
 
-      - name: Run WASM tests
+      - name: Run Wasm tests
         run: TARGET=wasm mix test

--- a/examples/eval-in-wasm/README.md
+++ b/examples/eval-in-wasm/README.md
@@ -1,4 +1,4 @@
-# Eval in WASM
+# Eval in Wasm
 
 A textarea-based code runner using Popcorn. Type Elixir or Erlang code and run it fully in the browser via WebAssembly.
 
@@ -26,4 +26,4 @@ Cross-Origin-Opener-Policy: "same-origin"
 Cross-Origin-Embedder-Policy: "require-corp"
 ```
 
-for the WASM runtime to work.
+for the Wasm runtime to work.

--- a/examples/eval-in-wasm/assets/erlang.html
+++ b/examples/eval-in-wasm/assets/erlang.html
@@ -6,7 +6,7 @@
     <meta name="code-language" content="erlang" />
     <link rel="icon" type="image/png" href="favicon-erl.png" />
     <link rel="stylesheet" href="style.css" />
-    <title>IEx x WASM x AtomVM</title>
+    <title>IEx x Wasm x AtomVM</title>
   </head>
 
   <body>

--- a/examples/eval-in-wasm/assets/index.html
+++ b/examples/eval-in-wasm/assets/index.html
@@ -6,7 +6,7 @@
     <meta name="code-language" content="elixir" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <link rel="stylesheet" href="style.css" />
-    <title>IEx x WASM x AtomVM</title>
+    <title>IEx x Wasm x AtomVM</title>
   </head>
 
   <body>

--- a/examples/game-of-life/lib/game_of_life/application.ex
+++ b/examples/game-of-life/lib/game_of_life/application.ex
@@ -15,7 +15,7 @@ defmodule GameOfLife.Application do
     Supervisor.start_link(children, opts)
   end
 
-  # The bridge exists only inside the OTP/WASM runtime; on the host BEAM
+  # The bridge exists only inside the OTP/Wasm runtime; on the host BEAM
   # (e.g. `mix test`) the app runs without the UI.
   defp ui() do
     if Popcorn.Wasm.available?() do

--- a/examples/game-of-life/mise.toml
+++ b/examples/game-of-life/mise.toml
@@ -1,4 +1,4 @@
-# The OTP/WASM runtime ships OTP 28 / Elixir 1.19.5, and this example is
+# The OTP/Wasm runtime ships OTP 28 / Elixir 1.19.5, and this example is
 # compiled to BEAM that runs inside it, so the local toolchain must match.
 # The repo-root mise.toml still pins the older AtomVM toolchain (1.17 / OTP 26);
 # once AtomVM support is dropped, this nested config can be removed.

--- a/examples/hello-popcorn/README.md
+++ b/examples/hello-popcorn/README.md
@@ -1,7 +1,7 @@
 # Hello Popcorn 👋
 
 This is a very simple example of using Popcorn with the OTP/BEAM WebAssembly
-runtime: it displays `Hello from WASM!` on the homepage and `Hello console!` in
+runtime: it displays `Hello from Wasm!` on the homepage and `Hello console!` in
 the browser console (see `lib/hello_popcorn.ex`).
 
 Install the JavaScript dependencies and build the OTP package from the

--- a/examples/hello-popcorn/assets/test/hello_popcorn.spec.ts
+++ b/examples/hello-popcorn/assets/test/hello_popcorn.spec.ts
@@ -2,10 +2,10 @@ import { expect, test } from "@playwright/test";
 
 const READY_TIMEOUT = 30_000;
 
-test("says hello from WASM", async ({ page }) => {
+test("says hello from Wasm", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.locator("body")).toHaveText("Hello from WASM!", {
+  await expect(page.locator("body")).toHaveText("Hello from Wasm!", {
     timeout: READY_TIMEOUT,
   });
 });

--- a/examples/hello-popcorn/lib/hello_popcorn.ex
+++ b/examples/hello-popcorn/lib/hello_popcorn.ex
@@ -14,7 +14,7 @@ defmodule HelloPopcorn do
     {:ok, _} =
       Popcorn.Wasm.run_js("""
       () => {
-        document.body.innerHTML = "Hello from WASM!";
+        document.body.innerHTML = "Hello from Wasm!";
       }
       """)
 

--- a/examples/hello-popcorn/mise.toml
+++ b/examples/hello-popcorn/mise.toml
@@ -1,4 +1,4 @@
-# The OTP/WASM runtime ships OTP 28 / Elixir 1.19.5, and this example is
+# The OTP/Wasm runtime ships OTP 28 / Elixir 1.19.5, and this example is
 # compiled to BEAM that runs inside it, so the local toolchain must match.
 # The repo-root mise.toml still pins the older AtomVM toolchain (1.17 / OTP 26);
 # once AtomVM support is dropped, this nested config can be removed.

--- a/examples/hello-popcorn/mix.exs
+++ b/examples/hello-popcorn/mix.exs
@@ -16,7 +16,7 @@ defmodule HelloPopcorn.MixProject do
     [
       # Only apps present in the OTP runtime manifest (kernel, stdlib,
       # compiler, elixir, logger) may be listed — they ship as tarballs baked
-      # into the OTP/WASM build. Other apps make the asset packer fail with a
+      # into the OTP/Wasm build. Other apps make the asset packer fail with a
       # missing dependency.
       extra_applications: [:logger],
       mod: {HelloPopcorn.Application, []}

--- a/examples/iex-wasm/assets/erlang.html
+++ b/examples/iex-wasm/assets/erlang.html
@@ -6,7 +6,7 @@
   <meta name="code-language" content="erlang" />
   <link rel="icon" type="image/png" href="favicon-erl.png" />
   <link rel="stylesheet" href="style.css" />
-  <title>erl x WASM x BEAM</title>
+  <title>erl x Wasm x BEAM</title>
 </head>
 <body>
   <h1 class="erl-color"><span class="erl-initial">erl</span> in the browser</h1>

--- a/examples/iex-wasm/assets/index.html
+++ b/examples/iex-wasm/assets/index.html
@@ -6,7 +6,7 @@
   <meta name="code-language" content="elixir" />
   <link rel="icon" type="image/png" href="favicon.png" />
   <link rel="stylesheet" href="style.css" />
-  <title>IEx x WASM x BEAM</title>
+  <title>IEx x Wasm x BEAM</title>
 </head>
 <body>
   <h1><span class="ex-initial">iex</span> in the browser</h1>

--- a/examples/iex-wasm/mise.toml
+++ b/examples/iex-wasm/mise.toml
@@ -1,6 +1,6 @@
 # The example has no Elixir code, but the packer shells out to `mix` and the
 # dev server to `elixir`, both inheriting this toolchain. It has to match the
-# OTP 28 / Elixir 1.19.5 the OTP/WASM runtime ships. The repo-root mise.toml
+# OTP 28 / Elixir 1.19.5 the OTP/Wasm runtime ships. The repo-root mise.toml
 # still pins the older AtomVM toolchain (1.17 / OTP 26); once AtomVM support is
 # dropped, this nested config can be removed.
 [tools]

--- a/examples/local-lv-burrito/assets/js/app.js
+++ b/examples/local-lv-burrito/assets/js/app.js
@@ -344,7 +344,7 @@ topbar.config({ barColors: { 0: "#29d" }, shadowColor: "rgba(0, 0, 0, .3)" });
 window.addEventListener("phx:page-loading-start", (_info) => topbar.show(300));
 window.addEventListener("phx:page-loading-stop", (_info) => topbar.hide());
 
-// Setup Local LiveViews (intercepts LLV data-pop-view elements and runs them via WASM)
+// Setup Local LiveViews (intercepts LLV data-pop-view elements and runs them via Wasm)
 import { LLVEngine } from "local_live_view";
 
 liveSocket.connect();

--- a/examples/local-lv-burrito/lib/burrito_web/components/info_modal.ex
+++ b/examples/local-lv-burrito/lib/burrito_web/components/info_modal.ex
@@ -29,7 +29,7 @@ defmodule BurritoWeb.InfoModal do
           <p>
             The same burrito form runs twice. Left as a standard Phoenix LiveView (server-rendered),
             right as <strong class="text-pop-brown">Local LiveView</strong>: Elixir code compiled
-            to WASM and running directly in the browser.
+            to Wasm and running directly in the browser.
           </p>
 
           <ul class="flex flex-col gap-2 list-none">

--- a/examples/local-lv-checkout/DEMO.md
+++ b/examples/local-lv-checkout/DEMO.md
@@ -39,7 +39,7 @@ CheckoutLive (Parent - Phoenix LiveView)
 CheckoutFormComponent (LiveComponent)
   └─ renders CheckoutLive local live view
 
-CheckoutLive (Local - LocalLiveView in WASM)
+CheckoutLive (Local - LocalLiveView in Wasm)
   └─ renders step form
   └─ handles field updates
   └─ handles navigation
@@ -117,7 +117,7 @@ Visit http://localhost:4000
 
 ### Current Limitation ⚠️
 - **Parent step indicator doesn't update in real-time** after navigation
-  - Reason: Parent is normal LiveView (server-side WebSocket), Local is WASM (client-side)
+  - Reason: Parent is normal LiveView (server-side WebSocket), Local is Wasm (client-side)
   - URL changes but parent doesn't get notified
   - This is the key problem that `handle_params` implementation would solve
 

--- a/examples/local-lv-checkout/IMPLEMENTATION_NOTES.md
+++ b/examples/local-lv-checkout/IMPLEMENTATION_NOTES.md
@@ -18,7 +18,7 @@ CheckoutLive (Phoenix LiveView)
   ├─ displays step indicator
   └─ renders <.local_live_view id={id} view="CheckoutLive" />
        ↓
-       CheckoutLive (LocalLiveView in WASM)
+       CheckoutLive (LocalLiveView in Wasm)
          ├─ independent state (form_data, current_step)
          ├─ handles mount/handle_params (but currently only on initial mount)
          └─ renders step forms

--- a/examples/local-lv-kanban/priv/repo/seeds.exs
+++ b/examples/local-lv-kanban/priv/repo/seeds.exs
@@ -81,7 +81,7 @@ boards = [
      {"Ideas",
       [
         "Learn Elixir LiveView",
-        {"Side project: WASM kanban", "Run local live views client-side."},
+        {"Side project: Wasm kanban", "Run local live views client-side."},
         "Read 'Designing Elixir Systems'"
       ]},
      {"Doing",

--- a/examples/local-lv-kanban/test/e2e_test.exs
+++ b/examples/local-lv-kanban/test/e2e_test.exs
@@ -128,7 +128,7 @@ defmodule LocalLvKanban.E2ETest do
 
   # The dev server used to build app.js/app.css on boot; in test env esbuild/tailwind
   # are `runtime: false`, so build them up front (in :dev) when missing. `mix llv.build`
-  # in the `test` alias already produced the WASM bundle + AtomVM.*; this fills the gap.
+  # in the `test` alias already produced the Wasm bundle + AtomVM.*; this fills the gap.
   defp ensure_assets! do
     unless File.regular?(Path.join(@app_root, "priv/static/assets/js/app.js")) do
       {_out, 0} =

--- a/examples/local-lv-kanban/test/playwright/README.md
+++ b/examples/local-lv-kanban/test/playwright/README.md
@@ -25,7 +25,7 @@ mix test --exclude e2e # fast: unit tests only (skip this suite)
 mix test --only e2e    # just this suite
 ```
 
-`mix test` prepends `mix llv.build`, so the WASM bundle the browser boots from is
+`mix test` prepends `mix llv.build`, so the Wasm bundle the browser boots from is
 current (adds ~30–60s; use `--exclude e2e` while iterating on unit tests). On a clean
 checkout the e2e test also builds `app.js`/`app.css` once via `mix assets.build`.
 

--- a/examples/local-lv-kanban/test/playwright/playwright.config.js
+++ b/examples/local-lv-kanban/test/playwright/playwright.config.js
@@ -14,9 +14,9 @@ const { defineConfig } = require("@playwright/test");
  */
 module.exports = defineConfig({
   testDir: "./tests",
-  // The board renders inside a WASM (Popcorn) runtime that boots per page; first
+  // The board renders inside a Wasm (Popcorn) runtime that boots per page; first
   // mount can take several seconds, so timeouts are generous.
-  // Generous timeouts: the WASM local live view runs in-browser and competes with the
+  // Generous timeouts: the Wasm local live view runs in-browser and competes with the
   // server + browser for CPU on constrained CI runners.
   timeout: 120_000,
   expect: { timeout: 30_000 },

--- a/examples/local-lv-kanban/test/playwright/tests/helpers.js
+++ b/examples/local-lv-kanban/test/playwright/tests/helpers.js
@@ -14,7 +14,7 @@ const columnByName = (page, name) => columns(page).filter({ hasText: name });
 // A task card located by its text.
 const taskCard = (page, text) => tasks(page).filter({ hasText: text });
 
-/** Wait until the WASM local live view has booted and rendered the board. */
+/** Wait until the Wasm local live view has booted and rendered the board. */
 async function waitForBoard(page) {
   // The heading now shows the board's own name, so the first rendered column is
   // the name-agnostic boot signal.
@@ -91,7 +91,7 @@ async function columnNames(page) {
 // JS that listens on window). Playwright's mouse-based dragTo does not fire those,
 // so we dispatch real DragEvents (with a DataTransfer) and let the bindings run.
 // Sequence: dragstart(src) -> dragover(target) -> dragend(src). The local view
-// processes them in order (waits give the WASM round-trips time to land).
+// processes them in order (waits give the Wasm round-trips time to land).
 
 // Dispatch a drag event on the first element matching `selector` whose text
 // contains `text`. The selector MUST be specific (TASK vs COLUMN): a column is an

--- a/examples/local-lv-kanban/test/playwright/tests/kanban.spec.js
+++ b/examples/local-lv-kanban/test/playwright/tests/kanban.spec.js
@@ -11,7 +11,7 @@ test.describe("board index + lifecycle", () => {
     // The local live view heading shows the board's own name.
     await expect(page.getByRole("heading", { name: "Untitled board", exact: true })).toBeVisible();
 
-    // Seeded columns render in the WASM local live view.
+    // Seeded columns render in the Wasm local live view.
     expect(await h.columnNames(page)).toEqual(SEEDED);
 
     // Opening the board recorded it in localStorage; the index renders it as a
@@ -229,7 +229,7 @@ test.describe("push failure (handle_push_error)", () => {
       }).observe(document.body, { childList: true, subtree: true, characterData: true });
     });
 
-    // add_column applies optimistically in WASM, then the failed push triggers
+    // add_column applies optimistically in Wasm, then the failed push triggers
     // handle_push_error, restoring the last authoritative board.
     await h.submitColumn(page, "Ghost");
     await page.waitForFunction(() => window.__llvTestSawGhost, null, { timeout: 15_000 });

--- a/examples/local-lv-pong/README.md
+++ b/examples/local-lv-pong/README.md
@@ -22,7 +22,7 @@ mix dev
 and visit [localhost:4000](http://localhost:4000).
 
 **Important: when the browser console is opened, the game slows down dramatically.**
-That's because the browser switches WASM engine to a debug-friendly one, which
+That's because the browser switches Wasm engine to a debug-friendly one, which
 is very slow. Closing the console may not help - you may have to reload the page
 or even reopen the tab.
 

--- a/landing-page/src/components/Steps.astro
+++ b/landing-page/src/components/Steps.astro
@@ -10,7 +10,7 @@ import Section from "./Section.astro";
 >
   <Step n="01">
     <Fragment slot="header-title">Elixir, meet <br /> WebAssembly.</Fragment>
-    <Fragment slot="title">Run your Elixir in WASM.</Fragment>
+    <Fragment slot="title">Run your Elixir in Wasm.</Fragment>
     <Fragment slot="description">
       Popcorn bridges your Elixir code with Wasm-compiled AtomVM runtime. No
       need to learn a new language – just use the one you already love.

--- a/local-live-view/assets/local_live_view/navigation.ts
+++ b/local-live-view/assets/local_live_view/navigation.ts
@@ -56,11 +56,11 @@ export function registerNavigationHandlers(
     llvHandleParams(window.location.href);
   });
 
-  // llv:navigate: LLV push_patch fires this event after the WASM-side
+  // llv:navigate: LLV push_patch fires this event after the Wasm-side
   // handle_params has run. We write the history entry per mode:
   //  - hosted: hand to Phoenix via pushHistoryPatch (Phoenix-owned patch entry + host
   //    handle_params); the phx:navigate echo is skipped via lastLLVNavigatedHref.
-  //  - standalone: just write the URL bar — the WASM side already ran handle_params.
+  //  - standalone: just write the URL bar — the Wasm side already ran handle_params.
   window.addEventListener("llv:navigate", (e: Event) => {
     const { href, replace } = (e as CustomEvent<{ href: string; replace: boolean }>).detail;
     lastLLVNavigatedHref = absHref(href);
@@ -87,7 +87,7 @@ export function registerNavigationHandlers(
   // phx:navigate: forward Phoenix LiveView patch navigations to all LLV views (hosted
   // mode only — never dispatched in dead mode). Fires for <.link patch> clicks and
   // browser back/forward. Skip navigations LLV itself triggered via push_patch, since
-  // LLV already ran handle_params on the WASM side for those.
+  // LLV already ran handle_params on the Wasm side for those.
   window.addEventListener("phx:navigate", (e: Event) => {
     const detail = (e as CustomEvent<{ href?: string; patch?: boolean }>).detail;
     if (!detail?.patch) return;

--- a/local-live-view/assets/local_live_view/transport.ts
+++ b/local-live-view/assets/local_live_view/transport.ts
@@ -4,7 +4,7 @@ import type { PopcornClient } from "./index";
 
 const llvIdFromTopic = (topic: string) => topic.slice("lv:".length);
 
-// Frames the WASM view must answer. Each entry needs a matching
+// Frames the Wasm view must answer. Each entry needs a matching
 // Message clause in LocalLiveView.Server.
 // Anything else — heartbeats, phx_leave — is acked in place
 // as Popcorn may be not booted yet.

--- a/local-live-view/assets/local_live_view/types.ts
+++ b/local-live-view/assets/local_live_view/types.ts
@@ -4,7 +4,7 @@ import type { LiveSocketInstanceInterface } from "phoenix_live_view";
 // --- Public API ---
 
 export interface LLVConfig {
-  /** Paths to compiled WASM bundle files. Defaults to `["wasm/bundle.avm"]` */
+  /** Paths to compiled Wasm bundle files. Defaults to `["wasm/bundle.avm"]` */
   bundlePaths?: string[];
   /** Enable Popcorn debug logging */
   debug?: boolean;
@@ -20,7 +20,7 @@ export interface LLVConfig {
 
 // --- Internal Phoenix types ---
 
-/** Opaque rendered diff payload delivered from WASM via structuredClone */
+/** Opaque rendered diff payload delivered from Wasm via structuredClone */
 export type RenderedDiff = Record<string, unknown>;
 
 /** A raw Phoenix channel frame as it crosses the (fake) transport. */

--- a/local-live-view/lib/local_live_view/utils.ex
+++ b/local-live-view/lib/local_live_view/utils.ex
@@ -2,7 +2,7 @@ defmodule LocalLiveView.Utils do
   @moduledoc false
 
   @doc """
-  Recursively turns a term into something JSON-serializable to cross the WASM
+  Recursively turns a term into something JSON-serializable to cross the Wasm
   boundary: structs become maps, map keys become strings, lists are mapped
   through. Used when sending assigns/payloads from the runtime to JS.
   """

--- a/local-live-view/lib/mix/tasks/llv.build.ex
+++ b/local-live-view/lib/mix/tasks/llv.build.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Llv.Build do
   use Mix.Task
 
-  @shortdoc "Copies LLV runtime assets and builds the WASM bundle"
+  @shortdoc "Copies LLV runtime assets and builds the Wasm bundle"
 
   @moduledoc """
-  Copies LocalLiveView runtime files into the host project and builds the WASM bundle.
+  Copies LocalLiveView runtime files into the host project and builds the Wasm bundle.
 
   ## Steps
 
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Llv.Build do
        from `deps/local_live_view/priv/static/` into `priv/static/assets/js/`.
        These must be served alongside Phoenix's `app.js` so Popcorn's
        `import.meta.url`-based lookups resolve.
-    2. Runs `mix build` inside `local/` to compile the WASM bundle.
+    2. Runs `mix build` inside `local/` to compile the Wasm bundle.
 
   ## Usage
 
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Llv.Build do
 
   @impl Mix.Task
   def run(args) do
-    # `--local` points at the local (WASM) project. Defaults to "local" (a
+    # `--local` points at the local (Wasm) project. Defaults to "local" (a
     # subdirectory of the host app); in an umbrella it's a sibling, e.g.
     # `mix llv.build --local ../local`.
     {opts, _} = OptionParser.parse!(args, strict: [local: :string])
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Llv.Build do
       File.cp!(Path.join(src_dir, file), Path.join(dst_dir, file))
     end
 
-    Mix.shell().info("[llv] Building WASM bundle...")
+    Mix.shell().info("[llv] Building Wasm bundle...")
     0 = Mix.shell().cmd("mix build", cd: local_dir)
   end
 end

--- a/local-live-view/lib/mix/tasks/llv.install.ex
+++ b/local-live-view/lib/mix/tasks/llv.install.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Llv.Install do
     * Generate a HelloLocalLive LiveView that renders it and route it at `/hello_local`
 
   `mix setup` will then run `mix llv.build` which copies the LLV JS runtime files
-  into your project's `priv/static/assets/js/` and builds the WASM bundle from `local/`.
+  into your project's `priv/static/assets/js/` and builds the Wasm bundle from `local/`.
   """
 
   @templates_dir Path.expand("../../../priv/templates/llv.install", __DIR__)
@@ -83,7 +83,7 @@ defmodule Mix.Tasks.Llv.Install do
       else
         :error ->
           {:warning,
-           "Could not find use Phoenix.Endpoint. Add LLV socket and WASM security headers manually."}
+           "Could not find use Phoenix.Endpoint. Add LLV socket and Wasm security headers manually."}
       end
     end
   end

--- a/local-live-view/lib/server/mirror.ex
+++ b/local-live-view/lib/server/mirror.ex
@@ -50,7 +50,7 @@ defmodule LocalLiveView.Mirror do
 
   These are the assigns last returned by the view's
   `c:LocalLiveView.Mirror.handle_sync/3`. Returns an empty map when no local
-  live view is currently joined under that id, for example before the WASM
+  live view is currently joined under that id, for example before the Wasm
   runtime has started.
 
   The browser is the source of truth here — mirror assigns are the server's view

--- a/local-live-view/lib/server/watcher.ex
+++ b/local-live-view/lib/server/watcher.ex
@@ -81,7 +81,7 @@ defmodule LocalLiveView.Watcher do
 
   @impl true
   def handle_info(:cooked, state) do
-    # Phoenix doesn't watch for WASM files by default
+    # Phoenix doesn't watch for Wasm files by default
     # so we touch a stub JS file.
     File.touch!("priv/static/assets/js/wasm/_reload.js")
 

--- a/local-live-view/mix.exs
+++ b/local-live-view/mix.exs
@@ -116,7 +116,7 @@ defmodule LocalLiveView.MixProject do
         Guides: ~r"/guides/"
       ],
       groups_for_modules: [
-        "Browser / WASM (Popcorn)": [
+        "Browser / Wasm (Popcorn)": [
           ~r/^LocalLiveView$/
         ],
         "Server Side": [

--- a/local-live-view/pages/getting-started/installation.md
+++ b/local-live-view/pages/getting-started/installation.md
@@ -38,14 +38,14 @@ The installer configures your project automatically:
 | What | Where |
 |---|---|
 | Adds `LocalLiveView.Socket` | `lib/*_web/endpoint.ex` |
-| Adds COOP/COEP security headers (required for WASM) | `lib/*_web/endpoint.ex` |
+| Adds COOP/COEP security headers (required for Wasm) | `lib/*_web/endpoint.ex` |
 | Registers `LocalLiveView.ChannelRegistry` | `lib/<app>/application.ex` |
 | Imports `LocalLiveView.Component` | `lib/*_web.ex` (html_helpers) |
 | Changes app.js script tag to `type="module"` | `lib/*_web/components/layouts/root.html.heex` |
 | Adds `LLVEngine.create` call for the JS bridge | `assets/js/app.js` |
 | Adds `local_live_view` JS package | `assets/package.json` |
 | Replaces esbuild watcher with `build.mjs` | `mix.exs`, `config/dev.exs` |
-| Generates the `local/` WASM project | `local/` |
+| Generates the `local/` Wasm project | `local/` |
 
 > **Manual fallback:** If the installer can't find a file (e.g. your project has a non-standard structure), it prints the exact snippet to add manually.
 
@@ -57,7 +57,7 @@ mix setup
 
 The installer already added `llv.build` to the `setup` alias in `mix.exs`. `llv.build` creates popcorn runtime for browser-side elixir.
 
-This compiles your `local/` project to a WASM bundle at `priv/static/assets/js/wasm/bundle.avm`.
+This compiles your `local/` project to a Wasm bundle at `priv/static/assets/js/wasm/bundle.avm`.
 
 
 ## Step 4 — Start the server
@@ -81,7 +81,7 @@ local/
 │   │   └── application.ex  # OTP application
 │   └── hello_local.ex      # Sample LocalLiveView
 ├── .formatter.exs
-└── mix.exs                 # Compiles to WASM via popcorn.cook
+└── mix.exs                 # Compiles to Wasm via popcorn.cook
 ```
 
 Now you can add your LocalLiveView modules to `local/lib/`. When the server is running, the LLV watcher detects changes and automatically rebuilds the local code. To enforce rebuild, run `mix llv.build` and restart the server.

--- a/local-live-view/pages/guides/first-view.md
+++ b/local-live-view/pages/guides/first-view.md
@@ -50,7 +50,7 @@ Use the `<.local_live_view>` component in any Phoenix template:
 <.local_live_view view="CounterLocal" />
 ```
 
-The `view` attribute is the module name as a string. The component renders a `<div>` that becomes the mount point for the WASM view.
+The `view` attribute is the module name as a string. The component renders a `<div>` that becomes the mount point for the Wasm view.
 
 The counter is now fully local — clicks are handled in the browser with no server round-trips.
 
@@ -87,7 +87,7 @@ end
 
 ## Multiple views on one page
 
-Each `<.local_live_view>` on the page runs as an independent process in the WASM runtime. You can mount as many as you need:
+Each `<.local_live_view>` on the page runs as an independent process in the Wasm runtime. You can mount as many as you need:
 
 ```heex
 <.local_live_view view="CounterLocal" />

--- a/local-live-view/pages/guides/navigation.md
+++ b/local-live-view/pages/guides/navigation.md
@@ -1,9 +1,9 @@
 # Navigation
 
 LocalLiveView supports patch navigation: updating the URL and re-running
-`handle_params/3` without a full page reload. The state update runs in the WASM
+`handle_params/3` without a full page reload. The state update runs in the Wasm
 VM, so it needs no network call; the URL change is coordinated between the Elixir
-code running in WASM, the Phoenix LiveView JavaScript runtime, and the browser.
+code running in Wasm, the Phoenix LiveView JavaScript runtime, and the browser.
 
 ## Two modes
 
@@ -49,8 +49,8 @@ def handle_event("select_tab", %{"tab" => tab}, socket) do
 end
 ```
 
-The state update happens client-side: `handle_params/3` runs in the WASM VM and
-its diff is applied to the DOM with no network call. The WASM side then emits an
+The state update happens client-side: `handle_params/3` runs in the Wasm VM and
+its diff is applied to the DOM with no network call. The Wasm side then emits an
 `llv:navigate` event, and how the history entry is written depends on the mode:
 
 * **Standalone** - the JS layer writes the browser history entry directly. No
@@ -76,8 +76,8 @@ so `handle_params/3` is not run twice for the same navigation.
 
 ```mermaid
 flowchart TD
-    PP["push_patch/2 (LLV)"] --> WASM["handle_params/3 runs in WASM, diff to DOM"]
-    WASM --> EMIT["local_live_view server emits llv:navigate event"]
+    PP["push_patch/2 (LLV)"] --> Wasm["handle_params/3 runs in Wasm, diff to DOM"]
+    Wasm --> EMIT["local_live_view server emits llv:navigate event"]
     EMIT --> H{Hosted?}
     H -- yes --> PHX["route through Phoenix, phx:navigate echo de-duplicated"]
     H -- no --> HIST["write browser history directly"]

--- a/local-live-view/pages/introduction/welcome.md
+++ b/local-live-view/pages/introduction/welcome.md
@@ -15,7 +15,7 @@ The result: **zero-latency UI**, offline capability, and a familiar Elixir/LiveV
 ```
            Server                                      Browser                 
 ┌───────────────────────────────┐              ┌──────────────────────────────┐
-│ Phoenix LiveView (host)       │              │ Popcorn (AtomVM WASM)        │
+│ Phoenix LiveView (host)       │              │ Popcorn (AtomVM Wasm)        │
 │                               │              │                              │
 │ render/1                      │              │ MyLocal                      │
 │   <.local_live_view           │              │   mount/3                    │
@@ -30,16 +30,16 @@ The result: **zero-latency UI**, offline capability, and a familiar Elixir/LiveV
 └───────────────────────────────┘              └──────────────────────────────┘
 ```
 
-1. Your `local/` project is compiled to a `.avm` WASM bundle at build time.
+1. Your `local/` project is compiled to a `.avm` Wasm bundle at build time.
 2. A server-side LiveView renders the mount point with `<.local_live_view view="MyLocal" />`. Every attribute other than `view` is passed down as assigns and delivered to the local view's `update/2` callback — so the host stays in control of the data, exactly as with `live_component/1`.
-3. When the page loads, Popcorn starts the WASM runtime and mounts your LocalLiveViews.
+3. When the page loads, Popcorn starts the Wasm runtime and mounts your LocalLiveViews.
 4. User interactions are handled in the browser — no round-trip to the server.
 5. A local view can push events back to its host with `push_server_event/3`, which arrives at the host LiveView's `handle_event/3`. Handling the event locally first and pushing afterwards gives you optimistic updates, with the server's authoritative state arriving as the next `update/2`.
 6. Optionally, you can sync selected assigns to a server-side mirror module via `mirror_sync/2`, letting other users' LiveViews react to local state changes.
 
 ## Key concepts
 
-**LocalLiveView module** — An Elixir module that uses `use LocalLiveView` and implements `mount/3`, `render/1`, and optionally `handle_event/3`. Lives in the `local/` project (compiled to WASM).
+**LocalLiveView module** — An Elixir module that uses `use LocalLiveView` and implements `mount/3`, `render/1`, and optionally `handle_event/3`. Lives in the `local/` project (compiled to Wasm).
 
 **`local/` project** — A separate Mix project inside your Phoenix app, built via `mix llv.build`. The `local/` project depends on `:local_live_view` and contains all your client-side Elixir code.
 

--- a/local-live-view/priv/templates/llv.install/hello_local.ex
+++ b/local-live-view/priv/templates/llv.install/hello_local.ex
@@ -5,7 +5,7 @@ defmodule HelloLocal do
   def render(assigns) do
     ~H"""
     <div>
-      <p>Hello from WASM!</p>
+      <p>Hello from Wasm!</p>
     </div>
     """
   end

--- a/local-live-view/test/mix/tasks/llv_install_e2e_test.exs
+++ b/local-live-view/test/mix/tasks/llv_install_e2e_test.exs
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
   Spins up a fresh Phoenix project via `mix phx.new` in a temp dir,
   injects local_live_view as a path dep, runs `mix llv.install` + `mix setup`,
   starts `mix phx.server`, and uses Playwright to assert that the bundled
-  HelloLocal component renders "Hello from WASM!" in the browser.
+  HelloLocal component renders "Hello from Wasm!" in the browser.
 
   Slow (~1-2 min) — covers what unit tests can't: real `mix llv.build`,
   real esbuild + popcorn.cook + AtomVM bootstrap, real DOM render.
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Llv.InstallE2ETest do
     wait_for(
       fn ->
         text = Playwright.Page.text_content(page, "body")
-        assert text =~ "Hello from WASM!"
+        assert text =~ "Hello from Wasm!"
       end,
       @assertion_timeout
     )

--- a/mise.toml
+++ b/mise.toml
@@ -20,11 +20,11 @@ description = "Build AtomVM"
 
 [tasks.build-openssl]
 run = "scripts/build-openssl.sh"
-description = "Build OpenSSL for WASM"
+description = "Build OpenSSL for Wasm"
 
 [tasks.build-otp]
 run = "scripts/build-beam.sh"
-description = "Build OTP/BEAM for WASM"
+description = "Build OTP/BEAM for Wasm"
 
 [tasks.build-otp-js]
 depends = ["build-otp debug"]
@@ -41,7 +41,7 @@ description = "Watch & rebuild LocalLiveView JS bundle"
 
 [tasks.build-otp-with-crypto]
 run = "scripts/build-beam.sh --with-crypto"
-description = "Build OTP/BEAM for WASM with crypto/asn1 NIFs"
+description = "Build OTP/BEAM for Wasm with crypto/asn1 NIFs"
 
 [tasks.regenerate-otp-patches]
 run = "scripts/patch-beam.sh --regen"

--- a/popcorn-2/elixir/lib/mix/tasks/popcorn.server.ex
+++ b/popcorn-2/elixir/lib/mix/tasks/popcorn.server.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Popcorn.Server do
-  @shortdoc "Starts a static file server with COOP/COEP headers for running WASM."
+  @shortdoc "Starts a static file server with COOP/COEP headers for running Wasm."
   @moduledoc """
   #{@shortdoc}
 

--- a/popcorn-2/elixir/lib/popcorn/api/wasm.ex
+++ b/popcorn-2/elixir/lib/popcorn/api/wasm.ex
@@ -137,7 +137,7 @@ defmodule Popcorn.Wasm do
   end
 
   @doc """
-  Runs JS code in the WASM iframe context. Takes a JS function as a string.
+  Runs JS code in the Wasm iframe context. Takes a JS function as a string.
   Returns list of `TrackedObject` (or values directly, see `return`) for each value in an array returned from JS function.
 
   ## Options

--- a/popcorn-2/elixir/pages/getting_started/first_steps.md
+++ b/popcorn-2/elixir/pages/getting_started/first_steps.md
@@ -59,7 +59,7 @@ defmodule MyApp.Worker do
   @impl true
   def init(_init_arg) do
     Popcorn.Wasm.ready(@process_name)
-    IO.puts("Hello from WASM!")
+    IO.puts("Hello from Wasm!")
     {:ok, %{}}
   end
 end
@@ -123,7 +123,7 @@ The JavaScript build step bundles your JavaScript, copies the WebAssembly runtim
 
 ### Serving the artifacts
 
-Run `mix popcorn.server` to start a local server. Then, at <http://localhost:4000>, you should see `Hello from WASM` printed in the browser console.
+Run `mix popcorn.server` to start a local server. Then, at <http://localhost:4000>, you should see `Hello from Wasm` printed in the browser console.
 
 The webpage can also be hosted with any HTTP static file server, but **it must add the following HTTP headers**:
 
@@ -132,7 +132,7 @@ Cross-Origin-Opener-Policy: same-origin
 Cross-Origin-Embedder-Policy: require-corp
 ```
 
-Otherwise, browsers refuse to run WASM.
+Otherwise, browsers refuse to run Wasm.
 
 ## Popcorn project files structure
 

--- a/popcorn-2/elixir/pages/getting_started/introduction.md
+++ b/popcorn-2/elixir/pages/getting_started/introduction.md
@@ -24,7 +24,7 @@
 
 Popcorn provides seamless APIs for communication between your Elixir and JavaScript code, handling serialization and ensuring browser responsiveness while your Elixir processes work in the background.
 
-## How Popcorn uses WASM
+## How Popcorn uses Wasm
 
 Popcorn takes a unique approach to Wasm in the Elixir ecosystem. Unlike [Wasmex](https://github.com/tessi/wasmex), which allows you to execute existing Wasm modules within Elixir on the _server_, Popcorn is run entirely in the _browser_.
 

--- a/popcorn-2/elixir/pages/reference/architecture.md
+++ b/popcorn-2/elixir/pages/reference/architecture.md
@@ -46,12 +46,12 @@ The patching is currently not exposed to users.
 sequenceDiagram
     participant MW as Main Window
     participant IF as iframe
-    participant WM as WASM Module
+    participant WM as Wasm Module
     participant AVM as AtomVM
     participant EA as Elixir App
 
     MW->>IF: Create iframe, load scripts
-    IF->>WM: Initialize WASM module
+    IF->>WM: Initialize Wasm module
     WM->>AVM: Start AtomVM runtime
     AVM->>EA: Load and start application
     EA->>AVM: Wasm.send_elixir_ready()

--- a/popcorn-2/elixir/patches/otp/stdlib/shell.erl
+++ b/popcorn-2/elixir/patches/otp/stdlib/shell.erl
@@ -65,7 +65,7 @@ non_builtin_local_func(F,As,Bs, FT) ->
 %%    end.
 
 %% Patch reason: even if the module is loaded in AtomVM it does not mean that 
-%% the path to the file is correct as we operate in WASM in Browser.
+%% the path to the file is correct as we operate in Wasm in Browser.
 %% Also - user_default module is never loaded in AtomVM.
 initiate_records(Bs, RT) ->
     RNs1 = popcorn_module:init_rec(shell_default, Bs, RT),

--- a/popcorn-2/js/src/errors.ts
+++ b/popcorn-2/js/src/errors.ts
@@ -90,7 +90,7 @@ export function buildError(error: ErrorData): PopcornInternalError {
         "Iframe already mounted",
       );
     case "unmounted":
-      return new PopcornInternalError("unmounted", "WASM iframe not mounted");
+      return new PopcornInternalError("unmounted", "Wasm iframe not mounted");
     case "bad_target":
       return new PopcornInternalError(
         "bad_target",

--- a/popcorn-2/js/src/iframe.ts
+++ b/popcorn-2/js/src/iframe.ts
@@ -16,7 +16,7 @@ type EmscriptenFS = {
   writeFile: (path: string, data: Int8Array) => void;
 };
 
-/** AtomVM Module interface - the WASM module with Elixir runtime */
+/** AtomVM Module interface - the Wasm module with Elixir runtime */
 type AtomVMModule = {
   serialize: (data: AnySerializable) => string;
   deserialize: (

--- a/popcorn-2/js/src/popcorn.ts
+++ b/popcorn-2/js/src/popcorn.ts
@@ -94,7 +94,7 @@ const INIT_TOKEN = Symbol();
 const IFRAME_URL = new URL("./iframe.mjs", import.meta.url).href;
 
 /**
- * Manages Elixir by setting up iframe, WASM module, and event listeners. Used to sent messages to Elixir processes.
+ * Manages Elixir by setting up iframe, Wasm module, and event listeners. Used to sent messages to Elixir processes.
  */
 export class Popcorn {
   public heartbeatTimeoutMs: number | null = null;

--- a/popcorn/js/plugins/shared.ts
+++ b/popcorn/js/plugins/shared.ts
@@ -216,7 +216,7 @@ function errorLines(error: unknown): string[] {
       .map(({ app, capability }) => `${app} (needs ${capability})`)
       .join(", ");
     return [
-      `These applications need native support the WASM runtime wasn't built`,
+      `These applications need native support the Wasm runtime wasn't built`,
       `with: ${apps}.`,
       `Drop them from your dependencies, or use a runtime built with it.`,
     ];

--- a/popcorn/js/scripts/setup-assets.sh
+++ b/popcorn/js/scripts/setup-assets.sh
@@ -23,11 +23,11 @@ have_runtime_artifacts() {
 
 ensure_runtime_artifacts() {
   if have_runtime_artifacts; then
-    echo "popcorn/js: using existing OTP WASM artifacts from ${OUT_DIR}"
+    echo "popcorn/js: using existing OTP Wasm artifacts from ${OUT_DIR}"
     return
   fi
 
-  echo "popcorn/js: building OTP WASM artifacts..."
+  echo "popcorn/js: building OTP Wasm artifacts..."
   "${PROJECT_ROOT}/scripts/build-beam.sh" debug
 }
 

--- a/popcorn/mise.toml
+++ b/popcorn/mise.toml
@@ -1,4 +1,4 @@
-# The OTP/WASM runtime ships OTP 28 / Elixir 1.19.5, and this package is
+# The OTP/Wasm runtime ships OTP 28 / Elixir 1.19.5, and this package is
 # compiled to BEAM that runs inside it, so the local toolchain must match.
 # The repo-root mise.toml still pins the older AtomVM toolchain (1.17 / OTP 26);
 # once AtomVM support is dropped, this nested config can be removed.

--- a/popcorn/utils/popcorn_server.ex
+++ b/popcorn/utils/popcorn_server.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Popcorn.Server do
-  @shortdoc "Starts a static file server with COOP/COEP headers for running WASM."
+  @shortdoc "Starts a static file server with COOP/COEP headers for running Wasm."
   @moduledoc """
   #{@shortdoc}
 

--- a/scripts/build-atomvm.sh
+++ b/scripts/build-atomvm.sh
@@ -17,8 +17,8 @@ Usage: $0 [OPTIONS] <build-mode>
 Build AtomVM from source.
 
 Build modes (positional):
-  debug-wasm      Build debug WASM target
-  release-wasm    Build release WASM target
+  debug-wasm      Build debug Wasm target
+  release-wasm    Build release Wasm target
   debug-unix      Build debug Unix target
   release-unix    Build release Unix target
 
@@ -129,7 +129,7 @@ ensure_ninja() {
 
 ensure_emscripten() {
     if ! command -v emcmake &> /dev/null; then
-        error "emscripten is required for WASM builds but not found. Please install emscripten."
+        error "emscripten is required for Wasm builds but not found. Please install emscripten."
     fi
 }
 
@@ -196,7 +196,7 @@ build_wasm() {
     local jobs="$6"
     local build_dir="${atomvm_dir}/src/platforms/emscripten/build"
 
-    log "Building WASM target (${build_type})"
+    log "Building Wasm target (${build_type})"
 
     ensure_ninja
     ensure_emscripten
@@ -247,7 +247,7 @@ build_wasm() {
         gzip -9 -k -f "${out_dir}/AtomVM.mjs"
     fi
 
-    success "WASM build complete. Artifacts written to: ${out_dir}"
+    success "Wasm build complete. Artifacts written to: ${out_dir}"
 }
 
 main() {

--- a/scripts/build-beam.sh
+++ b/scripts/build-beam.sh
@@ -225,7 +225,7 @@ build_openssl() {
     local mode="$1"
     local jobs="$2"
 
-    log "Building OpenSSL for WASM..."
+    log "Building OpenSSL for Wasm..."
     local openssl_args=("${mode}")
     if [[ -n "${jobs}" ]]; then
         openssl_args+=("-j" "${jobs}")
@@ -399,7 +399,7 @@ build_beam() {
     local mode="$2"
     local jobs="$3"
 
-    log "Building BEAM for WASM (${mode}, ${jobs} jobs)..."
+    log "Building BEAM for Wasm (${mode}, ${jobs} jobs)..."
 
     local extra_emcc_link_flags
     extra_emcc_link_flags=$(emulator_link_settings "${mode}")

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -48,7 +48,7 @@ require_cmd() {
 ensure_wasm_assets() {
     local js_dir="$1"
     if [[ ! -f "${js_dir}/assets/AtomVM.wasm" ]]; then
-        log "WASM assets not found, building..."
+        log "Wasm assets not found, building..."
         cd "${js_dir}"
         pnpm run setup
     fi

--- a/scripts/runtime-manifest.sh
+++ b/scripts/runtime-manifest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Write the WASM runtime manifest describing the built emulator.
+# Write the Wasm runtime manifest describing the built emulator.
 #
 # BEAM applications are packaged from the user's own Erlang/Elixir
 # installation at build time, so the manifest only records what the emulator
@@ -23,7 +23,7 @@ usage() {
     cat << EOF
 Usage: $0 [OPTIONS]
 
-Write the WASM runtime manifest describing the built emulator.
+Write the Wasm runtime manifest describing the built emulator.
 
 Options:
   --beam-dir <path>       OTP build directory (default: popcorn/sources/otp)


### PR DESCRIPTION
Use canonical “Wasm” casing across the codebase. WASM → Wasm

According to the [WebAssembly spec 3.0](https://webassembly.github.io/spec/core/intro/introduction.html): 
> WebAssembly (abbreviated Wasm [[1]](https://webassembly.github.io/spec/core/intro/introduction.html#wasm)) 
> [[1] “A contraction of “WebAssembly”, not an acronym, hence not using all-caps."](https://webassembly.github.io/spec/core/intro/introduction.html#wasm)

I skipped changing popcorn/patches/0001-emscripten-support.patch to avoid possible issues