### PR TITLE
landing: add website metadata

### DIFF
--- a/landing-page/src/layouts/Layout.astro
+++ b/landing-page/src/layouts/Layout.astro
@@ -12,6 +12,40 @@ import {
   TOP_BAR_BANNER,
 } from "../components/TopBarBanner";
 
+interface Props {
+  title?: string;
+  description?: string;
+}
+
+const {
+  title = "Popcorn: Elixir & Wasm",
+  description = "Compile Elixir to Wasm and run it in the browser with no extra setup.",
+} = Astro.props;
+
+const canonical = new URL(Astro.url.pathname, Astro.site).href;
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://swmansion.com/#organization",
+      name: "Software Mansion",
+      url: "https://swmansion.com",
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://popcorn.swmansion.com/#software",
+      name: "Popcorn",
+      url: "https://popcorn.swmansion.com",
+      description: "Compile Elixir to Wasm and run it in the browser with no extra setup.",
+      applicationCategory: "DeveloperApplication",
+      operatingSystem: "Web",
+      publisher: { "@id": "https://swmansion.com/#organization" },
+    },
+  ],
+};
+
 const firstZone = TOP_BAR_BANNER!.zones[0];
 const reservationScript = topBarBannerReservationScript(
   firstZone.zoneId,
@@ -31,26 +65,23 @@ const bannerHidden = isBannerHidden(
     <meta name="viewport" content="width=device-width" />
     {import.meta.env.PROD && <script is:inline src="/cookie-script.js" />}
     <script is:inline set:html={reservationScript} />
-    <title>Popcorn: Elixir & Wasm</title>
-    <meta
-      name="description"
-      content="Compile Elixir to Wasm and run it in the browser with no extra setup."
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="canonical" href={canonical} />
+    <script
+      is:inline
+      type="application/ld+json"
+      set:html={JSON.stringify(structuredData).replace(/</g, "\\u003c")}
     />
 
-    <meta property="og:title" content="Popcorn: Elixir & Wasm" />
-    <meta
-      property="og:description"
-      content="Compile Elixir to Wasm and run it in the browser with no extra setup."
-    />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Popcorn" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Popcorn: Elixir & Wasm" />
-    <meta
-      name="twitter:description"
-      content="Compile Elixir to Wasm and run it in the browser with no extra setup."
-    />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon.png" type="image/png" sizes="49x80" />
     <link

--- a/landing-page/src/pages/demos/eval.astro
+++ b/landing-page/src/pages/demos/eval.astro
@@ -4,7 +4,10 @@ import Section from "../../components/Section.astro";
 import { Icon } from "astro-icon/components";
 ---
 
-<Layout>
+<Layout
+  title="Demo: eval | Popcorn"
+  description="Evaluate Elixir expressions in the browser, compiled to Wasm."
+>
   <Section background="light" class="max-w-2xl gap-4 self-center">
     <h1 class="font-handjet text-brown-header mb-4 text-center text-6xl">
       Elixir Eval Demo

--- a/landing-page/src/pages/demos/game-of-life.astro
+++ b/landing-page/src/pages/demos/game-of-life.astro
@@ -3,7 +3,10 @@ import Layout from "../../layouts/Layout.astro";
 import Section from "../../components/Section.astro";
 ---
 
-<Layout>
+<Layout
+  title="Demo: game of life | Popcorn"
+  description="Conway's game of life running on Elixir compiled to Wasm."
+>
   <Section background="light">
     <header class="mb-4 text-center">
       <h1

--- a/landing-page/src/pages/demos/local-forms.astro
+++ b/landing-page/src/pages/demos/local-forms.astro
@@ -3,7 +3,10 @@ import Layout from "../../layouts/Layout.astro";
 import Section from "../../components/Section.astro";
 ---
 
-<Layout>
+<Layout
+  title="Demo: local forms | Popcorn"
+  description="Form handling driven entirely client-side by Elixir in the browser."
+>
   <Section background="light">
     <header class="mb-4 text-center">
       <h1

--- a/landing-page/src/pages/demos/local-thermostat.astro
+++ b/landing-page/src/pages/demos/local-thermostat.astro
@@ -3,7 +3,10 @@ import Layout from "../../layouts/Layout.astro";
 import Section from "../../components/Section.astro";
 ---
 
-<Layout>
+<Layout
+  title="Demo: local thermostat | Popcorn"
+  description="Stateful UI backed by an Elixir process running in the browser."
+>
   <Section background="light">
     <header class="mb-4 text-center">
       <h1

--- a/landing-page/src/pages/llms.txt.ts
+++ b/landing-page/src/pages/llms.txt.ts
@@ -1,0 +1,55 @@
+import type { APIRoute } from "astro";
+
+const SITE = "https://popcorn.swmansion.com";
+
+const SUMMARY =
+  "Popcorn compiles Elixir to WebAssembly and runs it in the browser with no extra setup. Built by Software Mansion.";
+
+const PAGES = [
+  {
+    path: "/",
+    title: "Popcorn",
+    description: "What Popcorn does and how to start",
+  },
+  {
+    path: "/demos/eval",
+    title: "Demo: eval",
+    description: "Evaluate Elixir expressions in the browser",
+  },
+  {
+    path: "/demos/game-of-life",
+    title: "Demo: game of life",
+    description: "Conway's game of life running on Elixir in Wasm",
+  },
+  {
+    path: "/demos/local-forms",
+    title: "Demo: local forms",
+    description: "Form handling driven entirely client-side",
+  },
+  {
+    path: "/demos/local-thermostat",
+    title: "Demo: local thermostat",
+    description: "Stateful UI backed by an Elixir process in the browser",
+  },
+];
+
+export const GET: APIRoute = () =>
+  new Response(
+    [
+      "# Popcorn",
+      "",
+      `> ${SUMMARY}`,
+      "",
+      "## Pages",
+      "",
+      ...PAGES.map(
+        (page) => `- [${page.title}](${SITE}${page.path}): ${page.description}`,
+      ),
+      "",
+      "## Documentation",
+      "",
+      "- [Popcorn on HexDocs](https://hexdocs.pm/popcorn): api reference and guides",
+      "",
+    ].join("\n"),
+    { headers: { "Content-Type": "text/plain; charset=utf-8" } },
+  );

--- a/landing-page/src/pages/robots.txt.ts
+++ b/landing-page/src/pages/robots.txt.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from "astro";
+
+const SITE = "https://popcorn.swmansion.com";
+
+export const GET: APIRoute = () =>
+  new Response(
+    [
+      "User-agent: *",
+      "Content-Signal: search=yes, ai-input=yes, ai-train=yes",
+      "Allow: /",
+      "",
+      `Sitemap: ${SITE}/sitemap.xml`,
+      "",
+    ].join("\n"),
+    { headers: { "Content-Type": "text/plain; charset=utf-8" } },
+  );

--- a/landing-page/src/pages/sitemap.xml.ts
+++ b/landing-page/src/pages/sitemap.xml.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from "astro";
+
+const SITE = "https://popcorn.swmansion.com";
+const ROUTES = [
+  "/",
+  "/demos/eval",
+  "/demos/game-of-life",
+  "/demos/local-forms",
+  "/demos/local-thermostat",
+];
+
+export const GET: APIRoute = () => {
+  const urls = ROUTES.map(
+    (route) =>
+      `<url><loc>${SITE}${route}</loc><changefreq>weekly</changefreq></url>`,
+  ).join("");
+
+  return new Response(
+    `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`,
+    { headers: { "Content-Type": "application/xml; charset=utf-8" } },
+  );
+};


### PR DESCRIPTION
popcorn.swmansion.com serves no robots.txt, no sitemap and no structured data today.

- **robots.txt** with `Content-Signal: search=yes, ai-input=yes, ai-train=yes`, the signal we use across swmansion domains
- **sitemap.xml** listing the landing page and the four demos
- **llms.txt** — plain-text index, pointing on to hexdocs for the api reference
- **json-ld** carrying the shared `https://swmansion.com/#organization` id, so this domain resolves to the same entity as the rest of our sites
- **canonical link**, which the layout did not emit

one thing beyond the strict scope, say if you'd rather split it: `Layout.astro` had `title` and `description` hardcoded, so all five pages shipped the homepage's copy. it now takes them as props with the same defaults, and each demo passes its own — otherwise the four demos are duplicates as far as search engines are concerned.

check: `/robots.txt`, `/sitemap.xml`, `/llms.txt`, and the title plus `application/ld+json` on `/demos/eval`.